### PR TITLE
replaces ballistic fist and also bos timer

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -967,7 +967,7 @@ Initiate
 	selection_color = "#95a5a6"
 
 	exp_type = EXP_TYPE_FALLOUT
-	exp_requirements = 300
+	exp_requirements = 0
 
 	loadout_options = list(
 	/datum/outfit/loadout/initiatek, //AEP7 and Engibelt with combat armor, no helmet

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -700,10 +700,10 @@ commented out pending rework*/
 
 /datum/outfit/loadout/expambusher
 	name = "Ambusher"
-	suit_store = /obj/item/gun/ballistic/automatic/smg/tommygun
+	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/tommygunm45 = 2,
+		/obj/item/ammo_box/magazine/uzim9mm = 2,
 		/obj/item/bottlecap_mine = 1,
 		/obj/item/restraints/legcuffs/bola = 1,
 		)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -700,14 +700,12 @@ commented out pending rework*/
 
 /datum/outfit/loadout/expambusher
 	name = "Ambusher"
-	suit_store = /obj/item/gun/ballistic/revolver/ballisticfist
+	suit_store = /obj/item/gun/ballistic/automatic/smg/tommygun
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/ammo_box/magazine/tommygunm45 = 2,
 		/obj/item/bottlecap_mine = 1,
 		/obj/item/restraints/legcuffs/bola = 1,
-		/obj/item/reagent_containers/pill/patch/bitterdrink = 2,
-		/obj/item/restraints/legcuffs/beartrap = 2,
 		)
 
 /datum/outfit/loadout/expsniper
@@ -716,6 +714,7 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/rifle/enfield
 	backpack_contents = list(
 		/obj/item/ammo_box/a762 = 3,
+		/obj/item/restraints/legcuffs/beartrap = 2,
 		/obj/item/book/granter/trait/rifleman = 1,
 		/obj/item/attachments/scope = 1,
 		/obj/item/grenade/smokebomb = 1,


### PR DESCRIPTION
## About The Pull Request
scratch that, mp5 back
also opened up initiate for everyone

## Why It's Good For The Game
might as well give them decent weapons

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: replaces ballistic fist with thompson in explorer loadout
/:cl:
