### PR TITLE
Khan ported + botany update for BOS

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -1,4 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/raiders)
+"ad" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ae" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
@@ -74,6 +87,14 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"aE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench_center"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "aF" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -114,6 +135,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"aL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "aN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -520,6 +549,14 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"dO" = (
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "dP" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13{
@@ -750,6 +787,11 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"fu" = (
+/obj/structure/campfire/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "fv" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -823,6 +865,13 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"gg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "go" = (
 /obj/machinery/door/unpowered/securedoor{
 	desc = "Door with a built-in lock. Can't be padlocked. You can smell the whisky and toughness from even outside the door.";
@@ -896,6 +945,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"gO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/wasteland)
 "gP" = (
 /obj/structure/sign/poster/prewar/poster71,
 /obj/structure/decoration/rag,
@@ -913,6 +968,14 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"gX" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"gZ" = (
+/obj/structure/chair/stool/retro,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -1424,6 +1487,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"kj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "kx" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -1488,6 +1559,15 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
+"ls" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/candle/infinite{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "lt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -1628,6 +1708,9 @@
 	dir = 8
 	},
 /area/f13/building)
+"mm" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "mq" = (
 /obj/structure/table,
 /obj/item/caution{
@@ -1669,6 +1752,13 @@
 	icon_state = "plating"
 	},
 /area/f13/building)
+"mA" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "mD" = (
 /obj/structure/window/fulltile/ruins,
 /obj/effect/decal/cleanable/dirt{
@@ -1726,6 +1816,13 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"nb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "nd" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1768,6 +1865,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nB" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/raiders)
 "nC" = (
 /obj/structure/chair/wood/modern{
 	dir = 8;
@@ -1811,6 +1917,11 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"nN" = (
+/obj/structure/chair/sofa/left,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "nO" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
@@ -1908,6 +2019,15 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"on" = (
+/obj/structure/table/wood/settler,
+/obj/item/candle/infinite{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "or" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -1997,6 +2117,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
+"pg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/raiders)
 "pi" = (
 /obj/structure/sign/plaques/golden/captain{
 	desc = "To be Efficient is not an action or a way of life, but a mental state. Only those with the force of Will strong enough to act during a crisis, are truly Efficient. Stay Efficient, Robert.";
@@ -2249,6 +2375,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"ru" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "rz" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -2283,6 +2413,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"rC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/wasteland)
 "rG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -2521,6 +2657,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"ty" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "tB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2649,6 +2792,27 @@
 "ub" = (
 /turf/closed/wall/r_wall,
 /area/f13/ncr)
+"ue" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench"
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_x = -6;
+	pixel_y = 7;
+	layer = 4
+	},
+/obj/item/toy/plush/lizardplushie{
+	pixel_x = 2;
+	pixel_y = 3;
+	name = "Khanizard"
+	},
+/obj/item/clothing/head/helmet/f13/khan/pelt{
+	pixel_y = 10
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "ui" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/door/unpowered/securedoor{
@@ -2680,6 +2844,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ux" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/raiders)
 "uB" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -2930,6 +3100,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"ws" = (
+/obj/structure/lattice/catwalk,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "wt" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -3127,6 +3301,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/corp/corner{
@@ -3220,6 +3399,13 @@
 "ye" = (
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"yf" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "yg" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -3352,10 +3538,30 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
+"yZ" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"zc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/wasteland)
 "ze" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"zf" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "zg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -3544,6 +3750,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"As" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "At" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -3622,6 +3835,11 @@
 "AM" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"AN" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "AQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -3780,6 +3998,11 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"Cd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "Ci" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/red,
@@ -3867,6 +4090,11 @@
 	dir = 1
 	},
 /area/f13/brotherhood/surface)
+"CM" = (
+/obj/structure/table/wood/settler,
+/obj/item/binoculars,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "CQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3909,6 +4137,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"Dd" = (
+/obj/structure/decoration/rag,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "Dk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -4040,6 +4275,12 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"Ej" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/raiders)
 "El" = (
 /obj/structure/chair/comfy/plywood,
 /turf/open/floor/wood/wood_large,
@@ -4111,6 +4352,16 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"EM" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 4.1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/raiders)
 "ET" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/caves)
@@ -4126,6 +4377,13 @@
 "EZ" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Ff" = (
+/obj/structure/campfire/stove{
+	density = 0;
+	pixel_y = -13
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "Fj" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block{
@@ -4163,6 +4421,22 @@
 	dir = 1
 	},
 /area/f13/building)
+"Fp" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/raiders)
+"Fu" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "Fw" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -4680,6 +4954,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"IF" = (
+/obj/structure/table/wood/settler,
+/obj/item/candle/infinite{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "IH" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -5370,6 +5653,10 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"No" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "Nq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5501,6 +5788,12 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"Of" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/raiders)
 "Oj" = (
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -5556,6 +5849,13 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"OA" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "OC" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -5607,6 +5907,15 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"OT" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "OY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -5661,6 +5970,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Pm" = (
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5703,6 +6020,20 @@
 "PO" = (
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
+"PS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/hostile/wolf/alpha{
+	icon_living = "tippen";
+	icon_state = "tippen";
+	icon_dead = "tippen_dead";
+	faction = list("neutral");
+	desc = "Sheepdogs are known for their intelligence and have worked alongside humans for thousands of years. This one has a dopey smile and smells of barbecue sauce.";
+	health = 200;
+	name = "Dreams-of-Moonlight"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "PV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/metal/dirtystore,
@@ -5794,6 +6125,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"Qw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "Qx" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -5850,6 +6185,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"QR" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "QY" = (
 /obj/machinery/light{
 	dir = 1
@@ -6004,6 +6346,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"RM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/tentwall,
+/area/f13/building)
 "RN" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -6218,6 +6564,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"Tc" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/raiders)
 "Td" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -6228,6 +6584,13 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"Tf" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/raiders)
 "Tm" = (
 /turf/open/indestructible/ground/outside/wood{
 	icon = 'icons/fallout/turfs/floors.dmi';
@@ -6270,6 +6633,17 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"TC" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
+"TF" = (
+/obj/structure/simple_door/repaired,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "TG" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -6341,6 +6715,11 @@
 "Uy" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
+"Uz" = (
+/obj/structure/chair/sofa,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "UA" = (
 /obj/machinery/light{
 	dir = 4
@@ -6472,6 +6851,16 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/building)
+"Vp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/candle/infinite{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/warpaint_bowl,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "Vq" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -6500,6 +6889,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"Vu" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Vw" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
@@ -6517,6 +6912,11 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"VE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "VJ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -7036,6 +7436,13 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
+"ZA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "ZB" = (
 /obj/structure/table/wood,
@@ -18038,10 +18445,10 @@ kC
 kC
 kC
 kC
-kC
-PL
-PL
-PL
+Qw
+Qw
+Qw
+xo
 PL
 PL
 PL
@@ -18295,10 +18702,10 @@ kC
 kC
 kC
 kC
-kC
-PL
-PL
-PL
+Qw
+Qw
+zc
+Qw
 PL
 PL
 BY
@@ -18546,16 +18953,16 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+Vp
+Qw
+gg
+Qw
+Qw
+gg
+Qw
+Qw
+ue
+Qw
 PL
 PL
 BY
@@ -18803,16 +19210,16 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+VE
+Qw
+Qw
+Qw
+Qw
+Qw
+Qw
+rC
+aE
+Qw
 PL
 PL
 BY
@@ -19060,16 +19467,16 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+ls
+Qw
+ZA
+Qw
+Qw
+ZA
+Qw
+Qw
+aE
+Qw
 PL
 PL
 PL
@@ -19314,19 +19721,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+mm
+mm
+No
+OT
+Dd
+yf
+No
+dO
+Qw
+Qw
+kj
+Qw
 PL
 PL
 PL
@@ -19571,19 +19978,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+ab
+nB
+mA
+TC
+ru
+aL
+Cd
+OA
+Qw
+Qw
+Qw
+Qw
 PL
 PL
 PL
@@ -19828,19 +20235,19 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+Tf
+EM
+Uz
+IF
+ru
+ru
+pg
+TF
+Qw
+gO
+Qw
+Qw
 PL
 PL
 PL
@@ -20085,19 +20492,19 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+ru
+Of
+nN
+on
+ru
+ru
+Fu
+No
+Qw
+Qw
+Qw
+xo
 PL
 PL
 PL
@@ -20109,8 +20516,8 @@ PL
 PL
 BY
 BY
+RM
 BY
-PL
 PL
 PL
 PL
@@ -20342,15 +20749,15 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+Ff
+ru
+ru
+ru
+As
+ru
+ux
+ru
+Tc
 PL
 PL
 PL
@@ -20367,7 +20774,7 @@ PL
 BY
 BY
 BY
-PL
+BY
 PL
 PL
 PL
@@ -20599,15 +21006,15 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+ru
+pg
+ru
+Of
+ru
+ru
+ru
+Tc
 PL
 PL
 PL
@@ -20624,7 +21031,7 @@ PL
 BY
 BY
 BY
-PL
+BY
 PL
 PL
 PL
@@ -20856,15 +21263,15 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+PS
+ty
+nb
+ru
+ru
+ru
+ru
+Pm
 PL
 PL
 PL
@@ -20881,7 +21288,7 @@ PL
 BY
 BY
 BY
-PL
+BY
 PL
 PL
 PL
@@ -21113,15 +21520,15 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+mm
+mm
+mm
+mm
+mm
+Ej
+Fp
+zf
+QR
 PL
 PL
 PL
@@ -21375,6 +21782,8 @@ kC
 kC
 kC
 kC
+Gl
+Gl
 PL
 PL
 PL
@@ -21389,20 +21798,18 @@ PL
 PL
 PL
 PL
-PL
-PL
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+AM
+AM
+AM
+AM
+AM
+AM
+AM
+ad
+AM
+AM
+AM
 PL
 PL
 PL
@@ -21632,9 +22039,9 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
+Ka
+Ka
+AN
 PL
 PL
 PL
@@ -21648,18 +22055,18 @@ PL
 PL
 PL
 PL
+AM
+kC
+kC
+AM
+gX
+AM
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+AM
+AM
 PL
 PL
 PL
@@ -21887,11 +22294,11 @@ kC
 kC
 kC
 kC
-kC
-kC
-Wx
-Wx
-Wx
+AM
+AM
+Ka
+Ka
+fu
 PL
 PL
 PL
@@ -21903,20 +22310,20 @@ PL
 PL
 PL
 PL
+Gl
+Gl
+AM
+kC
+kC
+gZ
+CM
+Vu
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+AM
+gX
 PL
 PL
 PL
@@ -22143,12 +22550,28 @@ kC
 kC
 kC
 kC
+gX
+AM
+AM
+Ka
+Ka
+AN
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+AM
+ad
 kC
 kC
 kC
-Wx
-Wx
-Wx
 PL
 PL
 PL
@@ -22156,23 +22579,7 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-kC
-kC
-kC
-kC
-kC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-kC
+AM
 PL
 PL
 PL
@@ -22400,10 +22807,10 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
+AM
+AM
+AM
+AM
 PL
 PL
 PL
@@ -22417,7 +22824,7 @@ PL
 PL
 PL
 PL
-kC
+AM
 kC
 kC
 PL
@@ -22659,8 +23066,8 @@ kC
 kC
 PL
 PL
-kC
-kC
+AM
+AM
 PL
 PL
 PL
@@ -22673,8 +23080,8 @@ kC
 kC
 kC
 kC
-kC
-kC
+AM
+AM
 kC
 PL
 PL
@@ -22916,21 +23323,21 @@ kC
 kC
 PL
 PL
-kC
-kC
+AM
+AM
 kC
 PL
 PL
 PL
 PL
+ws
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+AM
+AM
+AM
+AM
+AM
 kC
 PL
 PL
@@ -23174,19 +23581,19 @@ kC
 PL
 PL
 PL
+ad
+AM
+Gl
+Gl
+Gl
+AM
+AM
+AM
+AM
 kC
 kC
-PL
-PL
-PL
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+yZ
+yZ
 kC
 kC
 PL
@@ -23432,11 +23839,11 @@ PL
 PL
 PL
 kC
-kC
-PL
-PL
-PL
-kC
+AM
+Gl
+Gl
+Gl
+ad
 kC
 kC
 kC

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -40,6 +40,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
+"abq" = (
+/obj/effect/decal/riverbank{
+	dir = 10
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aby" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/barricade/bars,
@@ -276,6 +282,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"afN" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "agd" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/dirt,
@@ -385,9 +397,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ahK" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/turf/closed/wall/f13/wood,
 /area/f13/caves)
 "aig" = (
 /obj/item/bedsheet,
@@ -449,12 +461,7 @@
 	},
 /area/f13/wasteland)
 "ajr" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
+/obj/item/trash/f13/dandyapples,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ajD" = (
@@ -515,13 +522,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "akA" = (
-/obj/machinery/autolathe,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/prewar/poster80{
-	pixel_y = 31
-	},
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/item/trash/f13/fancylads,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "akD" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -729,6 +732,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aoC" = (
+/obj/structure/flora/tree/cactus,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aoD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -1279,6 +1289,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"azU" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/raiders)
 "aAr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/waterbottle{
@@ -1665,6 +1680,11 @@
 /obj/machinery/processor/chopping_block,
 /turf/open/floor/wood/f13,
 /area/f13/village)
+"aIO" = (
+/obj/structure/tires/two,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aIZ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2114,15 +2134,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "aSW" = (
-/obj/machinery/workbench/bottler,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 31
+/obj/effect/decal/riverbank{
+	dir = 6
 	},
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aTv" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
@@ -2281,6 +2297,16 @@
 	icon_state = "rubble"
 	},
 /area/f13/village)
+"aWY" = (
+/obj/structure/table/wood,
+/obj/item/crafting/abraxo,
+/obj/item/soap/homemade,
+/obj/item/reagent_containers/spray,
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aXl" = (
 /obj/structure/pool/Rboard,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -2586,6 +2612,12 @@
 	icon_state = "housewastelandsouth"
 	},
 /area/f13/village)
+"bcy" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "bcF" = (
 /obj/structure/decoration/vent/rusty{
 	desc = "It's very old and rusty. You hear some weird noises behind these vents...";
@@ -2750,14 +2782,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bgd" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/raiders)
+/obj/item/trash/f13/mechanist,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bgk" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -2886,10 +2913,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "bix" = (
-/obj/structure/rack,
-/obj/effect/spawner/bundle/f13/greasegun,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/bundle/f13/greasegun,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "biA" = (
@@ -3065,6 +3091,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"blg" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "blt" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -3957,12 +3989,10 @@
 	},
 /area/f13/wasteland)
 "bBK" = (
-/obj/structure/nest/scorpion{
-	max_mobs = 3;
-	spawn_time = 100
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/forge,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "bBX" = (
 /obj/item/instrument/guitar,
 /turf/open/floor/f13/wood{
@@ -4543,6 +4573,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"bOH" = (
+/obj/item/trash/plate,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bOQ" = (
 /obj/structure/table/wood,
 /obj/item/stack/medical/suture,
@@ -5141,12 +5175,13 @@
 	},
 /area/f13/village)
 "cbM" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/glowstick/red,
 /obj/item/flashlight/glowstick/red,
 /obj/item/flashlight/glowstick/red,
 /obj/item/reagent_containers/food/drinks/bottle/molotov/filled,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light/floor,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -5261,6 +5296,10 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
+"cdU" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cdZ" = (
 /turf/open/floor/wood/f13/stage_b/outdoors,
 /area/f13/building)
@@ -5718,10 +5757,8 @@
 	},
 /area/f13/wasteland)
 "cos" = (
-/obj/machinery/workbench/forge,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/f13/wood/house,
 /area/f13/raiders)
 "cot" = (
 /obj/structure/debris/v3,
@@ -5884,11 +5921,11 @@
 	},
 /area/f13/building)
 "crg" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/binoculars,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/effect/landmark/start/f13/pusher,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "crl" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -6145,6 +6182,10 @@
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
+"czr" = (
+/obj/structure/wreck/car,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "czu" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -6511,6 +6552,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"cGO" = (
+/obj/effect/landmark/start/f13/pusher,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "cGS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7127,6 +7174,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"cVn" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cVx" = (
 /obj/effect/landmark/start/f13/ncrmedofficer,
 /turf/open/floor/f13{
@@ -7178,10 +7229,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cWy" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/chem_master/advanced,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/chem_heater{
+	pixel_y = 5
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "cWG" = (
@@ -7530,6 +7582,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"ddo" = (
+/obj/item/trash/pistachios,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ddD" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -7678,6 +7734,8 @@
 /area/f13/building)
 "dgK" = (
 /obj/machinery/door/unpowered/securedoor{
+	max_integrity = 300;
+	obj_integrity = 300;
 	req_access_txt = "125"
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -7827,17 +7885,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "djh" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1";
-	pixel_y = -32
-	},
-/obj/structure/sign/poster/contraband/pinup_pink{
-	pixel_x = -31
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "djI" = (
@@ -7912,7 +7969,6 @@
 	},
 /area/f13/wasteland)
 "dkW" = (
-/obj/effect/landmark/start/f13/pusher,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood{
@@ -8354,6 +8410,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"dti" = (
+/obj/item/trash/can,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dtk" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -8543,7 +8603,12 @@
 	icon_dead = "rottweiler_dead";
 	icon_living = "rottweiler";
 	icon_state = "rottweiler";
-	name = "Sunflower"
+	name = "Sunflower";
+	health = 200
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 31
 	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
@@ -8572,7 +8637,6 @@
 /area/f13/wasteland)
 "dyt" = (
 /obj/structure/closet,
-/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dyB" = (
@@ -8939,11 +9003,6 @@
 "dEc" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1";
-	pixel_x = -6
-	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -9082,11 +9141,13 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/legion)
 "dIj" = (
-/obj/structure/closet,
-/obj/item/defibrillator/primitive,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/structure/closet/crate/large,
+/obj/item/paper/secretrecipe,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/neck/apron/chef,
+/obj/item/melee/onehanded/knife/cosmicdirty,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dIP" = (
 /obj/machinery/light{
 	dir = 4
@@ -9814,9 +9875,19 @@
 	},
 /area/f13/wasteland)
 "dXQ" = (
-/obj/structure/dresser,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_x = -31
+	},
+/obj/machinery/chem_dispenser,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1";
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "dXV" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/f13/ncr/steelpot_bandolier{
@@ -11086,6 +11157,11 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"ews" = (
+/obj/structure/decoration/clock,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "ewI" = (
 /obj/item/trash/f13/cram,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12371,6 +12447,11 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"eXn" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/raiders)
 "eXo" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13{
@@ -12649,6 +12730,10 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"fcy" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fcE" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt{
@@ -12663,12 +12748,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "fcI" = (
-/obj/structure/fluff/fokoff_sign,
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
+/obj/structure/nest/ghoul{
+	max_mobs = 2
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -12743,6 +12824,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/village)
+"fdV" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/savannah/topcenter,
+/area/f13/wasteland)
 "fdX" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/f13/wood,
@@ -12931,6 +13016,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"fhq" = (
+/obj/structure/rack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fht" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_y = 32
@@ -13105,16 +13194,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "fmR" = (
-/obj/structure/wreck/car/bike{
-	density = 0;
-	layer = 3.5;
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland)
+/obj/structure/nest/molerat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fmW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/pistachios,
@@ -13251,11 +13333,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
 "fpv" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/obj/item/stack/medical/gauze,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/table/optable,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/raiders)
 "fpJ" = (
 /obj/structure/table/wood,
@@ -13849,10 +13931,10 @@
 	},
 /area/f13/building)
 "fCM" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/reagent_containers/medspray/sterilizine,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table,
+/obj/item/reagent_containers/medspray/sterilizine,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "fCO" = (
@@ -14287,6 +14369,11 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"fLf" = (
+/obj/structure/destructible/tribal_torch/wall,
+/obj/item/trash/can,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fLx" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14482,10 +14569,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fPU" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "fQr" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
@@ -14726,6 +14813,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"fTJ" = (
+/obj/item/trash/sosjerky{
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/end{
@@ -15097,7 +15190,8 @@
 	},
 /area/f13/building)
 "gaV" = (
-/turf/closed/indestructible/vaultdoor,
+/obj/item/trash/f13/tin,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gbh" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -15426,12 +15520,9 @@
 	},
 /area/f13/village)
 "gin" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/item/twohanded/spear/scrapspear,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gip" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -16118,13 +16209,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gun" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/baseball/spiked,
 /obj/item/melee/unarmed/punchdagger,
 /obj/item/melee/onehanded/knife/hunting,
 /obj/item/melee/onehanded/machete,
 /obj/item/melee/onehanded/machete,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "gus" = (
@@ -16253,9 +16344,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gwi" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gwp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16329,16 +16423,24 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"gxh" = (
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gxl" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/fence/wooden{
 	dir = 1;
 	icon_state = "post_wood";
 	pixel_x = -18
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = 4;
+	pixel_y = 2
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -17117,14 +17219,10 @@
 	},
 /area/f13/wasteland)
 "gND" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/raiders)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/spider/stickyweb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gNG" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -17312,8 +17410,10 @@
 	},
 /area/f13/wasteland)
 "gSx" = (
-/obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "gSB" = (
@@ -17404,18 +17504,10 @@
 	},
 /area/f13/building)
 "gVg" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
-	},
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/raiders)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "gVh" = (
 /obj/structure/wreck/car/bike{
 	dir = 9
@@ -17429,12 +17521,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gVt" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/raiders)
+/obj/item/trash/f13/blamco,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gVH" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -17946,11 +18035,8 @@
 	},
 /area/f13/building)
 "hft" = (
-/obj/structure/closet/crate/miningcar,
-/obj/item/shovel,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/mirelurkegg,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hfv" = (
 /turf/open/floor/wood/f13/oakbroken,
@@ -18138,10 +18224,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hhG" = (
-/obj/structure/closet/crate/miningcar,
-/obj/item/pickaxe,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
+/obj/item/chair/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hib" = (
@@ -18451,9 +18534,13 @@
 	},
 /area/f13/village)
 "hna" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/raiders)
 "hnh" = (
 /obj/structure/rack,
@@ -18533,11 +18620,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "hoH" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/ballistic/revolver/hobo/piperifle,
 /obj/item/gun/ballistic/revolver/hobo/knucklegun,
 /obj/item/ammo_box/c45/improvised,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "hoR" = (
@@ -19365,6 +19452,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"hDJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/flora/grass/jungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "hDM" = (
 /obj/structure/displaycase,
 /obj/item/clothing/under/f13/vault/vcity/skirt,
@@ -19712,11 +19804,8 @@
 	},
 /area/f13/building)
 "hJv" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/mineral/random/low_chance,
+/obj/item/trash/f13/sugarbombs,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hJB" = (
 /obj/effect/decal/remains{
@@ -19870,14 +19959,9 @@
 	},
 /area/f13/building)
 "hMz" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1";
-	pixel_x = -8
-	},
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/mechanical/old,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -22995,9 +23079,7 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "iWp" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag,
+/obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "iWt" = (
@@ -23616,6 +23698,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"jiN" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "jiR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24867,6 +24953,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/caves)
+"jJx" = (
+/obj/structure/table,
+/obj/item/binoculars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "jJB" = (
 /obj/structure/chair,
 /turf/open/floor/f13,
@@ -25654,12 +25746,7 @@
 /area/f13/wasteland)
 "jZk" = (
 /obj/structure/table/wood,
-/obj/item/trash/sosjerky{
-	icon_state = "plate"
-	},
-/obj/item/kitchen/knife{
-	pixel_x = 5
-	},
+/obj/item/mining_scanner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jZo" = (
@@ -26146,6 +26233,11 @@
 	tag = "icon-innermaincornerinner"
 	},
 /area/f13/wasteland)
+"kiC" = (
+/obj/structure/closet/crate/large,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kiH" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26546,13 +26638,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "krb" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = junglehome;
-	name = "Damp Ladder"
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "krc" = (
 /obj/structure/sign/poster/ncr/democracy,
 /turf/closed/wall/f13/store/constructed,
@@ -26593,13 +26687,13 @@
 	},
 /area/f13/wasteland)
 "krS" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_box/shotgun/bean,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/legcuffs/bola,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "krW" = (
@@ -27439,6 +27533,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"kMW" = (
+/obj/item/trash/f13/steak,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kNf" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -27516,6 +27614,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"kPq" = (
+/obj/structure/chair/stool/retro,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kPu" = (
 /obj/machinery/workbench,
 /obj/machinery/light/small/broken{
@@ -27722,11 +27824,7 @@
 	},
 /area/f13/building)
 "kUs" = (
-/obj/effect/decal/riverbank{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/clothing/head/cone,
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "kUA" = (
@@ -28736,6 +28834,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/city)
+"lov" = (
+/obj/structure/closet/crate/large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "loX" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -28966,6 +29068,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"luv" = (
+/obj/structure/closet/crate/large,
+/obj/item/circuitboard/machine/chem_dispenser/drinks,
+/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "luy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29046,6 +29154,17 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/raiders)
+"lvH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -24
+	},
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/raiders)
 "lvS" = (
 /obj/structure/holohoop{
@@ -29128,6 +29247,16 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"lxo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/drug_storage,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "lxJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -29174,6 +29303,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"lzU" = (
+/obj/item/trash/boritos,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lzW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flag/oasis,
@@ -29738,8 +29871,7 @@
 	},
 /area/f13/building)
 "lNp" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/item/trash/f13/specialapples,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lNv" = (
@@ -31325,6 +31457,11 @@
 	tag = "icon-platingdmg1"
 	},
 /area/f13/caves)
+"mpH" = (
+/obj/effect/landmark/start/f13/pusher,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "mpQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31679,6 +31816,16 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"mwQ" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/flashlight,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "mwZ" = (
 /obj/machinery/smartfridge/bottlerack/seedbin{
 	pixel_x = -2;
@@ -32207,6 +32354,10 @@
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mIg" = (
+/obj/item/trash/f13/instamash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mIv" = (
 /obj/effect/turf_decal,
 /obj/machinery/light{
@@ -32242,6 +32393,17 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mIK" = (
+/obj/structure/closet/crate/large,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/imitation,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/imitation,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mIW" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -32872,6 +33034,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
+"mUD" = (
+/obj/structure/table,
+/obj/item/camera,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "mUO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33632,10 +33802,14 @@
 	},
 /area/f13/building)
 "nla" = (
-/obj/structure/mirelurkegg,
-/obj/structure/destructible/tribal_torch/wall,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs{
+	barefootstep = "woodbarefoot";
+	color = "#A47449";
+	footstep = "wood";
+	icon_state = "stairs-r"
+	},
+/area/f13/raiders)
 "nlv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/supermart,
@@ -34538,7 +34712,9 @@
 	desc = "Advertisements would've played on this tv before the bombs dropped.";
 	icon = 'icons/fallout/objects/decorations.dmi';
 	icon_state = "television";
-	name = "pre-war advertising television"
+	name = "pre-war advertising television";
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = 5;
@@ -36048,6 +36224,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"oks" = (
+/obj/structure/wreck/car/bike{
+	density = 0;
+	layer = 3.5;
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "oku" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -36423,6 +36608,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"oqP" = (
+/obj/item/trash/f13/porknbeans,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oqR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36507,11 +36696,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "osF" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	pixel_y = -10
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "osQ" = (
@@ -37339,7 +37528,7 @@
 /area/f13/building)
 "oMn" = (
 /mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/savannah/topcenter,
+/turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
 "oMp" = (
 /obj/structure/fence/corner,
@@ -37903,6 +38092,14 @@
 	name = "concrete wall"
 	},
 /area/f13/village)
+"paa" = (
+/obj/structure/destructible/tribal_torch/wall,
+/obj/item/trash/f13/dog{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pad" = (
 /obj/structure/table/wood,
 /obj/item/documents{
@@ -38673,8 +38870,9 @@
 	},
 /area/f13/ncr)
 "ppm" = (
-/obj/structure/closet/fridge/meat,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/canned/dog,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ppn" = (
@@ -38818,10 +39016,11 @@
 	},
 /area/f13/wasteland)
 "psR" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/lattice/catwalk,
-/obj/item/fishingrod,
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/spider/stickyweb{
+	icon_state = "stickyweb2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "psT" = (
 /obj/structure/debris/v4,
@@ -38923,6 +39122,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"puY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "pvf" = (
 /obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/outside/dirt{
@@ -39404,6 +39608,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pFX" = (
+/obj/item/storage/trash_stack,
 /turf/open/floor/wood/f13/old/ruinedcornertr,
 /area/f13/wasteland)
 "pGa" = (
@@ -39426,7 +39631,10 @@
 /area/f13/building)
 "pGq" = (
 /obj/structure/table/wood,
-/obj/structure/bedsheetbin,
+/obj/item/reagent_containers/food/drinks/bottle/bawls{
+	pixel_x = -5;
+	pixel_y = 15
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pGH" = (
@@ -40183,6 +40391,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"pVb" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = junglehome;
+	name = "Damp Ladder"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pWe" = (
 /obj/item/bedsheet/orange,
 /obj/structure/bed/old,
@@ -40607,10 +40823,12 @@
 	},
 /area/f13/building)
 "qfi" = (
-/obj/structure/decoration/clock,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13/wood,
 /area/f13/raiders)
 "qfm" = (
 /obj/structure/car,
@@ -40637,6 +40855,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qfw" = (
+/obj/structure/chair/wood/worn{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qfA" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -40791,13 +41015,8 @@
 	},
 /area/f13/building)
 "qiN" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug{
-	pixel_y = 10
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack/drug_storage,
-/obj/item/reagent_containers/pill/patch/jet,
-/obj/item/reagent_containers/pill/patch/jet,
+/obj/machinery/autolathe,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "qiO" = (
@@ -41377,10 +41596,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"qwG" = (
+/obj/item/trash/f13/blamco_large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qwW" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/wasteland)
+/obj/item/trash/f13/tin_large,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qxf" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Bar";
@@ -41741,15 +41964,27 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qCV" = (
-/obj/item/trash/sosjerky{
-	pixel_x = -6
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/beer,
+/obj/item/reagent_containers/food/drinks/beer,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/obj/item/trash/sosjerky{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/item/reagent_containers/food/drinks/bottle/kahlua,
+/obj/item/reagent_containers/food/drinks/bottle/fernet,
+/obj/item/reagent_containers/food/drinks/bottle/champagne,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/reagent_containers/food/drinks/bottle/trappist,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/rotgut,
+/obj/item/reagent_containers/food/drinks/bottle/blazaam/empty,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/raiders)
 "qDb" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -43297,7 +43532,6 @@
 	},
 /area/f13/wasteland)
 "rht" = (
-/obj/effect/landmark/start/f13/pusher,
 /obj/structure/chair/sofa/right,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -43562,6 +43796,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"roj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "roG" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13/wasteland;
@@ -43625,8 +43864,8 @@
 /area/f13/wasteland)
 "rqc" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/turf/closed/wall/f13/wood/house,
+/area/f13/raiders)
 "rqs" = (
 /turf/open/floor/carpet,
 /area/f13/village)
@@ -43702,6 +43941,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"rsj" = (
+/obj/effect/decal/riverbank{
+	dir = 9
+	},
+/obj/structure/chair/stool,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rss" = (
 /obj/structure/dresser,
 /turf/open/indestructible/ground/outside/dirt,
@@ -43716,6 +43962,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rsH" = (
+/obj/item/trash/waffles,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rth" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/borscht,
@@ -45741,17 +45991,18 @@
 	},
 /area/f13/caves)
 "smk" = (
-/obj/structure/bed/old,
-/obj/item/newspaper,
-/obj/item/flashlight/lantern,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "smq" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
 /area/f13/raiders)
 "smw" = (
 /obj/structure/chair/wood/fancy{
@@ -45941,9 +46192,9 @@
 	},
 /area/f13/wasteland)
 "sqf" = (
-/obj/structure/bed/old,
-/obj/item/newspaper,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/lattice/catwalk,
+/obj/item/fishingrod,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "sqx" = (
 /obj/structure/fence{
@@ -46744,6 +46995,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"sHC" = (
+/obj/item/trash/candy,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -48460,15 +48715,11 @@
 	},
 /area/f13/building)
 "tqh" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/mineral/random/low_chance,
+/obj/structure/closet/crate/large,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/item/reagent_containers/food/snacks/f13/canned/porknbeans,
+/obj/item/reagent_containers/food/snacks/beans,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tqu" = (
 /obj/structure/barricade/wooden,
@@ -48553,9 +48804,6 @@
 /area/f13/building)
 "tsv" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 8
-	},
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
@@ -48789,6 +49037,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"twA" = (
+/obj/structure/table,
+/obj/machinery/chem_master/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "twO" = (
 /obj/machinery/light{
 	dir = 4
@@ -49707,6 +49961,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tRU" = (
+/obj/machinery/workbench/advanced,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tRX" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13{
@@ -50667,10 +50925,12 @@
 	},
 /area/f13/wasteland)
 "uke" = (
-/obj/effect/decal/riverbank,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/landmark/start/f13/pusher,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ukg" = (
 /obj/structure/rack,
 /obj/item/storage/box/rxglasses,
@@ -51066,9 +51326,7 @@
 	},
 /area/f13/wasteland)
 "urW" = (
-/obj/effect/decal/riverbank,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/clothing/head/cone,
+/obj/item/trash/f13/cram,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "usb" = (
@@ -51093,12 +51351,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ush" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "usx" = (
 /turf/closed/wall/f13/store{
@@ -51114,6 +51368,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"utw" = (
+/obj/structure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/f13/canned/borscht,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "utA" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -51131,7 +51390,8 @@
 /area/f13/wasteland)
 "utT" = (
 /obj/structure/barricade/wooden/strong,
-/turf/closed/mineral/random/low_chance,
+/obj/structure/barricade/wooden/strong,
+/turf/closed/wall/f13/wood,
 /area/f13/caves)
 "utX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51743,11 +52003,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "uFJ" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/camera,
+/obj/machinery/workbench/bottler,
+/obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "uFN" = (
@@ -52235,10 +52493,9 @@
 	},
 /area/f13/village)
 "uPU" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/decal/cleanable/blood/old,
+/obj/item/pickaxe/drill,
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uPY" = (
@@ -52308,12 +52565,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
-"uQP" = (
-/obj/structure/chair/wood/worn{
-	dir = 1
-	},
+"uQO" = (
+/obj/structure/rack,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uQP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/primitive,
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "uQY" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -52576,13 +52840,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uVT" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/item/flashlight,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "uVW" = (
@@ -53111,10 +53371,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
 "vhs" = (
-/obj/structure/vaultdoor{
-	desc = "An old, thick bulkhead door. Or what's left of it, at least.";
-	icon_state = "empty";
-	name = "Army Vault Door"
+/obj/item/trash/f13/tin{
+	dir = 4;
+	pixel_x = 9;
+	pixel_y = 3
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -53245,12 +53505,9 @@
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland)
 "vjO" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vjR" = (
 /turf/open/floor/wood/f13/old/ruinedstraightsouth,
 /area/f13/wasteland)
@@ -53565,12 +53822,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building)
 "vsm" = (
-/obj/structure/table/wood,
-/obj/item/crafting/abraxo,
-/obj/item/soap/homemade,
-/obj/item/reagent_containers/spray,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/nest/mirelurk{
+	max_mobs = 4;
+	spawn_time = 10
+	},
+/obj/effect/decal/riverbank{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vsn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -53628,6 +53888,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"vtV" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "vug" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -53666,15 +53934,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "vuU" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/raiders)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vvh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53894,6 +54156,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"vzs" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2"
+	},
+/obj/structure/car,
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vzw" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
@@ -54043,6 +54313,11 @@
 /obj/structure/fence/wooden{
 	dir = 4
 	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = 4;
+	pixel_y = 2
+	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/raiders)
 "vCK" = (
@@ -54055,6 +54330,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"vCW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "vDb" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/oil{
@@ -54787,6 +55067,10 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"vQq" = (
+/obj/item/trash/sosjerky,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vQu" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -55296,6 +55580,10 @@
 	dir = 1
 	},
 /area/f13/village)
+"wdx" = (
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wdz" = (
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/f13/wood,
@@ -55578,6 +55866,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wlJ" = (
+/obj/item/trash/f13/dog,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wlL" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -55590,6 +55882,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wmi" = (
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "wmp" = (
 /obj/structure/nest/gecko{
 	max_mobs = 2;
@@ -55743,9 +56039,7 @@
 	},
 /area/f13/building)
 "woL" = (
-/obj/structure/closet/crate/miningcar,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
+/obj/item/chair/stool,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "woN" = (
@@ -56363,6 +56657,10 @@
 /obj/item/shovel/spade,
 /obj/item/storage/bag/plants,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wBL" = (
@@ -56724,6 +57022,10 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/village)
+"wJN" = (
+/obj/machinery/vending/cola/starkist,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wKo" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -56953,11 +57255,7 @@
 	},
 /area/f13/building)
 "wNP" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/rag,
-/obj/item/storage/backpack,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill,
+/obj/item/trash/f13/c_ration_3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wOb" = (
@@ -57308,20 +57606,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "wTL" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/destructible/tribal_torch/wall,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/decal/riverbank{
+	dir = 8
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/mineral/random/low_chance,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wUc" = (
 /obj/structure/decoration/clock{
@@ -57761,17 +58049,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/brotherhood/surface)
 "xcV" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/reagent_containers/food/drinks/beer,
-/obj/item/reagent_containers/food/drinks/beer,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/raiders)
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xcX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -58319,6 +58599,10 @@
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"xnC" = (
+/obj/structure/bed/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xnD" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
@@ -58616,6 +58900,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xsD" = (
+/obj/structure/destructible/tribal_torch/wall,
+/obj/item/trash/f13/specialapples,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xsI" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -58698,6 +58987,13 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xuI" = (
+/obj/structure/car/rubbish1,
+/obj/structure/tires/two,
+/obj/structure/wreck/trash/halftire,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xuL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -59719,6 +60015,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"xRI" = (
+/obj/vehicle/ridden/wheelchair{
+	name = "Hawtrod"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xRV" = (
 /turf/open/floor/wood/f13/old/ruinedcornertl,
 /area/f13/wasteland)
@@ -60082,13 +60384,9 @@
 	},
 /area/f13/wasteland)
 "ybp" = (
-/obj/structure/table,
-/obj/machinery/chem_heater{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
+/obj/item/trash/semki,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ybq" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -60754,7 +61052,7 @@ ktB
 oYb
 oYb
 oYb
-oYb
+ktB
 ktB
 ktB
 ktB
@@ -60989,29 +61287,29 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 wOS
 wOS
 wOS
-hsj
-uke
+wOS
+wOS
+wOS
+wOS
+wOS
+wOS
 gcK
-hJv
 gcK
 gcK
-gcK
-gcK
+iOM
 ggK
 ggK
 ggK
-ggK
+gcK
 gcK
 gcK
 gcK
@@ -61242,35 +61540,35 @@ gcK
 gcK
 gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
+bkr
+ggK
 gbL
 gbL
+gbL
+gbL
+gbL
 gcK
-gcK
-gcK
-gcK
+dhG
+wOS
+wOS
 may
 wOS
 oNR
-fzl
+csk
+sqf
 kNT
-urW
+wOS
+gcK
+gcK
+dhG
 ggK
 ggK
 ggK
+psR
+psR
+gND
 ggK
-gAs
-ggK
-ggK
-ggK
-ggK
-ggK
-mwO
-hJv
+gcK
 gcK
 gcK
 gcK
@@ -61499,37 +61797,37 @@ gcK
 fyf
 gcK
 ktB
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-gcK
+vsm
+wTL
+abq
+wOS
+ush
+hsj
+wOS
+wOS
+wmi
+wOS
 kJu
 wOS
 wOS
-psR
-kNT
-pBX
-ggK
-ggK
-ggK
-ggK
-ggK
-ggK
-ggK
-ggK
+wOS
+sqf
+nhf
+mqp
+gcK
 gcK
 ggK
 ggK
-hJB
 ggK
+oqP
 ggK
-dcY
+gcK
+gND
+ggK
+lNp
+fTJ
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -61756,38 +62054,38 @@ fyf
 fyf
 gcK
 ktB
-gcK
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
+blg
+wOS
+hsj
+oNR
+wOS
+izB
+wOS
 rpf
 iyy
 wOS
 wOS
 hsj
 kNT
-kNT
+hDJ
 qNM
 ggK
+akA
 ggK
+ggK
+ggK
+ggK
+ggK
+ggK
+gcK
+gcK
+ggK
+mIg
+lzU
 mwO
-fbs
-ggK
-ggK
-ggK
-woL
+dhG
 gcK
 gcK
-gcK
-ggK
-dcY
-ggK
-ggK
-ggK
-ggK
 gcK
 gcK
 ktB
@@ -62012,40 +62310,40 @@ fyf
 fyf
 fyf
 gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
+ktB
+ktB
+hsj
+hft
+hsj
+iyy
+wOS
+wOS
 hsj
 izB
 wOS
 kNT
 kNT
-nhf
+rsj
 pBX
 ggK
 ggK
 ggK
 ggK
-gcK
-gcK
-gAs
-gAs
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fbs
 ggK
 ggK
 ggK
 ggK
+gcK
+gcK
+gcK
+gcK
+ggK
+qwG
+kMW
+vQq
+gcK
+gcK
+gcK
 gcK
 ktB
 gcK
@@ -62270,39 +62568,39 @@ fyf
 sND
 gcK
 gcK
-gcK
+ktB
 gbL
 gbL
-gbL
-gbL
-gcK
-gcK
+dhG
+pBX
+mqp
+aSW
 wOS
 gcK
 gcK
-kUs
-mqp
-ggK
-bkr
-ggK
+gcK
+pBX
+gxh
 ggK
 ggK
 ggK
 ggK
+ggK
+xsD
+fPU
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
+hJB
 ggK
 ggK
+jIU
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -62527,39 +62825,39 @@ fyf
 fyf
 gcK
 gcK
-gcK
+ktB
 gbL
 gbL
 gcK
+anb
+ggK
 gcK
 gcK
-utT
 gcK
-gcK
-fbs
+gVg
 ggK
 ggK
-nla
-gAs
-gcK
-gcK
 ggK
 ggK
-mwO
-hJv
+ggK
+ggK
+ggK
+ggK
+ggK
+ggK
 gcK
 gcK
 gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
+ffA
+gcK
+ggK
 gaV
-gcK
-gcK
+fcI
 ggK
-ggK
+fLf
+dhG
 gcK
 gcK
 gcK
@@ -62784,22 +63082,14 @@ fyf
 gcK
 gcK
 gcK
-gcK
+ktB
 gbL
 gbL
 gcK
 gcK
-gAs
-ggK
-ggK
-ggK
-gAs
-ggK
-ggK
-gAs
-gAs
 gcK
 gcK
+vuU
 ggK
 ggK
 ggK
@@ -62807,14 +63097,22 @@ ggK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gaV
+gcK
+vuU
+bOH
+ggK
+ggK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ggK
+ggK
+qwW
 hJB
 ggK
 gcK
@@ -63046,12 +63344,12 @@ gbL
 gbL
 gcK
 gcK
-gAs
-hft
+gcK
 ggK
 ggK
 ggK
-gAs
+ggK
+ggK
 gcK
 gcK
 gcK
@@ -63059,22 +63357,22 @@ gbL
 gcK
 gcK
 gcK
-ggK
-ggK
-ggK
+kkk
+ahK
 gcK
 gcK
+gcK
+gcK
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gaV
+gcK
+gcK
+oqP
 vhs
-wTL
 ggK
-mwO
-tqh
+ggK
+dti
+gcK
 gcK
 ktB
 gcK
@@ -63297,40 +63595,40 @@ doX
 wDc
 gcK
 gcK
-gcK
+ktB
 gcK
 gbL
 gbL
 gcK
 gcK
-gAs
 ggK
 ggK
 ggK
 ggK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gcK
-gcK
-fbs
 ggK
 ggK
 gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-ahK
-ggK
-ggK
+gcK
+gcK
 gcK
 ggK
+xKr
+ggK
+iOM
+gcK
+gcK
+gcK
+gbL
+gbL
+gcK
+hJB
+ggK
+hJv
+ggK
+xKr
 gcK
 gcK
 ktB
@@ -63554,7 +63852,7 @@ mvv
 bpD
 fyf
 gcK
-gcK
+ktB
 gcK
 gbL
 gbL
@@ -63563,30 +63861,30 @@ eST
 ggK
 ggK
 ggK
-dcY
 ggK
-dcY
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
-lNp
-kkk
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gaV
 ggK
 ggK
 gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+gcK
+sHC
+ggK
+oqP
+ggK
+fhq
+gcK
+gbL
+gcK
+gcK
+vjO
+gVt
+ggK
+fcI
+ggK
 ggK
 gcK
 gcK
@@ -63819,31 +64117,31 @@ gcK
 lwj
 ggK
 ggK
-gAs
-ggK
-ggK
-ggK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
 gcK
 ggK
-ggK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gaV
 lNp
-iWp
 ggK
+gcK
+gbL
+gbL
+gbL
+gcK
+gcK
+uQO
+ggK
+qwG
+afN
+ggK
+fcy
+gcK
+gcK
+gcK
+gcK
+gcK
+iOM
+ggK
+ggK
+wNP
 ggK
 gcK
 gcK
@@ -64076,32 +64374,32 @@ ktB
 fbs
 ggK
 mwO
-hJv
+gcK
 gcK
 ggK
 gcK
 gcK
 gbL
 gbL
-gbL
-gbL
 gcK
-gcK
+vtV
+xnC
+ahI
 woL
+wsq
+hhG
 ggK
-ggK
-iOM
+xnC
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gaV
-fcI
+gcK
+gcK
+gcK
+gcK
+gcK
+dhG
 ggK
-ggK
-ggK
+paa
+dhG
 gcK
 ktB
 ktB
@@ -64326,39 +64624,39 @@ gjP
 gjP
 gcK
 gcK
-gcK
+ktB
 gbL
 gbL
 gcK
 gcK
 ggK
 ggK
+ggK
 gcK
-gcK
-gcK
+gVg
 gcK
 gbL
 gbL
 gbL
 gcK
-smk
-ggK
-bBK
+spx
 ggK
 ggK
+ggK
+qfw
 ajr
 ggK
+utw
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 ggK
 ggK
-ggK
-ggK
-hJB
+bcy
 gcK
 gcK
 gbL
@@ -64583,7 +64881,7 @@ bol
 tRY
 gcK
 gcK
-gcK
+ktB
 gcK
 gbL
 gcK
@@ -64598,24 +64896,24 @@ gcK
 gcK
 gcK
 gcK
-dXQ
-ggK
-ggK
-wsq
-ggK
-ggK
-ggK
-spx
 gcK
-gcK
-ktB
+cVn
+ggK
+afN
+ggK
+ggK
+ggK
+iOM
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+luv
 ggK
 ggK
-ggK
-gAs
+gcK
 gcK
 gcK
 gbL
@@ -64840,39 +65138,39 @@ uRJ
 gjP
 gcK
 gcK
-gcK
+ktB
 gcK
 gbL
 gcK
 gcK
+eST
 ggK
 ggK
 ggK
 ggK
 ggK
 ggK
-ggK
-ggK
+xKr
 gcK
 gcK
-sqf
-jIU
+gcK
+gcK
 uPU
-ggK
+ahI
 ggK
 ggK
 ppm
 gcK
 gcK
 gcK
-ktB
 gcK
 gcK
-gAs
+gcK
+dIj
+gin
 ggK
-bBK
 ggK
-gAs
+mIK
 gcK
 gcK
 gbL
@@ -65090,46 +65388,46 @@ uRJ
 peu
 peu
 peu
-fzD
+uRJ
 cbk
 uRJ
 nVo
 gjP
 gcK
 gcK
-gcK
+ktB
 gcK
 gbL
 gcK
 fbs
-ggK
+lwj
 mwO
-hJv
+gcK
+iOM
 ggK
-ggK
-ggK
-ggK
+iWp
+dcY
 ggK
 gcK
 ktB
 gcK
-ush
-uQP
+gcK
+gcK
+xnC
 ggK
-qCV
 jZk
 gcK
 gcK
 gcK
-ktB
-ktB
 gcK
-ggK
-ggK
-ggK
-ggK
-ggK
 gcK
+gcK
+gcK
+tqh
+ggK
+ggK
+ggK
+lov
 gcK
 gcK
 gbL
@@ -65354,42 +65652,42 @@ peu
 ram
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gbL
 gcK
 gcK
+gAs
+gAs
+gcK
+gcK
+gcK
 ggK
 ggK
-gcK
-gcK
-gcK
-gcK
 ggK
-ggK
-ggK
-gcK
-ktB
-gcK
-iOM
-ggK
-uAs
-gcK
-gcK
-ktB
-ktB
+mwO
+gVg
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+wJN
+xcV
 ggK
-ggK
-ggK
-ggK
+ktB
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
+gbL
 gcK
 gbL
 gbL
@@ -65612,41 +65910,41 @@ gjP
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gcK
-eST
-ggK
-gcK
-gbL
-gbL
-gbL
-gcK
-ggK
-ggK
-gcK
-gcK
 ktB
+gbL
+gbL
 gcK
-wNP
+gAs
+gcK
+gbL
 gcK
 gcK
-ktB
+gcK
+ggK
+iWp
+dcY
+gcK
+gcK
 ktB
 gcK
 gcK
 gcK
 gcK
-ggK
 gcK
 gcK
-ggK
 gcK
 gcK
 gcK
 ktB
 ktB
+ktB
+gcK
+ggK
+gAs
+gcK
+ktB
+ktB
+gcK
 gbL
 gbL
 gbL
@@ -65869,41 +66167,41 @@ hwC
 gcK
 gcK
 gcK
+ktB
+gcK
+gbL
+gcK
+gcK
 gcK
 gcK
 gbL
+gbL
+gcK
+dhG
+ggK
+wdx
+ggK
+gcK
+ktB
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
 gcK
 gAs
-ggK
-gcK
-gbL
-gbL
-gbL
-gcK
-ggK
-ggK
-ggK
-gcK
-ktB
-gcK
-gcK
+dhG
 gcK
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gbL
 gbL
 gbL
 ktB
@@ -66126,41 +66424,41 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
+ktB
+gcK
+gcK
 gcK
 gcK
 gbL
+gcK
+gcK
 gcK
 gAs
-lwj
+ggK
+ggK
+ggK
 gcK
-gbL
-gbL
-gbL
+ktB
+gcK
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
 gcK
 gAs
 ggK
-ggK
-ggK
+bgd
+wlJ
+gAs
+gcK
 gcK
 ktB
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gcK
-gcK
-gbL
-gbL
-gbL
-gcK
-ktB
-gbL
 gbL
 gbL
 gbL
@@ -66386,9 +66684,10 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
-hhG
+gcK
 gcK
 gcK
 gcK
@@ -66398,26 +66697,25 @@ gAs
 ggK
 ggK
 ggK
+gcK
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+gcK
+tRU
+ggK
+ggK
+kUs
+ggK
+ybp
 ggK
 gcK
 ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-ktB
-gbL
 gbL
 gbL
 gbL
@@ -66646,37 +66944,37 @@ gcK
 gcK
 gcK
 gcK
-ggK
+gcK
 ggK
 ggK
 ggK
 gAs
 gAs
-gcK
+gAs
 gcK
 ggK
-ggK
-gcK
+mwO
+dhG
 ktB
 gcK
 gcK
 gcK
-gbL
 gcK
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
 gcK
 ktB
 gcK
+kiC
+ggK
+urW
+ggK
+cdU
+ggK
+ggK
 gcK
-gcK
+ktB
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -66901,14 +67199,14 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-ggK
-dcY
 ggK
 ggK
+fmR
 ggK
-gcK
+ggK
+gAs
 gcK
 gcK
 ggK
@@ -66919,20 +67217,20 @@ gcK
 gcK
 gcK
 gbL
+gcK
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+ktB
+gcK
+gwi
+ggK
+fcI
+ggK
+ggK
+ddo
 gcK
 gcK
-gcK
-gcK
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -67137,7 +67435,7 @@ fyf
 tBN
 mvv
 mvv
-mvv
+pVb
 bpD
 fyf
 fyf
@@ -67149,18 +67447,18 @@ gmz
 mTd
 fmY
 vzG
-krb
+vzG
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
+ktB
 gcK
+ktB
 gcK
-gcK
-gcK
-hJB
+ggK
 ggK
 ggK
 ggK
@@ -67178,18 +67476,18 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+ktB
 gcK
+dhG
+qwG
+ggK
+hJv
+aqZ
+rsH
 gcK
-gcK
-gcK
+ktB
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -67413,18 +67711,18 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+ggK
+ggK
 ggK
 ggK
 gcK
 gcK
 pFh
-utT
+dhG
 ggK
 mwO
 utT
@@ -67435,17 +67733,17 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+ktB
 gcK
 gcK
 gcK
+aqZ
+ggK
+ggK
+dhG
+gcK
+ktB
+gbL
 gcK
 gcK
 gcK
@@ -67670,11 +67968,11 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -67689,19 +67987,19 @@ gcK
 ktB
 ktB
 gcK
-gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+ktB
+ktB
+ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -67928,11 +68226,11 @@ gcK
 gcK
 gcK
 gcK
+ktB
+ktB
 gcK
 gcK
-gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -67951,14 +68249,14 @@ gbL
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -68186,12 +68484,12 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 fyf
 fyf
 fyf
@@ -68199,12 +68497,12 @@ fyf
 fyf
 fyf
 fyf
-xXi
+vSS
 gcK
 ktB
 gcK
 gcK
-gcK
+gbL
 gbL
 gbL
 gbL
@@ -68445,10 +68743,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+oYb
+oYb
+ktB
 oWC
 wOK
 wOK
@@ -68462,8 +68760,8 @@ ktB
 gcK
 gcK
 gcK
-gcK
-gcK
+gbL
+gbL
 gbL
 gbL
 gbL
@@ -68703,8 +69001,8 @@ gcK
 ktB
 ktB
 gcK
-ktB
-ktB
+ggK
+ggK
 gcK
 gcK
 ktB
@@ -68721,7 +69019,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+gbL
 gbL
 gbL
 gbL
@@ -68960,8 +69258,8 @@ gcK
 gcK
 ktB
 gcK
-gcK
-fyf
+ggK
+ggK
 ktB
 gcK
 eKM
@@ -68979,13 +69277,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
 gbL
 gbL
 gbL
 gbL
-gcK
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -69216,10 +69514,10 @@ ktB
 gcK
 gcK
 gcK
-gcK
-occ
-vAe
+jiN
 fyf
+fyf
+vAe
 ktB
 ktB
 fyf
@@ -69238,11 +69536,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
 gbL
 gbL
 gbL
-gcK
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -69465,9 +69763,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
 gcK
 ktB
 gcK
@@ -69496,10 +69794,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -69728,8 +70026,8 @@ gcK
 gcK
 bKy
 fFu
-fyf
-fyf
+udx
+udx
 lmk
 fyf
 uey
@@ -69753,9 +70051,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -69977,12 +70275,12 @@ gcK
 gbL
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 ktB
+gbL
+gbL
+gbL
+gbL
+gbL
 kZp
 jnN
 lHU
@@ -70012,7 +70310,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -70233,20 +70531,20 @@ gcK
 gcK
 gbL
 gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
 ktB
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 lmk
 jnE
 hTs
 lqV
 hTs
 oOh
-cWG
+wsw
 wDc
 fyf
 dys
@@ -70269,7 +70567,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -70488,15 +70786,15 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gbL
-gbL
 gbL
 gbL
 ktB
-ktB
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 fyf
 jnE
 rss
@@ -70526,7 +70824,7 @@ tvA
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -70745,14 +71043,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
 gbL
 gbL
 gbL
 gbL
 gbL
-ktB
-ktB
+gbL
+gbL
+gbL
 gbL
 fyf
 jnE
@@ -70760,7 +71058,7 @@ hTs
 unW
 hTs
 qSs
-mfD
+uke
 hCg
 qOV
 ntv
@@ -70783,7 +71081,7 @@ fyf
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -71002,11 +71300,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
 gbL
 ktB
 gbL
-ktB
+gbL
+gbL
 gbL
 gbL
 gbL
@@ -71259,21 +71557,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gbL
-gbL
-gbL
-gbL
-gbL
 ktB
 gbL
 gbL
-uey
-fyf
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
+dvk
 fyf
 fyf
 fyf
 qTG
+occ
 vAe
 fyf
 fyf
@@ -71298,7 +71596,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -71516,25 +71814,25 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
-ktB
-gbL
-ktB
-gbL
-gbL
-ktB
-gbL
-gbL
-bKy
-fyf
-fyf
+uKu
+uKu
+uKu
+uKu
+uKu
+uKu
+uKu
+qHX
+krb
+gke
 nxY
 jnN
 lHU
 lHU
 lHU
 mVv
-uey
+crg
 qOV
 cWG
 ghU
@@ -71555,7 +71853,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -71776,15 +72074,15 @@ gcK
 gcK
 gcK
 rqc
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
-fFu
-uey
-fyf
+mUD
+mwQ
+jJx
+ews
+twA
+dXQ
+vCW
+fph
+cYz
 fyf
 jnE
 hTs
@@ -71794,9 +72092,9 @@ nVu
 nDJ
 daU
 wUL
-gwi
 mvv
-vjO
+mvv
+doX
 xkI
 wDc
 xlE
@@ -71812,7 +72110,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -72029,20 +72327,20 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 ktB
 gcK
 uKu
-uKu
-uKu
-uKu
-uKu
-uKu
-uKu
-qHX
-fQu
-gke
-iVQ
+lxo
+buD
+buD
+buD
+buD
+mpH
+puY
+roj
+cYz
+fyf
 jnE
 rss
 jkk
@@ -72069,7 +72367,7 @@ jZo
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -72285,21 +72583,21 @@ fyf
 gcK
 gcK
 gcK
-gcK
-gcK
 ktB
+ktB
+gcK
 gcK
 cYz
 uFJ
-uVT
-crg
+buD
+buD
 qfi
 cWy
 djh
-dIj
-fph
-grc
-fyf
+buD
+uQP
+pgL
+iVQ
 jnE
 hTs
 unW
@@ -72326,7 +72624,7 @@ hCg
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -72542,32 +72840,32 @@ jJb
 gcK
 gcK
 gcK
+ktB
 gcK
-ktB
-ktB
+gcK
 gcK
 uKu
 dxJ
 cOU
 buD
 hMz
-gin
+buD
 dkW
 lsF
 gSx
-gVg
-bKy
+cYz
+fyf
 hqL
 iaB
 iaB
 iaB
 lHr
-tBN
+cGO
 mvv
 mvv
+kPq
 mvv
-mvv
-mvv
+kPq
 mvv
 doX
 cWG
@@ -72581,13 +72879,13 @@ fyf
 fyf
 fyf
 gcK
-gbL
 gcK
 gcK
 gcK
+ktB
 gcK
-gbL
-gbL
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -72799,26 +73097,26 @@ fyf
 gcK
 gcK
 gcK
-gcK
 ktB
-gcK
-gcK
-cYz
+uKu
+uKu
+uKu
+grc
 qiN
 buD
 lsF
 cbM
-hna
-ybp
-lsF
+buD
+buD
+azU
 fpv
-gND
+wpR
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
+vtg
+vtg
+vtg
 tBN
 mvv
 mvv
@@ -72841,7 +73139,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -73057,11 +73355,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-pgL
-aSW
+uKu
+eXn
+nla
+buD
+urJ
 lsF
 buD
 eoI
@@ -73071,8 +73369,8 @@ buD
 fCM
 vCF
 fyf
+ijK
 fyf
-qTY
 fyf
 qOV
 cWG
@@ -73081,10 +73379,10 @@ mvv
 pGq
 tsv
 mvv
+mvv
 tpD
-vsm
+aWY
 aBH
-mfD
 xGH
 mvv
 mvv
@@ -73098,7 +73396,7 @@ bKy
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -73315,20 +73613,20 @@ gcK
 gcK
 ktB
 uKu
-uKu
-uKu
-uKu
-akA
+lvH
+uVT
+buD
+buD
 buD
 lsF
 cOU
 urJ
 lsF
 egU
-fPU
+buD
 gTD
 iGM
-ijK
+qTY
 iRT
 fyf
 tBN
@@ -73338,10 +73636,10 @@ goK
 rlm
 ttU
 unW
+unW
 vwt
 xzn
 xqy
-fyf
 nlO
 mfD
 mfD
@@ -73352,7 +73650,7 @@ wDc
 vAe
 qLa
 kHB
-gbL
+gcK
 gcK
 gcK
 gcK
@@ -73574,8 +73872,8 @@ ktB
 cYz
 cos
 dEc
-gVt
-bgd
+lsF
+cOU
 urJ
 cOU
 gun
@@ -73595,10 +73893,10 @@ vVU
 jnE
 tBm
 unW
+unW
 vBr
 xKi
 vAe
-fyf
 fyf
 fyf
 fyf
@@ -73829,7 +74127,7 @@ gcK
 gcK
 ktB
 cYz
-lsF
+hna
 dLB
 lsF
 buD
@@ -73852,12 +74150,12 @@ fyf
 ryH
 unW
 uBU
+unW
 vDe
 xKi
 bKy
-fyf
-fmR
-fyf
+hAC
+oks
 fyf
 nlO
 mfD
@@ -73866,8 +74164,8 @@ doX
 vly
 wDc
 fyf
-gcK
-gcK
+mmw
+ktB
 gcK
 gcK
 uqa
@@ -74086,7 +74384,7 @@ gcK
 gcK
 ktB
 cYz
-buD
+bBK
 jQz
 cOU
 fFS
@@ -74102,20 +74400,20 @@ cWG
 daU
 mvv
 mvv
-iJV
-gzq
-pYj
-pYj
-vuU
+mvv
+bpD
+uey
+fyf
+jnE
 tZT
+unW
 nJr
 vJP
 xKi
 fyf
 fyf
 iVQ
-fyf
-fyf
+keK
 vAe
 jxH
 mvB
@@ -74123,8 +74421,8 @@ mvv
 mvv
 phN
 pKq
-gcK
-gcK
+czr
+xuI
 gcK
 gcK
 uqa
@@ -74359,19 +74657,19 @@ mvv
 mvv
 mvv
 mvv
-mvv
-mWy
-clL
-qwW
+iJV
+gzq
+pYj
+pYj
 smq
 bEP
-xcV
+unW
+qCV
 mRH
 xKi
 qTY
 fyf
 fyf
-keK
 pEv
 cqG
 kKk
@@ -74380,8 +74678,8 @@ mvv
 mvv
 doX
 mib
-gcK
-gcK
+fyf
+hLi
 gcK
 gcK
 uqa
@@ -74613,19 +74911,19 @@ tBN
 mvv
 mvv
 mvv
-mvv
 rjH
 rjH
 rjH
-srL
-cdL
+rjH
+mWy
+clL
 oMn
 qoL
 iaB
 iaB
 iaB
+iaB
 lHr
-gcK
 gcK
 gcK
 pEv
@@ -74637,8 +74935,8 @@ mfD
 xGH
 mvv
 bpD
-gcK
-gcK
+eBu
+aIO
 gcK
 gcK
 uqa
@@ -74861,8 +75159,8 @@ ktB
 gcK
 gcK
 gcK
-udx
-udx
+xRI
+fyf
 fyf
 uey
 fyf
@@ -74870,7 +75168,7 @@ tBN
 mvv
 mvv
 mvv
-mvv
+rjH
 rjH
 rjH
 rjH
@@ -74894,8 +75192,8 @@ qDb
 nwZ
 dgK
 egy
-gcK
-gcK
+oWC
+aoC
 gcK
 gcK
 uqa
@@ -75115,9 +75413,9 @@ gcK
 gcK
 gcK
 gcK
+gcK
 ktB
-ktB
-ktB
+gcK
 bcK
 bcK
 cqr
@@ -75127,13 +75425,13 @@ daU
 mvv
 mvv
 mvv
-mvv
+rjH
 rjH
 rjH
 lYH
 srL
-egW
-ebx
+cdL
+fdV
 gcK
 ktB
 ktB
@@ -75152,7 +75450,7 @@ cVF
 mvv
 bpD
 fyf
-gcK
+fyf
 uqa
 rTi
 uqa
@@ -75388,9 +75686,9 @@ ims
 jfD
 jwl
 ueT
-pon
-gcK
-gcK
+smk
+egW
+ebx
 gcK
 ktB
 gcK
@@ -75409,7 +75707,7 @@ mvB
 mvv
 bpD
 fyf
-fyf
+uey
 uqa
 pob
 xJz
@@ -75645,7 +75943,7 @@ iqZ
 jha
 jGe
 lZX
-lPT
+pon
 gcK
 ktB
 ktB
@@ -75665,7 +75963,7 @@ qkT
 nrV
 mfD
 hCg
-fyf
+hAC
 fyf
 uqa
 pob
@@ -76152,8 +76450,8 @@ cPZ
 mvv
 bpD
 lpL
-vtg
-vtg
+fyf
+fyf
 gcK
 gcK
 gcK
@@ -76179,7 +76477,7 @@ jxH
 jxH
 fyf
 fyf
-sND
+fyf
 fyf
 uqa
 pkR
@@ -76436,7 +76734,7 @@ uey
 dzE
 cWG
 wDc
-fyf
+uey
 fyf
 uqa
 uqa
@@ -76694,8 +76992,8 @@ tBN
 mvv
 bpD
 fyf
-fyf
-fyf
+hLi
+dDC
 uqa
 nKn
 xJz
@@ -76951,8 +77249,8 @@ tBN
 mvv
 bpD
 fyf
-fyf
-fyf
+hLi
+pEv
 uqa
 fYp
 xJz
@@ -77209,7 +77507,7 @@ mvv
 bpD
 fyf
 fyf
-vzp
+vzs
 uqa
 mlb
 aej
@@ -77465,7 +77763,7 @@ jwX
 mvv
 bpD
 fyf
-fyf
+hAC
 fyf
 uqa
 fym
@@ -77978,7 +78276,7 @@ fyf
 tBN
 aBH
 hCg
-fyf
+uey
 fyf
 hll
 uqa
@@ -78492,10 +78790,10 @@ fyf
 cqG
 uey
 tBN
-bpD
-fyf
-fyf
-fyf
+doX
+wDc
+hLi
+hLi
 fyf
 fyf
 fyf
@@ -106877,7 +107175,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (181,1,1) = {"
@@ -107134,7 +107432,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (182,1,1) = {"
@@ -107391,7 +107689,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (183,1,1) = {"
@@ -107648,7 +107946,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (184,1,1) = {"
@@ -107905,7 +108203,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (185,1,1) = {"
@@ -108162,7 +108460,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+uqa
 ktB
 "}
 (186,1,1) = {"
@@ -108417,9 +108715,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+rTi
+uqa
 ktB
 "}
 (187,1,1) = {"
@@ -108674,9 +108972,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+pob
+xJz
 ktB
 "}
 (188,1,1) = {"
@@ -108931,9 +109229,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+pob
+xJz
 ktB
 "}
 (189,1,1) = {"
@@ -109188,9 +109486,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+nKn
+hHX
 ktB
 "}
 (190,1,1) = {"
@@ -109445,9 +109743,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+pkR
+xJz
 ktB
 "}
 (191,1,1) = {"
@@ -109702,9 +110000,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+uqa
+uqa
+uqa
 ktB
 "}
 (192,1,1) = {"
@@ -109959,9 +110257,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+fyf
+uqa
+nKn
 ktB
 "}
 (193,1,1) = {"
@@ -110216,9 +110514,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+fyf
+uqa
+fYp
 ktB
 "}
 (194,1,1) = {"
@@ -110473,9 +110771,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+vzp
+uqa
+mlb
 ktB
 "}
 (195,1,1) = {"
@@ -110730,9 +111028,9 @@ gcK
 gbL
 gbL
 gcK
-gcK
-gcK
-gcK
+fyf
+uqa
+fym
 ktB
 "}
 (196,1,1) = {"
@@ -110987,9 +111285,9 @@ gbL
 gbL
 gcK
 gcK
-gcK
-gcK
-gcK
+fyf
+uqa
+fUR
 ktB
 "}
 (197,1,1) = {"
@@ -111244,9 +111542,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+hll
+uqa
+pTP
 ktB
 "}
 (198,1,1) = {"
@@ -111501,9 +111799,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+fyf
+uqa
+uqa
 ktB
 "}
 (199,1,1) = {"

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1421,9 +1421,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "aSl" = (
-/obj/machinery/light/small,
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/obj/machinery/smartfridge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "aSo" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -2748,11 +2749,8 @@
 	},
 /area/f13/tunnel)
 "bBA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/plantgenes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "bBM" = (
 /obj/item/pickaxe/drill,
@@ -4155,11 +4153,11 @@
 	},
 /area/f13/caves)
 "cmM" = (
-/obj/structure/table/reinforced,
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_x = 8
 	},
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "cnf" = (
@@ -5169,7 +5167,7 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "cMe" = (
-/obj/machinery/biogenerator,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -7604,8 +7602,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eec" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "eeq" = (
 /obj/structure/table,
@@ -8011,8 +8012,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/caves)
 "enK" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/seed_extractor,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "enN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11817,6 +11821,10 @@
 	color = "#3e3d42";
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
 /turf/open/water,
 /area/f13/brotherhood/leisure)
 "grU" = (
@@ -14282,7 +14290,9 @@
 	name = "gardening locker";
 	req_access = list(120)
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "hSr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19158,8 +19168,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "kVL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "kVP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20909,10 +20921,14 @@
 	},
 /area/f13/bunker)
 "mbe" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "mbT" = (
 /obj/structure/table/wood,
@@ -21033,7 +21049,9 @@
 "mhx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/leisure)
 "mir" = (
 /turf/open/indestructible/ground/inside/subway,
@@ -29747,10 +29765,6 @@
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"rAs" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "rAt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13chair2,
@@ -29998,6 +30012,7 @@
 	color = "000000"
 	},
 /obj/structure/table,
+/obj/item/trash/f13/electronic/toaster/atomics,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhdirty_chess2"
 	},
@@ -30765,6 +30780,9 @@
 /area/f13/bunker)
 "saB" = (
 /obj/structure/simple_door/bunker/glass,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "saC" = (
@@ -31621,11 +31639,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "sEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "sEi" = (
 /obj/structure/cable{
@@ -37055,8 +37072,7 @@
 /turf/closed/wall/rust,
 /area/f13/den)
 "wmL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/seed_extractor,
+/obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -38991,6 +39007,10 @@
 	},
 /obj/structure/flora/ausbushes/grassybush{
 	layer = 2.1
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
 /turf/open/water,
 /area/f13/brotherhood/leisure)
@@ -93878,7 +93898,7 @@ lAK
 jNu
 ood
 ebT
-qkX
+hXf
 rZx
 cOc
 dBX
@@ -94136,7 +94156,7 @@ bRV
 ood
 pHr
 qkX
-hXf
+qkX
 qkX
 uBh
 tci
@@ -94399,7 +94419,7 @@ qkX
 ood
 bps
 gqM
-gqM
+eec
 gqM
 btc
 aSi
@@ -94656,7 +94676,7 @@ qkX
 fgN
 btc
 btc
-bBA
+gqM
 btc
 btc
 cwz
@@ -94913,7 +94933,7 @@ pnq
 ood
 erQ
 btc
-wmL
+gqM
 btc
 gqM
 cwz
@@ -95171,7 +95191,7 @@ ood
 bps
 gqM
 btc
-btc
+cMe
 btc
 aSi
 xZn
@@ -95419,7 +95439,7 @@ web
 lQa
 bRV
 ood
-ksg
+bBA
 xta
 qin
 mjR
@@ -95678,14 +95698,14 @@ bfK
 dEr
 cmM
 jLd
-mjR
+kom
 hQs
 xta
 ood
 xsD
-cMe
-uFr
-htQ
+btc
+btc
+btc
 btc
 grM
 ood
@@ -95939,12 +95959,12 @@ rFC
 hQs
 sXq
 ood
-ood
-ood
-ood
-ood
 mbe
-ood
+btc
+enK
+wmL
+btc
+aSl
 cLU
 vLv
 qCb
@@ -96195,13 +96215,13 @@ sXq
 sXq
 xta
 kom
-aSl
 ood
-ood
-enK
-kVL
-kVL
-kVL
+sEa
+btc
+btc
+gqM
+gqM
+gqM
 saB
 vLv
 adZ
@@ -96452,11 +96472,11 @@ xta
 sXq
 xta
 xta
-rAs
 ood
-ood
-eec
-sEa
+kVL
+btc
+uFr
+htQ
 hSp
 mhx
 cLU


### PR DESCRIPTION
## About The Pull Request

https://github.com/LoneStarF13/LoneStar/pull/445
https://github.com/LoneStarF13/LoneStar/pull/480
https://github.com/LoneStarF13/LoneStar/pull/511

This PR ports all of the khan updated from lonestar and ports the BOS botany update.

This PR adds the highly requested Khan Khamp second story, as it expands the workshop/armory and adds a top floor which is more dedicated to the tribals of the khans compared to the ones who do live on the first floor. Most of this PR was mapped in discord and was discussed with many of the main khan players including the names of the pets and plushie even. I have brought this to the narrative Kneesox with the second floor and they said it should be fine.
With photos below the first photo is the second layer of the workshop, with the two new pets of the khamp. These pets include the khanfarer dog of the khamp. 'Dreams-of-Moonlight' The dog is from one of the litters of the west wayfarers khamp, which is from Sniffs-the-Earth. As the first few khanfarers who did come join the khans, eventually brought over Dreams of Moonlight. The next pet is 'Khanizard' This is a lizard plushie who has the great khan pelt helmet and even the rollie on his mouth. There is no lore on this pet. That is all with the pets to explain.
The same image, there is a fancy table with infinite burning candles, this is more like a prayer stuff in a way. Besides that, on the cliff area, there is binos and outlooks so khans can view outwards, so that they can scout and basically sit up there and chill until it comes to conflict at heart.
So this is the next part of the PR: This PR also adds the Stone Age back to the khans, removing of their "vault" that was NEVER used and was rejected. This basically adds a mini dungeon for them but it doesnt give them any other special thing or even anything among the lines of overpoweredness. Basically anything back here besides the advanced workbench and part 3, everything else in a way is an gimmick crates, such as what if they would like to be cooking for the week, they have the "secret" recipe, PROVIDED by a "trading caravan" that taken a place in the cave long ago, before they gotten into ghouls. This also adds in a bigger river, so youll have much more mirelurks by the khans as they are known for there world famous "Mirelurk Stew" This PR removes the khans of the extra food they gotten earlier in a PR I have made and forces them to actually fight for more food. At the end of it all is two legendary ghouls with three nests to get through it all. Did I mention there is a bawls vendor in there?!
ALL images down below.

## Why It's Good For The Game

Khans rule, and this PR is good for khans and can bring a bit of people over to lay some khans who wish for these updates to come in.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: replaces khan caves with new khan caves that should bring them to more usefulness instead of forgotten ages.
tweak: BOS Botany moving around in the same spot just some items around.
add: Second floor khamp, Khanfarer/Wayfarer Dog, Khanizard.
add: larger workshop
add: workwall
add: boozes and more boozes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
