### PR TITLE
reverts longpork back to molerat stew icon

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/food.dm
+++ b/code/modules/fallout/obj/food_and_drinks/food.dm
@@ -630,7 +630,7 @@
 	name = "longpork stew"
 	desc = "A thick, oily stew that tastes and smells weird. Has small pieces of raw, chewy meat."
 	icon = 'icons/fallout/objects/food&drinks/soupsalad.dmi'
-	icon_state = "longpork_stew"
+	icon_state = "molerat_stew"
 	bitesize = 4
 	volume = 30
 	list_reagents = list(/datum/reagent/medicine/longpork_stew = 30)


### PR DESCRIPTION
## About The Pull Request

This PR simply just reverts the longpork stew back to its original state instead of keeping it invisble on its own which was a whoopsies and will be fixed sometime soon.

## Why It's Good For The Game

longpork was kinda of invisble this PR will revert the changes I have done and take them back a bit before that PR.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

:cl:
tweak: Icon of longpork
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of