### PR TITLE
more ncr loadouts + crafting recipe standardization + rigbe's mateba

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -194,7 +194,7 @@
 	name = "12g handloaded ammo bag"
 	result = /obj/item/ammo_box/shotgun/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -207,7 +207,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/prewar = 2,
 	/obj/item/stack/sheet/metal = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -220,7 +220,7 @@
 	result = /obj/item/ammo_box/m22
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/metal = 1,
-	/datum/reagent/blackpowder = 30
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -234,7 +234,7 @@
 	/obj/item/stack/cable_coil = 5,
 	/obj/item/stack/crafting/electronicparts = 2,
 	/obj/item/stack/sheet/metal = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -245,7 +245,7 @@
 	name = "9mm handloaded ammo bag"
 	result = /obj/item/ammo_box/c9mm/improv
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -259,7 +259,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/metal = 5,
 	/datum/reagent/fuel = 20,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -274,7 +274,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/metal = 5,
 	/datum/reagent/fuel = 20,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -285,7 +285,7 @@
 	name = ".38 handloaded ammo bag"
 	result = /obj/item/ammo_box/c38box/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -297,8 +297,8 @@
 	result = /obj/item/ammo_box/c10mm/fire
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/metal = 6,
-	/datum/reagent/phosphorus = 20,
-	/datum/reagent/blackpowder = 50
+	/datum/reagent/fuel = 10,
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -322,8 +322,8 @@
 	result = /obj/item/ammo_box/a357box/incendiary
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/phosphorus = 20,
-	/datum/reagent/blackpowder = 50
+	/datum/reagent/fuel = 10,
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -334,7 +334,7 @@
 	name = ".357 handloaded ammo bag"
 	result = /obj/item/ammo_box/a357box/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -347,9 +347,8 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/crafting/abraxo = 1,
 	/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/phosphorus = 10,
 	/datum/reagent/fuel = 10,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -360,7 +359,7 @@
 	name = ".44 handloaded ammo bag"
 	result = /obj/item/ammo_box/m44box/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 6,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -373,9 +372,8 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/crafting/abraxo = 1,
 	/obj/item/stack/sheet/metal = 5,
-	/datum/reagent/phosphorus = 10,
 	/datum/reagent/fuel = 10,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -386,7 +384,7 @@
 	name = ".45 ACP handloaded ammo bag"
 	result = /obj/item/ammo_box/c45/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 6,
-	/datum/reagent/blackpowder = 25
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -399,7 +397,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 2,
 	/obj/item/stack/sheet/mineral/titanium = 1,
 	/obj/item/stack/sheet/prewar = 2,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -412,7 +410,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/mineral/titanium = 1,
 	/obj/item/stack/sheet/prewar = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 75
@@ -427,7 +425,7 @@
 	/obj/item/stack/sheet/prewar = 1,
 	/obj/item/stack/cable_coil = 5,
 	/obj/item/stack/crafting/electronicparts = 2,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -440,7 +438,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/prewar = 2,
 	/obj/item/stack/sheet/mineral/titanium = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -451,7 +449,7 @@
 	name = ".223  handloaded ammo bag"
 	result = /obj/item/ammo_box/a556/sport/improvised
 	reqs = list(/obj/item/stack/sheet/metal = 6,
-	/datum/reagent/blackpowder = 30
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_MSRELOADER)
 	time = 75
@@ -465,7 +463,7 @@
 	/obj/item/stack/sheet/mineral/titanium = 1,
 	/obj/item/stack/sheet/prewar = 1,
 	/obj/item/stack/sheet/mineral/uranium = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -479,7 +477,7 @@
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
 	/obj/item/stack/sheet/prewar = 2,
 	/obj/item/stack/sheet/mineral/titanium = 1,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -493,7 +491,7 @@
 	/obj/item/stack/sheet/mineral/titanium = 2,
 	/obj/item/stack/sheet/prewar = 2,
 	/obj/item/stack/sheet/mineral/uranium = 2,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -507,7 +505,7 @@
 	/obj/item/stack/sheet/mineral/titanium = 2,
 	/obj/item/stack/sheet/prewar = 2,
 	/datum/reagent/toxin/formaldehyde = 25,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100
@@ -522,7 +520,7 @@
 	/obj/item/stack/sheet/mineral/titanium = 2,
 	/obj/item/stack/sheet/prewar = 2,
 	/datum/reagent/toxin/formaldehyde = 30,
-	/datum/reagent/blackpowder = 50
+	/obj/item/stack/ore/blackpowder = 1
 	)
 	tools = list(TOOL_AWORKBENCH)
 	time = 100

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -186,6 +186,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/beret/ncr
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	ears = /obj/item/radio/headset/headset_ncr_com
+	glasses = /obj/item/clothing/glasses/night/ncr
 	gloves = /obj/item/clothing/gloves/f13/leather
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr/CPT
@@ -195,16 +196,19 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncr = 1,
 		/obj/item/megaphone = 1,
-		/obj/item/grenade/frag = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/grenade/syndieminibomb/concussion = 2,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 3,
 		/obj/item/lighter = 1,
 		/obj/item/reagent_containers/food/snacks/grown/tobacco/dried = 1,
+		/obj/item/stack/crafting/armor_plate = 5
 		)
 
 /datum/outfit/loadout/elcapitan
 	name = "El Capitan"
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
+	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator
 	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m556/rifle/extended = 1,
+		/obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan,
 		/obj/item/ammo_box/magazine/m14mm = 3,
 		/obj/item/storage/box/ration/menu_two = 1,
 		/obj/item/melee/onehanded/knife/trench = 1,
@@ -212,9 +216,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/courtmartial
 	name = "The Court Martial"
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle
+	suit_store = /obj/item/gun/ballistic/automatic/shotgun/pancor
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m44 = 3,
+		/obj/item/ammo_box/magazine/d12g = 3,
 		/obj/item/twohanded/sledgehammer/rockethammer/courtmartial = 1,
 		/obj/item/storage/box/ration/menu_eight = 1,
 		)
@@ -260,11 +264,12 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	r_pocket = /obj/item/binoculars
 	suit_store = /obj/item/gun/ballistic/automatic/m1garand/republicspride
 	backpack_contents = list(
-		/obj/item/melee/onehanded/knife/bayonet = 1, \
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1, \
-		/obj/item/ammo_box/magazine/m9mmds = 2, \
+		/obj/item/melee/onehanded/knife/bayonet = 1,
+		/obj/item/ammo_box/magazine/m45 = 3,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/ammo_box/magazine/garand308 = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/grenade/syndieminibomb/concussion = 1,
 		)
 
 /datum/outfit/job/ncr/f13lieutenant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -318,6 +323,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	backpack_contents = list(
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
+		/obj/item/grenade/f13/frag = 1,
 		)
 
 /datum/outfit/loadout/sergeantrifleman
@@ -328,19 +334,19 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/ammo_box/magazine/m5mm = 1,
 		/obj/item/storage/box/ration/menu_two = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 3,
+		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
+		/obj/item/ammo_box/magazine/m45 = 3,
 		/obj/item/flashlight/seclite = 1,
 		)
 
 /datum/outfit/loadout/sergeantrecon
 	name = "Recon"
-	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/compact
+	suit_store = /obj/item/gun/ballistic/automatic/service/carbine
 	head = /obj/item/clothing/head/f13/ncr
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 3,
+		/obj/item/ammo_box/magazine/m556/rifle = 2,
+		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
+		/obj/item/ammo_box/magazine/m45 = 3,
 		/obj/item/storage/box/ration/menu_eight = 1,
 		/obj/item/attachments/scope = 1,
 		/obj/item/book/granter/trait/trekking = 1,
@@ -355,8 +361,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/clothing/mask/gas = 1,
 		/obj/item/grenade/smokebomb = 2,
 		/obj/item/melee/onehanded/knife/bayonet = 1,
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 3,
+		/obj/item/gun/ballistic/automatic/pistol/m1911 = 1,
+		/obj/item/ammo_box/magazine/m45 = 3,
 		)
 
 // DRILL SERGEANT
@@ -533,6 +539,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/storage/survivalkit_aid_adv = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/grenade/smokebomb = 1,
 		)
 
 /datum/outfit/loadout/vrclassic
@@ -541,7 +549,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/amr = 2,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
-		/obj/item/ammo_box/c4570 = 1,
+		/obj/item/ammo_box/c4570box/knockback = 1,
 		/obj/item/ammo_box/magazine/amr = 2,
 		)
 
@@ -556,12 +564,12 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/vrshotgunner
 	name = "Veteran Ranger Shotgunner"
-	suit_store = /obj/item/gun/ballistic/automatic/shotgun/riot
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller
 	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck = 2,
-		/obj/item/ammo_box/shotgun/slug = 1,
+		/obj/item/ammo_box/shotgun/buck = 3,
+		/obj/item/ammo_box/shotgun/trainshot = 1,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
-		/obj/item/ammo_box/c4570 = 1,
+		/obj/item/ammo_box/c4570box/knockback = 1,
 		)
 
 /datum/outfit/loadout/vrcqc
@@ -592,7 +600,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	loadout_options = list( // ALL: Binoculars, Bowie knife
 	/datum/outfit/loadout/rangerrecon, // DKS Sniper rifle, .45 Revolver
 	/datum/outfit/loadout/rangertrail, // Trail carbine, 2 x .357 Revolvers
-	/datum/outfit/loadout/rangerpatrol, // Scout carbine, .44 SA Revolver
+	/datum/outfit/loadout/rangerpatrol, // Assault Rifle, .44 SA Revolver
 	/datum/outfit/loadout/rangerpatrolcqb, // Auto-5, .44 Snubnose revolver
 	)
 
@@ -623,6 +631,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/clothing/mask/gas/ranger = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/grenade/smokebomb = 1,
 		)
 
 /datum/outfit/loadout/rangerrecon
@@ -631,7 +641,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	belt = /obj/item/storage/belt/military/reconbandolier
 	head = /obj/item/clothing/head/beret/ncr_recon_ranger
 	neck = /obj/item/clothing/neck/mantle/ranger
-	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper/sniperranger
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
 		/obj/item/storage/survivalkit_aid = 1,
@@ -644,9 +654,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit = /obj/item/clothing/suit/armor/f13/trailranger
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	neck = /obj/item/clothing/neck/mantle/ranger
-	suit_store = /obj/item/gun/ballistic/automatic/rangemaster
+	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m762 = 3,
+		/obj/item/ammo_box/tube/m44 = 3,
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/attachments/scope = 1,
@@ -660,12 +670,11 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/f13/ranger
 	uniform	= /obj/item/clothing/under/f13/ranger/patrol
 	belt = /obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/automatic/service/carbine
+	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556/rifle/assault = 1,
+		/obj/item/ammo_box/magazine/m556/rifle/extended = 1,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1,
-		/obj/item/attachments/scope = 1,
 		/obj/item/gun/ballistic/revolver/revolver44 = 1,
 		/obj/item/ammo_box/m44 = 2,
 		)
@@ -676,10 +685,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/f13/ranger
 	uniform	= /obj/item/clothing/under/f13/ranger/patrol
 	belt = /obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm = 1,
 	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck = 1,
-		/obj/item/ammo_box/shotgun/slug = 1,
+		/obj/item/ammo_box/magazine/m10mm_adv = 2,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/gun/ballistic/revolver/m29/snub = 1,
@@ -711,6 +719,14 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/datum/outfit/loadout/supportht, // R84
 		)
 
+/datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_IRONFIST, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+
 /datum/outfit/job/ncr/f13heavytrooper	// 9mm sidearm, Bayonet, Heavy armor
 	name = "NCR Heavy Trooper"
 	jobtype	= /datum/job/ncr/f13heavytrooper
@@ -722,9 +738,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	neck = /obj/item/storage/belt/holster/legholster
 	suit = /obj/item/clothing/suit/armored/heavy/salvaged_NCR
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
 		/obj/item/storage/survivalkit_aid = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 2,
+		/obj/item/ammo_box/magazine/m45exp = 2,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
 		)
 
@@ -762,6 +778,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/datum/outfit/loadout/combatengineerbuilder, // M1/n carbine, X4 explosive, Extra materials
 		/datum/outfit/loadout/combatengineertrapper, // Grease Gun, Minelaying, Explosive Crafting
 		/datum/outfit/loadout/combatengineerflamethrower, // Flamer, M1/n carbine
+		/datum/outfit/loadout/combatengineerrocketeer, //rocket launcher, m1/n carbine
 		)
 
 	matchmaking_allowed = list(
@@ -789,6 +806,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingshotgun)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/m1carbine)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /datum/outfit/job/ncr/f13combatengineer
 	name = "NCR Combat Engineer"
@@ -804,6 +822,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/shovel/trench = 1,
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/grenade/f13/frag = 1,
 		)
 
 /datum/outfit/loadout/combatengineerbuilder
@@ -811,23 +831,27 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	belt = /obj/item/storage/belt/military/assault/ncr/engineer
 	glasses = /obj/item/clothing/glasses/welding
-	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/m1n
+	suit_store = /obj/item/gun/ballistic/automatic/service/r82
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
-		/obj/item/grenade/plastic = 1,
-		/obj/item/stack/sheet/metal/twenty = 1,
-		/obj/item/stack/sheet/glass/ten = 1,
+		/obj/item/ammo_box/magazine/m556/rifle = 2,
+		/obj/item/grenade/plastic/x4 = 1,
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/glass/fifty = 1,
+		/obj/item/stack/sheet/blackpowder/twenty = 1,
+		/obj/item/stack/crafting/armor_plate = 3
 		)
 
 /datum/outfit/loadout/combatengineertrapper
 	name = "Minelayer"
-	head = /obj/item/clothing/head/f13/ncr
+	head = head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	belt = /obj/item/storage/belt/military/assault/ncr/engineer
-	suit_store = /obj/item/gun/ballistic/automatic/smg/greasegun
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm = 1
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/greasegun = 2,
+		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
 		/obj/item/book/granter/crafting_recipe/blueprint/trapper = 1,
-		/obj/item/book/granter/trait/explosives = 1
+		/obj/item/book/granter/trait/explosives = 1,
+		/obj/item/book/granter/trait/explosives_advanced = 1,
+		/obj/item/stack/crafting/armor_plate = 3
 		)
 
 /datum/outfit/loadout/combatengineerflamethrower
@@ -835,12 +859,21 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	belt = /obj/item/storage/belt/military/assault/ncr
 	glasses	= /obj/item/clothing/glasses/sunglasses
-	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/m1n
+	suit_store = /obj/item/gun/ballistic/automatic/service/r82
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
 		/obj/item/m2flamethrowertank = 1,
+		/obj/item/stack/crafting/armor_plate = 3
 		)
 
+/datum/outfit/loadout/rocketht
+	name = "Rocket Engineer"
+	suit_store = /obj/item/gun/ballistic/rocketlauncher = 1
+		backpack_contents = list(
+		/obj/item/ammo_casing/caseless/rocket = 4,
+		/obj/item/ammo_casing/caseless/rocket/big = 1,
+		/obj/item/book/granter/trait/explosives = 1,
+		)
 
 // MILITARY POLICE
 
@@ -874,7 +907,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
 		/obj/item/ammo_box/shotgun/bean = 2,
-		/obj/item/melee/classic_baton/militarypolice = 1
+		/obj/item/melee/classic_baton/militarypolice = 1,
+		/obj/item/stack/crafting/armor_plate = 4,
 		)
 
 /datum/outfit/job/ncr/f13mp/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -882,6 +916,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_IRONFIST, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 
 // COMBAT MEDIC
@@ -922,6 +957,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/survivalkit_aid_adv = 1,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
 		/obj/item/storage/firstaid/regular = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/stack/crafting/armor_plate = 4,
 		)
 
 /datum/outfit/job/ncr/f13combatmedic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -930,6 +967,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		return
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	
 
 
 
@@ -964,6 +1003,12 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 			),
 		)
 
+/datum/outfit/job/ncr/f13corporal/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+
 /datum/outfit/job/ncr/f13corporal
 	name = "NCR Corporal"
 	jobtype	= /datum/job/ncr/f13corporal
@@ -973,6 +1018,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/melee/onehanded/knife/bayonet = 1,
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
 		/obj/item/storage/survivalkit_aid = 1,
+		/obj/item/stack/crafting/armor_plate = 4,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/grenade/f13/frag = 2,
 		)
 
 /datum/outfit/loadout/corporaldesignatedmarksman
@@ -980,10 +1028,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	head = /obj/item/clothing/head/f13/ncr/steelpot_bandolier
 	neck = /obj/item/storage/belt/holster/legholster
-	suit_store = /obj/item/gun/ballistic/rifle/hunting/remington
+	suit_store = /obj/item/gun/ballistic/automatic/marksman
 	backpack_contents = list(
-		/obj/item/attachments/scope = 1,
-		/obj/item/ammo_box/a762 = 4,
+		/obj/item/ammo_box/magazine/m556/rifle = 2,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/ammo_box/magazine/m9mmds = 1,
 		/obj/item/storage/box/ration/menu_two = 1,
@@ -1028,6 +1075,12 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 			),
 		)
 
+/datum/outfit/job/ncr/f13trooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+
 /datum/outfit/job/ncr/f13trooper
 	name = "NCR Trooper"
 	jobtype	= /datum/job/ncr/f13trooper
@@ -1038,6 +1091,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	glasses	= null
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncrenlisted = 1,
+		/obj/item/stack/crafting/armor_plate = 4,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/grenade/f13/frag = 1
 		)
 
 /datum/outfit/loadout/trooperrifleman
@@ -1073,8 +1129,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	outfit = /datum/outfit/job/ncr/f13conscript
 
 	loadout_options = list(
-		/datum/outfit/loadout/conscriptvarmint, // varmint rifle, Bayonet
-		/datum/outfit/loadout/conscripthunting, // hunting rifle, Trench tool, Sandbags
+		/datum/outfit/loadout/conscriptvarmint, // service rifle, Bayonet
+		/datum/outfit/loadout/conscripthunting, // hunting shotgun, Trench tool, Sandbags
 		)
 
 	matchmaking_allowed = list(
@@ -1101,7 +1157,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/conscriptvarmint
 	name = "Assault"
-	suit_store = /obj/item/gun/ballistic/automatic/varmint
+	suit_store = /obj/item/gun/ballistic/automatic/service
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle = 1,
 		/obj/item/melee/onehanded/knife/bayonet = 1,
@@ -1236,9 +1292,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	glasses	= /obj/item/clothing/glasses/welding
 	belt = /obj/item/storage/belt/military/assault/ncr/engineer
 	gloves = /obj/item/clothing/gloves/color/yellow
-	suit_store = /obj/item/gun/ballistic/automatic/smg/greasegun
+	suit_store = /obj/item/gun/ballistic/automatic/m1garand
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/greasegun = 2,
+		/obj/item/ammo_box/magazine/garand308 = 2,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/ammo_box/magazine/m9mm = 2,
 		/obj/item/grenade/plastic/c4 = 1,
@@ -1247,7 +1303,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/stack/sheet/metal/twenty = 2,
 		/obj/item/stack/sheet/glass/ten = 2,
-		/obj/item/book/granter/trait/explosives = 1
+		/obj/item/book/granter/trait/explosives = 1,
+		/obj/item/book/granter/trait/explosives_advanced = 1,
 		)
 
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -654,9 +654,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit = /obj/item/clothing/suit/armor/f13/trailranger
 	belt = /obj/item/storage/belt/military/NCR_Bandolier
 	neck = /obj/item/clothing/neck/mantle/ranger
-	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
+	suit_store = /obj/item/gun/ballistic/automatic/rangemaster
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/m44 = 3,
+		/obj/item/ammo_box/magazine/m762 = 3,
 		/obj/item/melee/classic_baton/telescopic = 1,
 		/obj/item/storage/survivalkit_aid = 1,
 		/obj/item/attachments/scope = 1,

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -685,7 +685,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	head = /obj/item/clothing/head/f13/ranger
 	uniform	= /obj/item/clothing/under/f13/ranger/patrol
 	belt = /obj/item/storage/belt/military/assault/ncr
-	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm = 1,
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m10mm_adv = 2,
 		/obj/item/clothing/head/helmet/f13/combat/ncr_patrol = 1,
@@ -837,15 +837,15 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/grenade/plastic/x4 = 1,
 		/obj/item/stack/sheet/metal/fifty = 1,
 		/obj/item/stack/sheet/glass/fifty = 1,
-		/obj/item/stack/sheet/blackpowder/twenty = 1,
+		/obj/item/stack/ore/blackpowder/twenty = 1,
 		/obj/item/stack/crafting/armor_plate = 3
 		)
 
 /datum/outfit/loadout/combatengineertrapper
 	name = "Minelayer"
-	head = head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
+	head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	belt = /obj/item/storage/belt/military/assault/ncr/engineer
-	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm = 1
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
 		/obj/item/book/granter/crafting_recipe/blueprint/trapper = 1,
@@ -866,10 +866,10 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/stack/crafting/armor_plate = 3
 		)
 
-/datum/outfit/loadout/rocketht
+/datum/outfit/loadout/combatengineerrocketeer
 	name = "Rocket Engineer"
-	suit_store = /obj/item/gun/ballistic/rocketlauncher = 1
-		backpack_contents = list(
+	suit_store = /obj/item/gun/ballistic/rocketlauncher
+	backpack_contents = list(
 		/obj/item/ammo_casing/caseless/rocket = 4,
 		/obj/item/ammo_casing/caseless/rocket/big = 1,
 		/obj/item/book/granter/trait/explosives = 1,

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -535,11 +535,11 @@
 	item_state = "rifle"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv
 	burst_size = 1
-	fire_delay = 5
+	fire_delay = 3
 	spread = 2
 	extra_damage = 20
 	extra_penetration = 0.1
-	slowdown = 0.4
+	slowdown = 0.35
 	automatic_burst_overlay = FALSE
 	can_bayonet = TRUE
 	bayonet_state = "bayonet"
@@ -563,11 +563,10 @@
 /obj/item/gun/ballistic/automatic/m1carbine/m1n
 	name = "M1/N carbine"
 	desc = "An M1 Carbine with markings identifying it as issued to the NCR Mojave Expedtionary Force. Looks beat up but functional."
-	can_automatic = FALSE
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "ncr-m1carbine"
 	item_state = "rifle"
-	extra_damage = 21
+	extra_damage = 25
 
 
 //M1A1 Carbine				Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel, Folding stock.
@@ -747,7 +746,7 @@
 	item_state = "servicerifle"
 	icon_prefix = "servicerifle"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	slowdown = 0.45
+	slowdown = 0.3
 	fire_delay = 3
 	burst_size = 1
 	spread = 1
@@ -788,7 +787,7 @@
 	desc = "A cut down version of the standard-issue service rifle tapped with mounting holes for a scope. Shorter barrel, lower muzzle velocity."
 	icon_state = "scout_carbine"
 	spread = 1.2
-	slowdown = 0.3
+	slowdown = 0.15
 	extra_damage = 25
 	can_scope = TRUE
 	scope_state = "scope_short"
@@ -972,7 +971,7 @@
 	icon_state = "republics_pride"
 	item_state = "scoped308"
 	extra_damage = 45
-	extra_penetration = 0.1
+	extra_penetration = 0.3
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
@@ -1043,6 +1042,12 @@
 	zoom_out_amt = 17
 	extra_penetration = 0.4
 	extra_damage = 45
+
+/obj/item/gun/ballistic/automatic/marksman/sniper/sniperranger
+	name = "compact sniper rifle"
+	desc = "A DKS 501, chambered in .308 Winchester.  With a light polymer body, it's suited for long treks through the desert. This particular model is lighter and faster."
+	slowdown = 0.3
+	fire_delay = 6
 
 //////////////////
 //ASSAULT RIFLES//

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -874,6 +874,8 @@
 	force = 20
 	mag_type = /obj/item/ammo_box/magazine/m762
 	extra_damage = 40
+	extra_penetration = 0.2
+	extra_speed = 500
 	burst_size = 1
 	fire_delay = 4
 	slowdown = 0.4

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -174,6 +174,12 @@
 	spread = 0
 	fire_sound = 'sound/f13weapons/357magnum.ogg'
 
+/obj/item/gun/ballistic/revolver/colt357/mateba //this is a skin that rigbe wanted
+	name = "\improper Unica 6 auto-revolver"
+	desc = "A pre-war high-power autorevolver commonly used by people who think they look cool."
+	icon_state = "mateba"
+	item_state = "mateba"
+	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
 
 //Lucky							Keywords: UNIQUE, .357, Double action, 6 rounds cylinder, Block chance, Fire delay -1
 /obj/item/gun/ballistic/revolver/colt357/lucky
@@ -390,7 +396,7 @@
 	name = "Needler pistol"
 	desc = "You suspect this Bringham needler pistol was once used in scientific field studies. It uses small hard-plastic hypodermic darts as ammo. "
 	extra_damage = 21
-	extra_penetration = 0.5
+	extra_penetration = 0.8
 	icon_state = "needler"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
@@ -508,8 +514,8 @@
 //////////////////
 // CODE ARCHIVE //
 //////////////////
-/*
-SLING CODE
+
+/*SLING CODE
 /obj/item/gun/ballistic/revolver/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
 	if(istype(A, /obj/item/stack/cable_coil) && !sawn_off)
@@ -533,7 +539,7 @@ SLING CODE
 		slung = 0
 		update_icon()
 
-BREAK ACTION CODE
+//BREAK ACTION CODE
 /obj/item/gun/ballistic/revolver/doublebarrel/attack_self(mob/living/user)
 	var/num_unloaded = 0
 	while (get_ammo() > 0)
@@ -548,7 +554,7 @@ BREAK ACTION CODE
 	else
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 
-DODGE CODE
+//DODGE CODE
 /obj/item/gun/ballistic/revolver/colt357/lucky/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)
 		if(prob(block_chance))
@@ -670,7 +676,7 @@ DODGE CODE
 		. += charge_bar
 
 
-ACCIDENTALLY SHOOT YOURSELF IN THE FACE CODE
+//ACCIDENTALLY SHOOT YOURSELF IN THE FACE CODE
 /obj/item/gun/ballistic/revolver/reverse/can_trigger_gun(mob/living/user)
 	if((HAS_TRAIT(user, TRAIT_CLUMSY)) || (user.mind && HAS_TRAIT(user.mind, TRAIT_CLOWN_MENTALITY)))
 		return ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -23,7 +23,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	force = 15 //Decent clubs generally speaking
-	fire_delay = 7 //Typical pump action, pretty fast.
+	fire_delay = 4 //Typical pump action, pretty fast.
 	spread = 2
 	recoil = 0.1
 	can_scope = FALSE
@@ -178,7 +178,6 @@
 	item_state = "shotgunpump"
 	icon_prefix = "shotgunpump"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/lethal
-	fire_delay = 8 //slightly slower than police/military versions.
 
 /obj/item/gun/ballistic/shotgun/hunting/update_icon_state()
 	if(sawn_off)
@@ -303,7 +302,7 @@
 /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
 	name = "Browning Auto-5"
 	desc = "A semi automatic shotgun with a four round tube."
-	fire_delay = 7
+	fire_delay = 5
 	icon_state = "auto5"
 	item_state = "shotgunauto5"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
@@ -318,7 +317,7 @@
 	item_state = "shotgunlever"
 	icon_prefix = "shotgunlever"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
-	fire_delay = 9
+	fire_delay = 6
 	recoil = 0.5
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
@@ -400,6 +399,19 @@
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
+
+/obj/item/gun/ballistic/automatic/shotgun/pancor
+	name = "Pancor Jackhammer"
+	desc = "A drum-loaded, fully automatic shotgun. The pinnacle of turning things into swiss cheese."
+	icon_state = "pancor"
+	item_state = "cshotgun1"
+	fire_sound = 'sound/f13weapons/repeater_fire.ogg'
+	mag_type = /obj/item/ammo_box/magazine/d12g
+	is_automatic = TRUE
+	autofire_shot_delay = 5
+	recoil = 1
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 
 // BETA // Obsolete
 /obj/item/gun/ballistic/shotgun/shotttesting


### PR DESCRIPTION
does the same thing the legion loadouts guy did and expands the NCR's weapon options and improves their underpowered stuff

helps equalize them with the legion. NCR and legion now have an = number of automatics and the legion's still faster than the NCR but not four times faster anymore

also standardizes ammo crafting to use blackpowder sheets instead of the reagent

also adds the mateba that rigbe wanted to the game

also adds the pancor jackhammer back to the game and gives it to the NCR cap since he's supposed to be the master chief of the NCR according to rigbe

also buffs the rangemaster since it is currently literally JUST the fucking trail carbine, same ROF and everythign, when the rangemaster is a literal top tier gun
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->