### PR TITLE
readds cyborgs, glass floors, some multiz stuff, and some other content

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -66,7 +66,7 @@
 					R.use(2)
 					to_chat(user, "<span class='notice'>You reinforce the floor.</span>")
 				return
-	/* Fortuna edit: glass floors disabled
+
 	if(istype(C, /obj/item/stack/sheet/glass))
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>Repair the plating first!</span>")
@@ -101,7 +101,7 @@
 					RG.use(2)
 					to_chat(user, "<span class='notice'>You add reinforced glass to the floor.</span>")
 				return
-	*/
+
 	else if(istype(C, /obj/item/stack/tile))
 		if(!broken && !burnt)
 			for(var/obj/O in src)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -312,8 +312,7 @@
 		return
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/attackby(obj/item/W, mob/user, params)
-	/* Coconut bombs (disabled)
-	//DEFUSING NADE LOGIC
+
 	if (W.tool_behaviour == TOOL_WIRECUTTER && fused)
 		user.show_message("<span class='notice'>You cut the fuse!</span>", MSG_VISUAL)
 		playsound(user, W.hitsound, 50, 1, -1)
@@ -353,7 +352,7 @@
 			desc = "A makeshift bomb made out of a coconut. You estimate the fuse is long enough for 5 seconds."
 			name = "coconut bomb"
 			return
-	*/
+
 	//ADDING STRAW LOGIC
 	if (istype(W,/obj/item/stack/sheet/mineral/bamboo) && opened && !straw && fused)
 		user.show_message("<span class='notice'>You add a bamboo straw to the coconut!</span>", 1)
@@ -456,10 +455,10 @@
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/afterattack(obj/target, mob/user, proximity)
 	. = ..()
-	/* coconut bombs disabled
+
 	if(fusedactive)
 		return
-	*/
+
 
 	if((!proximity) || !check_allowed_items(target,target_self=1))
 		return
@@ -499,7 +498,7 @@
 	. = ..()
 	transform *= TRANSFORM_USING_VARIABLE(40, 100) + 0.5 //temporary fix for size?
 
-/* coconut bombs disabled
+
 /obj/item/reagent_containers/food/snacks/grown/coconut/proc/prime()
 	if (defused)
 		return
@@ -517,7 +516,7 @@
 		prime()
 	if(!QDELETED(src))
 		qdel(src)
-*/
+
 
 /obj/item/seeds/aloe
 	name = "pack of aloe seeds"

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -12,7 +12,7 @@
 	icon_grow = "tomato-grow"
 	icon_dead = "tomato-dead"
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood) // Fortuna edit: removed killer tomatoes from the mutate list
+	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood, /obj/item/seeds/tomato/killer) // Fortuna edit: removed killer tomatoes from the mutate list
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tomato

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -932,7 +932,7 @@
 		M.losebreath++
 		. = 1
 	..()
-/* no. just no. the revive timer is 30 minutes(hopefully lowered soon); that is plenty of time. we do not need this.
+
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
@@ -992,7 +992,7 @@
 	M.adjustFireLoss(0.5*REM, 0)
 	..()
 	. = 1
-*/
+
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"
 	description = "Efficiently restores brain damage."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -899,7 +899,6 @@
 	H.visible_message("<b>[H]</b> suddenly transforms!")
 	randomize_human(H)
 
-/* Fortuna edit: disabled slime mutation toxins
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
 	description = "An advanced corruptive toxin produced by slimes."
@@ -910,13 +909,12 @@
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(method != TOUCH)
 		L.ForceContractDisease(new /datum/disease/transformation/slime(), FALSE, TRUE)
-*/
+
 
 /datum/reagent/gluttonytoxin
 	name = "Gluttony's Blessing"
 	description = "An advanced corruptive toxin produced by something terrible."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	can_synth = FALSE
 	taste_description = "decay"
 	value = REAGENT_VALUE_GLORIOUS
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -190,14 +190,12 @@
 	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 2)
 	required_temp = 525
 
-//Technically a mutation toxin
-/* Fortuna edit: Mutation toxins disabled
 /datum/chemical_reaction/mulligan
 	name = "Mulligan"
 	id = "mulligan"
 	results = list(/datum/reagent/mulligan = 1)
 	required_reagents = list(/datum/reagent/slime_toxin = 1, /datum/reagent/toxin/mutagen = 1)
-*/
+
 
 /datum/chemical_reaction/fermis_plush
 	name = "Fermis plush"
@@ -613,7 +611,7 @@
 	id = /datum/reagent/colorful_reagent
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
-/* strange reagent removed
+
 /datum/chemical_reaction/life
 	name = "Life"
 	id = "life"
@@ -644,7 +642,7 @@
 	for(var/i = rand(1, multiplier), i <= multiplier, i++) // More lulz.
 		new /mob/living/simple_animal/pet/dog/corgi(location)
 	..()
-*/
+
 /datum/chemical_reaction/hair_dye
 	name = "hair_dye"
 	id = /datum/reagent/hair_dye

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -118,7 +118,7 @@
 	var/location = get_turf(holder.my_atom)
 	empulse(location, multiplier)
 	holder.clear_reagents()
-/* strange reagent removed
+
 /datum/chemical_reaction/beesplosion
 	name = "Bee Explosion"
 	id = "beesplosion"
@@ -142,7 +142,7 @@
 			if(LAZYLEN(beeagents))
 				new_bee.assign_reagent(pick(beeagents))
 
-*/
+
 /datum/chemical_reaction/stabilizing_agent
 	name = "stabilizing_agent"
 	id = /datum/reagent/stabilizing_agent

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -423,8 +423,7 @@
 	new /obj/item/slimepotion/genderchange(get_turf(holder.my_atom))
 	..()
 
-//Black
-/* Fortuna edit: Mutation toxins disabled
+
 /datum/chemical_reaction/slime/slimemutate2
 	name = "Advanced Mutation Toxin"
 	id = /datum/reagent/aslimetoxin
@@ -432,7 +431,7 @@
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/black
-*/
+
 
 //Oil
 /datum/chemical_reaction/slime/slimeexplosion

--- a/code/modules/research/techweb/nodes/robotics_nodes.dm
+++ b/code/modules/research/techweb/nodes/robotics_nodes.dm
@@ -21,7 +21,7 @@
 	starting_node = TRUE
 	display_name = "Cyborg Construction"
 	description = "Sapient robots with preloaded tool modules and programmable laws."
-	design_ids = list("robocontrol", "sflash", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
+	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
 	"cyborgrecharger", "borg_upgrade_restart", "borg_upgrade_rename")
 
 
@@ -73,7 +73,7 @@
 	design_ids = list("borg_upgrade_vtec", "borg_upgrade_disablercooler")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
-/*
+
 /datum/techweb_node/ai
 	id = "ai"
 	display_name = "Artificial Intelligence"
@@ -83,4 +83,4 @@
 	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "corporate_module",
 	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-*/
+

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -1,4 +1,4 @@
-/*SDGF
+
 ////////////////////////////////////////////////////
 // 		synthetic-derived growth factor			 //
 //////////////////////////////////////////////////
@@ -396,4 +396,4 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 			M.adjustToxLoss(2, 0)
 			M.reagents.remove_reagent(type, 1)
 	..()
-*/
+

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -101,8 +101,7 @@
 	return
 
 
-//serum
-/* disable SDGF as a whole. ~FO13
+
 /datum/chemical_reaction/fermi/SDGF
 	name = "Synthetic-derived growth factor"
 	id = /datum/reagent/fermi/SDGF
@@ -141,8 +140,7 @@
 		S.color = "#810010"
 	my_atom.reagents.clear_reagents()
 	my_atom.visible_message("<span class='warning'>An horrifying tumoural mass forms in [my_atom]!</span>")
-*/
-/*
+
 /datum/chemical_reaction/fermi/astral
 	name = "Astrogen"
 	id = /datum/reagent/fermi/astral
@@ -164,14 +162,14 @@
 	FermiChem				= TRUE
 	FermiExplode 			= TRUE
 	PurityMin 				= 0.25
-*/
+
 
 /datum/chemical_reaction/fermi/enthrall //check this
 	name = "MKUltra"
 	id = /datum/reagent/fermi/enthrall
 	results = list(/datum/reagent/fermi/enthrall = 5)
-//	required_reagents = list(/datum/reagent/consumable/coco = 1, /datum/reagent/bluespace = 1, /datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/psicodine = 1, /datum/reagent/drug/happiness = 1)
-//	required_catalysts = list(/datum/reagent/blood = 1)
+	required_reagents = list(/datum/reagent/consumable/coco = 1, /datum/reagent/bluespace = 1, /datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/psicodine = 1, /datum/reagent/drug/happiness = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
 	mix_message = "the reaction gives off a burgundy plume of smoke!"
 	//FermiChem vars:
 	OptimalTempMin 			= 780
@@ -315,7 +313,7 @@
 	name = "Yamerol"
 	id = /datum/reagent/fermi/yamerol
 	results = list(/datum/reagent/fermi/yamerol = 3)
-	//required_reagents = list(/datum/reagent/medicine/perfluorodecalin = 1, /datum/reagent/medicine/salbutamol = 1, /datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/medicine/perfluorodecalin = 1, /datum/reagent/medicine/salbutamol = 1, /datum/reagent/water = 1)
 	//FermiChem vars:
 	OptimalTempMin 	= 300
 	OptimalTempMax 	= 500
@@ -335,7 +333,7 @@
 	name = "Zeolites"
 	id = /datum/reagent/fermi/zeolites
 	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot!
-	//required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 	//FermiChem vars:
 	OptimalTempMin 	= 300
 	OptimalTempMax 	= 900
@@ -350,3 +348,36 @@
 	HIonRelease 	= 0.01
 	RateUpLim 		= 15
 	FermiChem 		= TRUE
+
+datum/chemical_reaction/fermi/eigenstate
+	name = "Eigenstasium"
+	id = /datum/reagent/fermi/eigenstate
+	results = list(/datum/reagent/fermi/eigenstate = 1)
+	//required_reagents = list(/datum/reagent/bluespace = 1, /datum/reagent/stable_plasma = 1, /datum/reagent/consumable/caramel = 1)
+	mix_message = "the reaction zaps suddenly!"
+	//FermiChem vars:
+	OptimalTempMin 		= 350 // Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax		= 600 // Upper end for above
+	ExplodeTemp			= 650 //Temperature at which reaction explodes
+	OptimalpHMin		= 7 // Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax		= 9 // Higest value for above
+	ReactpHLim			= 5 // How far out pH wil react, giving impurity place (Exponential phase)
+	CatalystFact		= 0 // How much the catalyst affects the reaction (0 = no catalyst)
+	CurveSharpT 		= 1.5 // How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 3 // How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= 10 //Temperature change per 1u produced
+	HIonRelease 		= -0.02 //pH change per 1u reaction
+	RateUpLim 			= 3 //Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE//If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE //If the chemical explodes in a special way
+	PurityMin			= 0.4 //The minimum purity something has to be above, otherwise it explodes.
+
+/datum/chemical_reaction/fermi/eigenstate/FermiFinish(datum/reagents/holder, atom/my_atom)//Strange how this doesn't work but the other does.
+	var/datum/reagent/fermi/eigenstate/E = locate(/datum/reagent/fermi/eigenstate) in my_atom.reagents.reagent_list
+	if(!E)
+		return
+	var/turf/open/location = get_turf(my_atom)
+	if(location)
+		E.location_created = location
+		E.data["location_created"] = location
+


### PR DESCRIPTION
list of readded content:

you can make floors out of glass now, that let you see below zlevels. this is useful for multiz construction which we have now

many chemicals are now uncommented (but still unavailable, just so that admins can use them for events) or back in the game. most of the bad ones-for example, SDGF and eigen-are still unavailable. this is mainly just so that admins can use them for events, as they do mechanically unique things.

cyborgs are printable now. seeing as we added assaultron modules and exosuit fabricators, this was a requested feature including by some admins.

coconut bombs are back. these are 50u coconut shells you can fill with a chemical then light. they're basically shittier IEDs, as you can already do the exact same thing with beakers. these aren't true grenades, just time-delayed beakers.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
