### PR TITLE
Plant disks where DNA manipulators are.

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -12180,7 +12180,7 @@
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/disk/plantgene,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gCv" = (

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -2264,7 +2264,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "XX" = (
-/turf/open/floor/plating/tunnel,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/bunker)
 "XY" = (
 /turf/closed/indestructible/rock,
@@ -2872,7 +2876,7 @@ Rl
 xG
 IG
 Zf
-XX
+oj
 LV
 oj
 xG
@@ -3437,7 +3441,7 @@ kj
 kj
 MU
 Lt
-XM
+XX
 kj
 xG
 xG

--- a/_maps/map_files/templates/dungeons/north_bunker_3.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_3.dmm
@@ -881,6 +881,7 @@
 "zv" = (
 /obj/machinery/plantgenes,
 /obj/structure/table/reinforced,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "zz" = (


### PR DESCRIPTION
## About The Pull Request

Simple adding plant disks where the dna maniplators are. We arent putting them in autolathes for people to abuse.

## Why It's Good For The Game

that way wastelanders can play with dna manipulators without having to trek to the brotherhood or enclave to get some.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: DNA manipulator box to two bunkers and a spot on the map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
