### PR TITLE
Adds Midwest BOS loadout + more

### DIFF
--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -348,6 +348,15 @@
 	icon_state = "t51bhelmet[light_on]"
 	item_state = "t51bhelmet[light_on]"
 
+/obj/item/clothing/head/helmet/f13/power_armor/midwest
+	name = "Midwestern Power Helmet"
+	desc = "It's a Midwest power helmet, typically used by the Brotherhood. It looks somewhat charming."
+	icon_state = "midwestgrey_helm"
+	item_state = "midwestgrey_helm"
+	armor = list("melee" = 70, "bullet" = 70, "laser" = 70, "energy" = 27, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light)
+
+
 
 /obj/item/clothing/head/helmet/f13/power_armor/t60
 	name = "T-60a power helmet"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -402,6 +402,14 @@
 	slowdown = 0.15 //+0.05 from helmet = total 0.2
 	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 27, "bomb" = 64, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 75)
 
+/obj/item/clothing/suit/armor/f13/power_armor/hmidwest
+	name = "Hardened Midwestern power armor"
+	desc = "This set of power armor belongs to the Midwestern branch of the Brotherhood of Steel. This particular one has gone through a chemical hardening process, increasing its armor capabilities."
+	icon_state = "midwestgrey_pa"
+	item_state = "midwestgrey_pa"
+	slowdown = 0.15 //+0.05 from helmet = total 0.2
+	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 27, "bomb" = 64, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 75)
+
 /obj/item/clothing/suit/armor/f13/power_armor/t51b/bos
 	name = "Brotherhood T-51b Power Armour"
 	desc = "The pinnacle of pre-war technology, appropriated by the Brotherhood of Steel. Commonly worn by Head Paladins."

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -107,11 +107,12 @@ Head Paladin
 	exp_requirements = 4800
 
 	loadout_options = list(
-	/datum/outfit/loadout/sentstand, //Tribeam laser
+	/datum/outfit/loadout/sentstand, //Tribeam laser + Hardened T-51
 	/datum/outfit/loadout/sentvet, //xl70e3
-	/datum/outfit/loadout/sentheavy, //Gauss + Glock
-	/datum/outfit/loadout/sentgat, // Gatling
-	/datum/outfit/loadout/sentmini // Minigun
+	/datum/outfit/loadout/sentheavy, //Gauss + Glock + Hardened T-51
+	/datum/outfit/loadout/sentgat, // Gatling + Hardened T-51
+	/datum/outfit/loadout/sentmini, // Minigun + Hardened T-51
+	/datum/outfit/loadout/midwest, // AER14 + Laser Pistol + Midwest PA
 	)
 
 	outfit = /datum/outfit/job/bos/f13sentinel
@@ -143,12 +144,10 @@ Head Paladin
 	uniform = 		/obj/item/clothing/under/f13/recon
 	accessory = 	/obj/item/clothing/accessory/bos/sentinel
 	glasses =       /obj/item/clothing/glasses/night
-	suit =			/obj/item/clothing/suit/armor/f13/power_armor/t51green
-	head =			/obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	belt =			/obj/item/storage/belt/military/assault
 	mask =			/obj/item/clothing/mask/gas/sechailer
 	id = 			/obj/item/card/id/dogtag
-	neck = 			/obj/item/storage/belt/holster
+	neck = 			/obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/melee/powerfist/f13 = 1,
@@ -159,6 +158,8 @@ Head Paladin
 
 /datum/outfit/loadout/sentstand
 	name = "Shock Head Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51green
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	l_hand = /obj/item/gun/energy/laser/scatter
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc = 3,
@@ -166,6 +167,8 @@ Head Paladin
 
 /datum/outfit/loadout/sentvet
 	name = "Veteran Head Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51green
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/xl70e3 = 1,
 		/obj/item/ammo_box/magazine/m556/rifle/assault = 3,
@@ -173,6 +176,8 @@ Head Paladin
 
 /datum/outfit/loadout/sentheavy
 	name = "Heavy Head Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51green
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/m72 = 1,
 		/obj/item/ammo_box/magazine/m2mm = 3,
@@ -182,16 +187,31 @@ Head Paladin
 
 /datum/outfit/loadout/sentgat
 	name = "Gatling Head Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51green
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	backpack_contents = list(
 		/obj/item/minigunpack=1,
 	)
 
 /datum/outfit/loadout/sentmini
 	name = "Minigun Head Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51green
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t51b/bos
 	backpack_contents = list(
 		/obj/item/minigunpackbal5mm=1,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
+	)
+
+/datum/outfit/loadout/midwest
+    name = "Midwestern Head Paladin"
+    suit = /obj/item/clothing/suit/armor/f13/power_armor/hmidwest
+    head = /obj/item/clothing/head/helmet/f13/power_armor/midwest
+    l_hand = /obj/item/gun/energy/laser/aer14
+    backpack_contents = list(
+        /obj/item/stock_parts/cell/ammo/mfc = 3,
+        /obj/item/gun/energy/laser/pistol=1,
+        /obj/item/stock_parts/cell/ammo/ec=2,
 	)
 
 
@@ -414,7 +434,7 @@ Star Paladin
 	uniform =	/obj/item/clothing/under/f13/recon
 	mask =	/obj/item/clothing/mask/gas/sechailer
 	belt =	/obj/item/storage/belt/military/assault
-	neck =	/obj/item/storage/belt/holster
+	neck =	/obj/item/clothing/neck/mantle/bos/paladin
 
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
@@ -514,7 +534,7 @@ Paladin
 	uniform =	/obj/item/clothing/under/f13/recon
 	mask =	/obj/item/clothing/mask/gas/sechailer
 	belt =	/obj/item/storage/belt/military/assault
-	neck =	/obj/item/storage/belt/holster
+	neck =	/obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak= 1,


### PR DESCRIPTION
About The Pull Request
Gives BOS cloak back to the paladin caste.  Adds a loadout for Head Paladin called Midwestern Head Paladin, it contains one AER14, one laser pistol, 3 MFC cells, 2 EC's and the Midwestern PA (same stats as hardened T-51.) It also puts the Head Paladin's PA in his loadouts.

Why It's Good For The Game
Because funny midwestern loadout go brr. Also most BOS players (the two of them) wanted the BOS cloak back, and a loadout for Midwest BOS.

Pre-Merge Checklist
 You tested this on a local server.
 This code did not runtime during testing. Yes.
 You documented all of your changes. Yes.
Changelog
🆑
add: Midwestern Head Paladin loadout, BOS cloak back to the paladin caste
![midwestttt](https://user-images.githubusercontent.com/57302152/161934238-1349949a-9084-4d2f-bee4-2dd5f2074ac8.PNG)

