### PR TITLE
Nerfs the throwing star

### DIFF
--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -344,10 +344,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
-	throwforce = 15 
+	throwforce = 12
 	throw_speed = 4
-	embedding = list("pain_mult" = 1.5, "embed_chance" = 15, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
-	armour_penetration = 0.10
+	embedding = list("pain_mult" = 2, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
+	armour_penetration = 0.15
 
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -338,7 +338,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/throwing_star
 	name = "throwing star"
-	desc = "A serrated metal disk. Useless against armor, but looks painful if chucked it at someone's face."
+	desc = "A serrated metal disk. Useless against armor, but looks painful if chucked into someone's face."
 	icon_state = "throwingstar"
 	item_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -338,7 +338,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/throwing_star
 	name = "throwing star"
-	desc = "A serrated metal disk. Useless against armor, but looks painful if you chucked it at someone's face. "
+	desc = "A serrated metal disk. Useless against armor, but looks painful if chucked it at someone's face."
 	icon_state = "throwingstar"
 	item_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -346,8 +346,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 15 
 	throw_speed = 4
-	embedding = list("pain_mult" = 1, "embed_chance" = 10, "fall_chance" = 0, "embed_chance_turf_mod" = 50)
-	armour_penetration = 0
+	embedding = list("pain_mult" = 1, "embed_chance" = 10, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
+	armour_penetration = 0.10
 
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -346,7 +346,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 15 
 	throw_speed = 4
-	embedding = list("pain_mult" = 1, "embed_chance" = 15, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
+	embedding = list("pain_mult" = 1.5, "embed_chance" = 15, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
 	armour_penetration = 0.10
 
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -338,16 +338,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/throwing_star
 	name = "throwing star"
-	desc = "An ancient weapon still used to this day, due to its ease of lodging itself into its victim's body parts."
+	desc = "A serrated metal disk. Useless against armor, but looks painful if you chucked it at someone's face. "
 	icon_state = "throwingstar"
 	item_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
-	throwforce = 10 //This is never used on mobs since this has a 100% embed chance.
+	throwforce = 15 
 	throw_speed = 4
-	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
-	armour_penetration = 0.65
+	embedding = list("pain_mult" = 1, "embed_chance" = 10, "fall_chance" = 0, "embed_chance_turf_mod" = 50)
+	armour_penetration = 0
 
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -346,7 +346,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 15 
 	throw_speed = 4
-	embedding = list("pain_mult" = 1, "embed_chance" = 10, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
+	embedding = list("pain_mult" = 1, "embed_chance" = 15, "fall_chance" = 0, "embed_chance_turf_mod" = 75)
 	armour_penetration = 0.10
 
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## About The Pull Request

- Nerfs the throwing star, you can't use it for 100% embed on armored people anymore, upped it's damage slightly to compensate.

## Why It's Good For The Game

Currently, a throwing star has 65% AP and 100% embed chance making it ignore any armor and deal 5-10 damage every few seconds to the victim even if they're not moving. This is really excessive for a small sized item /especially/ if the victim is embedded multiple times at which it'll actually out-damage a stimpak and there's no way to really help someone. Here I've lowered the AP to 15% so it's not so overwhelming against armored opponents.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


:cl:
balance: Nerfs AP values on the throwing stars and slightly increases its damage to compensate.
/:cl: