### PR TITLE
Actually adds in the cyborg modules Oli made + Makes treating burn wounds easier + New medicine + Href bug exploit fix + Broadhead arrow nerf + makes salvaging take less time + Fixes an admin only chem so that it works properly + Slight nerf to legion healing + Return of coconut

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(global_all_wound_types, list(/datum/wound/blunt/critical, /datu
 
 
 /// how quickly sanitization removes infestation and decays per tick
-#define WOUND_BURN_SANITIZATION_RATE 	0.15
+#define WOUND_BURN_SANITIZATION_RATE 	0.4
 /// how much blood you can lose per tick per slash max. 8 is a LOT of blood for one cut so don't worry about hitting it easily
 #define WOUND_SLASH_MAX_BLOODFLOW		8
 /// dead people don't bleed, but they can clot! this is the minimum amount of clotting per tick on dead people, so even critical cuts will slowly clot in dead people

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -83,7 +83,7 @@
 		return ..()
 	if(istype(W,/obj/item/salvage))
 		var/obj/item/salvage/S = W
-		if(do_after(user,25,target = src))
+		if(do_after(user,1,target = src))
 			if(HAS_TRAIT(user, TRAIT_TECHNOPHREAK))
 				var/obj/I = pick(S.Loot)
 				new I (src.loc)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -37,19 +37,28 @@
 
 	if(victim.reagents)
 		if(victim.reagents.has_reagent(/datum/reagent/medicine/spaceacillin))
-			sanitization += 0.9
+			sanitization += 7
 		if(victim.reagents.has_reagent(/datum/reagent/abraxo_cleaner/sterilizine/))
-			sanitization += 0.9
+			sanitization += 4
 		if(victim.reagents.has_reagent(/datum/reagent/medicine/mine_salve))
-			sanitization += 0.3
+			sanitization += 4
+			flesh_healing += 1
+		if(victim.reagents.has_reagent(/datum/reagent/medicine/healing_powder))
+			sanitization -= 0.02 //you are rubbing dirty powder in your burns
+			flesh_healing += 0.1
+		if(victim.reagents.has_reagent(/datum/reagent/medicine/stimpak))
+			sanitization +=0.01
 			flesh_healing += 0.5
+		if(victim.reagents.has_reagent(/datum/reagent/medicine/bitter_drink))
+			sanitization +=0.5
+			flesh_healing +=0.3
 
 	if(limb.current_gauze)
 		limb.seep_gauze(WOUND_BURN_SANITIZATION_RATE)
 
 	if(flesh_healing > 0)
 		var/bandage_factor = (limb.current_gauze ? limb.current_gauze.splint_factor : 1)
-		flesh_damage = max(0, flesh_damage - 1)
+		flesh_damage = max(0, flesh_damage - 2)
 		flesh_healing = max(0, flesh_healing - bandage_factor) // good bandages multiply the length of flesh healing
 
 	// here's the check to see if we're cleared up
@@ -170,7 +179,7 @@
 			if(WOUND_INFECTION_SEPTIC to INFINITY)
 				. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
 		if(infestation > sanitization)
-			. += "\tSurgical debridement, antiobiotics/sterilizers, or regenerative mesh will rid infection. Paramedic UV penlights are also effective.\n"
+			. += "\tSurgery will remove infection. Antibiotics like penicillin or miner's salve will remove infection. The burn must be treated separately with synthflesh, regenerative mesh, and ointment.\n"
 
 		if(flesh_damage > 0)
 			. += "Flesh damage detected: Please apply ointment or regenerative mesh to allow recovery.\n"
@@ -191,6 +200,7 @@
 	I.use(1)
 	sanitization += I.sanitization
 	flesh_healing += I.flesh_regeneration
+	infestation -= I.sanitization * 0.05
 
 	if((infestation <= 0 || sanitization >= infestation) && (flesh_damage <= 0 || flesh_healing > flesh_damage))
 		to_chat(user, "<span class='notice'>You've done all you can with [I], now you must wait for the flesh on [victim]'s [limb.name] to recover.</span>")
@@ -208,6 +218,7 @@
 	I.use(1)
 	sanitization += I.sanitization
 	flesh_healing += I.flesh_regeneration
+	infestation -= I.sanitization * 0.2
 
 	if(sanitization >= infestation && flesh_healing > flesh_damage)
 		to_chat(user, "<span class='notice'>You've done all you can with [I], now you must wait for the flesh on [victim]'s [limb.name] to recover.</span>")
@@ -248,13 +259,13 @@
 		infestation = max(0, infestation - WOUND_BURN_SANITIZATION_RATE * 0.2)
 
 /datum/wound/burn/on_synthflesh(amount)
-	flesh_healing += amount * 0.5 // 20u patch will heal 10 flesh standard
+	flesh_healing += amount * 2 // 20u patch will heal 40 flesh standard
 
 // we don't even care about first degree burns, straight to second
 /datum/wound/burn/moderate
 	name = "Second Degree Burns"
 	desc = "Patient is suffering considerable burns with mild skin penetration, weakening limb integrity and increased burning sensations."
-	treat_text = "Recommended application of topical ointment or regenerative mesh to affected region."
+	treat_text = "Apply penicillin, miner's salve, abraxo cleaner to clear infection, and use bandages, synthetic flesh, ointment, or regenerative mesh to heal the damaged tissue."
 	examine_desc = "is badly burned and breaking out in blisters"
 	occur_text = "breaks out with violent red burns"
 	severity = WOUND_SEVERITY_MODERATE
@@ -268,7 +279,7 @@
 /datum/wound/burn/severe
 	name = "Third Degree Burns"
 	desc = "Patient is suffering extreme burns with full skin penetration, creating serious risk of infection and greatly reduced limb integrity."
-	treat_text = "Recommended immediate disinfection and excision of any infected skin, followed by bandaging and ointment."
+	treat_text = "Apply penicillin, miner's salve, abraxo cleaner to clear infection, and use bandages, synthetic flesh, ointment, or regenerative mesh to heal the damaged tissue. Surgery will help treat infection, but not the burn itself."
 	examine_desc = "appears seriously charred, with aggressive red splotches"
 	occur_text = "chars rapidly, exposing ruined tissue and spreading angry red burns"
 	severity = WOUND_SEVERITY_SEVERE
@@ -284,7 +295,7 @@
 /datum/wound/burn/critical
 	name = "Catastrophic Burns"
 	desc = "Patient is suffering near complete loss of tissue and significantly charred muscle and bone, creating life-threatening risk of infection and negligible limb integrity."
-	treat_text = "Immediate surgical debriding of any infected skin, followed by potent tissue regeneration formula and bandaging."
+	treat_text = "Use surgery to treat infection, followed by penicillin, miner's salve, or abraxo. Ointment and regenerative mesh will treat both tissue damage and infection, and synthetic flesh will treat burn."
 	examine_desc = "is a ruined mess of blanched bone, melted fat, and charred tissue"
 	occur_text = "vaporizes as flesh, bone, and fat melt together in a horrifying mess"
 	severity = WOUND_SEVERITY_CRITICAL
@@ -294,6 +305,6 @@
 	threshold_penalty = 80
 	status_effect_type = /datum/status_effect/wound/burn/critical
 	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
-	infestation_rate = 0.15 // appx 4.33 minutes to reach sepsis without any treatment
+	infestation_rate = 0.10 // appx 4.33 minutes to reach sepsis without any treatment
 	flesh_damage = 20
 	scar_keyword = "burncritical"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -173,7 +173,6 @@
 
 			var/multiplier = text2num(href_list["multiplier"])
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
-			multiplier = clamp(multiplier,1,50)
 
 			/////////////////
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -682,7 +682,6 @@
 		if(actually_paints)
 			if(istype(target, /obj/item/canvas))
 				return
-			var/list/hsl = rgb2hsl(hex2num(copytext(paint_color,2,4)),hex2num(copytext(paint_color,4,6)),hex2num(copytext(paint_color,6,8)))
 			var/static/whitelisted = typecacheof(list(/obj/structure/window,
 										/obj/effect/decal/cleanable/crayon,
 										/obj/machinery/door/window)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -384,10 +384,10 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 
 		if(cyborg.health < cyborg.maxHealth)
 			if(cyborg.health < 0)
-				repair_amount = -2.5
+				repair_amount = -7 //super stim
 				powercost = 30
 			else
-				repair_amount = -1
+				repair_amount = -4 //stim
 				powercost = 10
 			cyborg.adjustBruteLoss(repair_amount)
 			cyborg.adjustFireLoss(repair_amount)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -121,7 +121,7 @@
 
 /obj/item/stack/medical/gauze
 	name = "medical gauze"
-	desc = "A roll of elastic cloth, perfect for stabilizing all kinds of wounds, from cuts and burns to broken bones."
+	desc = "A roll of elastic cloth. Use it to staunch and heal bleeding and burns, and treat infection."
 	gender = PLURAL
 	singular_name = "medical gauze"
 	icon_state = "gauze"
@@ -131,7 +131,7 @@
 	amount = 10
 	max_amount = 10
 	absorption_rate = 0.45
-	absorption_capacity = 7
+	absorption_capacity = 10
 	splint_factor = 0.35
 	custom_price = PRICE_REALLY_CHEAP
 	grind_results = list(/datum/reagent/cellulose = 2)
@@ -198,7 +198,7 @@
 	name = "improvised gauze"
 	singular_name = "improvised gauze"
 	heal_brute = 0
-	desc = "A roll of cloth roughly cut from something that does a decent job of stabilizing wounds, but less efficiently than real medical gauze."
+	desc = "A roll of cloth. Useful for staunching bleeding, healing burns, and reversing infection, but not THAT useful."
 	self_delay = 60
 	other_delay = 30
 	absorption_rate = 0.15
@@ -213,12 +213,12 @@
 /obj/item/stack/medical/gauze/adv
 	name = "sterilized medical gauze"
 	singular_name = "sterilized medical gauze"
-	desc = "A roll of elastic sterilized cloth that is extremely effective at stopping bleeding and covering burns."
+	desc = "A roll of elastic sterilized cloth that is extremely effective at stopping bleeding and covering burns. "
 	heal_brute = 6
 	self_delay = 45
 	other_delay = 15
 	absorption_rate = 0.4
-	absorption_capacity = 6
+	absorption_capacity = 15
 	merge_type = /obj/item/stack/medical/gauze/adv
 
 /obj/item/stack/medical/gauze/adv/one
@@ -242,7 +242,7 @@
 	max_amount = 15
 	repeating = TRUE
 	heal_brute = 10
-	stop_bleeding = 0.8
+	stop_bleeding = 2
 	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/suture
 
@@ -259,6 +259,7 @@
 	heal_brute = 5
 	amount = 5
 	max_amount = 15
+	stop_bleeding = 1
 	merge_type = /obj/item/stack/medical/suture/emergency
 
 /obj/item/stack/medical/suture/emergency/five
@@ -275,6 +276,7 @@
 	icon_state = "suture_purp"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
 	heal_brute = 15
+	stop_bleeding = 8
 	grind_results = list(/datum/reagent/medicine/polypyr = 2)
 	merge_type = /obj/item/stack/medical/suture/medicated
 
@@ -300,7 +302,7 @@
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
-	desc = "Basic burn ointment, rated effective for second degree burns with proper bandaging, though it's still an effective stabilizer for worse burns. Not terribly good at outright healing burns though."
+	desc = "Basic burn ointment, rated effective for second degree burns with proper bandaging. Not very effective at treating infection, but better than nothing. USE WITH A BANDAGE."
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
@@ -313,8 +315,8 @@
 	merge_type = /obj/item/stack/medical/ointment
 
 	heal_burn = 5
-	flesh_regeneration = 2.5
-	sanitization = 0.3
+	flesh_regeneration = 7
+	sanitization = 2
 	grind_results = list(/datum/reagent/medicine/kelotane = 10)
 
 /obj/item/stack/medical/ointment/five
@@ -337,7 +339,7 @@
 
 /obj/item/stack/medical/mesh
 	name = "regenerative mesh"
-	desc = "A bacteriostatic mesh used to dress burns."
+	desc = "An advanced bacteriostatic mesh used to dress burns and sanitize burns. Also removes infection directly, unlike ointment. Best for severe burns. This is the kind of thing you would expect to see in a pre-war hospital."
 	gender = PLURAL
 	singular_name = "regenerative mesh"
 	icon_state = "regen_mesh"
@@ -347,8 +349,8 @@
 	max_amount = 15
 	heal_burn = 10
 	repeating = TRUE
-	sanitization = 0.75
-	flesh_regeneration = 3
+	sanitization = 2
+	flesh_regeneration = 6
 	var/is_open = TRUE ///This var determines if the sterile packaging of the mesh has been opened.
 	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/mesh
@@ -361,11 +363,13 @@
 
 /obj/item/stack/medical/mesh/advanced
 	name = "advanced regenerative mesh"
-	desc = "An advanced mesh made with aloe extracts and sterilizing chemicals, used to treat burns."
+	desc = "An advanced mesh made with aloe extracts and sterilizing chemicals, used for the most critical burns. Also removes infection directly, unlike ointment. This is the kind of thing you would expect to see in a pre-war hospital for rich people."
 	gender = PLURAL
 	singular_name = "advanced regenerative mesh"
 	icon_state = "aloe_mesh"
 	heal_burn = 15
+	sanitization = 6
+	flesh_regeneration = 12
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 	merge_type = /obj/item/stack/medical/mesh/advanced
 
@@ -474,7 +478,7 @@
 	cost = 250
 	merge_type = /obj/item/stack/medical/bone_gel/cyborg
 
-/obj/item/stack/medical/aloe
+/obj/item/stack/medical/mesh/aloe
 	name = "aloe cream"
 	desc = "A healing paste you can apply on wounds."
 
@@ -484,29 +488,13 @@
 	novariants = TRUE
 	amount = 20
 	max_amount = 20
-	var/heal = 3
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 
-/obj/item/stack/medical/aloe/heal(mob/living/M, mob/user)
+/obj/item/stack/medical/mesh/aloe/Initialize()
 	. = ..()
-	if(M.stat == DEAD)
-		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
-		return FALSE
-	if(iscarbon(M))
-		return heal_carbon(M, user, heal, heal)
-	if(isanimal(M))
-		var/mob/living/simple_animal/critter = M
-		if (!(critter.healable))
-			to_chat(user, "<span class='warning'>You cannot use \the [src] on [M]!</span>")
-			return FALSE
-		else if (critter.health == critter.maxHealth)
-			to_chat(user, "<span class='notice'>[M] is at full health.</span>")
-			return FALSE
-		user.visible_message("<span class='green'>[user] applies \the [src] on [M].</span>", "<span class='green'>You apply \the [src] on [M].</span>")
-		M.heal_bodypart_damage(heal, heal)
-		return TRUE
-
-	to_chat(user, "<span class='warning'>You can't heal [M] with the \the [src]!</span>")
+	if(amount == max_amount)	 //aloe starts open lol
+		is_open = TRUE
+		update_icon()
 
 
 // ------------------

--- a/code/game/objects/structures/wrecks.dm
+++ b/code/game/objects/structures/wrecks.dm
@@ -356,7 +356,7 @@
 			inuse = FALSE
 			return //you can't use the tool, so stop
 		for(var/i1 in 1 to 2) //so, I hate waiting
-			if(!do_after(user, 3 SECONDS*W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
+			if(!do_after(user, 1 SECONDS*W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
 				user.visible_message("[user] stops disassembling [src].")
 				inuse = FALSE
 				return //you did something, like moving, so stop
@@ -402,7 +402,7 @@
 			inuse = FALSE
 			return //you can't use the tool, so stop
 		for(var/i1 in 1 to 2) //so, I hate waiting
-			if(!do_after(user, 3 SECONDS, target = src)) //this is my work around, because do_After does have a move away
+			if(!do_after(user, 1 SECONDS, target = src)) //this is my work around, because do_After does have a move away
 				user.visible_message("[user] stops disassembling [src].")
 				inuse = FALSE
 				return //you did something, like moving, so stop

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -179,8 +179,8 @@
 				/obj/item/stack/sheet/leather/ten,
 				/obj/item/stack/sheet/glass/ten,
 				/obj/item/stack/sheet/prewar/five,
-				/obj/item/stock_parts/cell/ammo/ec,
-				/obj/item/stack/crafting/goodparts/five
+				/obj/item/stack/crafting/goodparts/five,
+				/obj/item/stack/sheet/lead/five,
 				)
 
 /obj/item/salvage/crafting
@@ -223,9 +223,4 @@
 				/obj/item/advanced_crafting_components/alloys,
 				/obj/item/advanced_crafting_components/conductors,
 				/obj/item/advanced_crafting_components/lenses,
-				/obj/item/advanced_crafting_components/flux,
-				/obj/item/attachments/scope,
-				/obj/item/suppressor,
-				/obj/item/attachments/burst_improvement,
-				/obj/item/attachments/recoil_decrease,
-				/obj/item/attachments/auto_sear)
+				/obj/item/advanced_crafting_components/flux)

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -235,7 +235,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
 	overdose_threshold = 31
 	var/heal_factor = -3 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -5.2 //Multiplier if you have the right perk.
+	var/heal_factor_perk = -4.5 //Multiplier if you have the right perk. //it's weaker than it used to be, because it's insanely easy to mass produce (availability based on plant potency, which scales upward)
 
 /datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
 	var/is_tribal = FALSE
@@ -249,6 +249,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 		M.adjustBruteLoss(heal_rate)
 		M.adjustToxLoss(heal_rate)
 		M.hallucination = max(M.hallucination, is_tribal ? 0 : 5)
+		M.radiation -= min(M.radiation, 8)
 		. = TRUE
 	..()
 
@@ -310,7 +311,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	color = "#C8A5DC"
 	overdose_threshold = 20
 	heal_factor = -2
-	heal_factor_perk = -4.3
+	heal_factor_perk = -4 //same as stimpak
 
 // ---------------------------
 // RAD-X REAGENT

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -312,7 +312,7 @@
 		return
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/attackby(obj/item/W, mob/user, params)
-	/* Coconut bombs (disabled)
+
 	//DEFUSING NADE LOGIC
 	if (W.tool_behaviour == TOOL_WIRECUTTER && fused)
 		user.show_message("<span class='notice'>You cut the fuse!</span>", MSG_VISUAL)
@@ -334,8 +334,6 @@
 			fusedactive = TRUE
 			defused = FALSE
 			playsound(src, 'sound/effects/fuse.ogg', 100, 0)
-			message_admins("[ADMIN_LOOKUPFLW(user)] ignited a coconut bomb for detonation at [ADMIN_VERBOSEJMP(user)] [pretty_string_from_reagent_list(reagents.reagent_list)]")
-			log_game("[key_name(user)] primed a coconut grenade for detonation at [AREACOORD(user)].")
 			addtimer(CALLBACK(src, .proc/prime), 5 SECONDS)
 			icon_state = "coconut_grenade_active"
 			desc = "RUN!"
@@ -353,7 +351,7 @@
 			desc = "A makeshift bomb made out of a coconut. You estimate the fuse is long enough for 5 seconds."
 			name = "coconut bomb"
 			return
-	*/
+
 	//ADDING STRAW LOGIC
 	if (istype(W,/obj/item/stack/sheet/mineral/bamboo) && opened && !straw && fused)
 		user.show_message("<span class='notice'>You add a bamboo straw to the coconut!</span>", 1)
@@ -456,10 +454,10 @@
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/afterattack(obj/target, mob/user, proximity)
 	. = ..()
-	/* coconut bombs disabled
+
 	if(fusedactive)
 		return
-	*/
+	
 
 	if((!proximity) || !check_allowed_items(target,target_self=1))
 		return
@@ -499,14 +497,13 @@
 	. = ..()
 	transform *= TRANSFORM_USING_VARIABLE(40, 100) + 0.5 //temporary fix for size?
 
-/* coconut bombs disabled
+
 /obj/item/reagent_containers/food/snacks/grown/coconut/proc/prime()
 	if (defused)
 		return
 	var/turf/T = get_turf(src)
 	reagents.chem_temp = 1000
 	reagents.handle_reactions()
-	log_game("Coconut bomb detonation at [AREACOORD(T)], location [loc]")
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/ex_act(severity)
@@ -517,11 +514,11 @@
 		prime()
 	if(!QDELETED(src))
 		qdel(src)
-*/
+
 
 /obj/item/seeds/aloe
 	name = "pack of aloe seeds"
-	desc = "These seeds grow into aloe."
+	desc = "These seeds grow into aloe, a plant useful for treating burns."
 	icon_state = "seed-aloe"
 	species = "aloe"
 	plantname = "Aloe"
@@ -533,12 +530,12 @@
 	yield = 6
 	growthstages = 5
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
-	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/kelotane = 0.01)
 
 /obj/item/reagent_containers/food/snacks/grown/aloe
 	seed = /obj/item/seeds/aloe
 	name = "aloe"
-	desc = "Cut leaves from the aloe plant."
+	desc = "Cut leaves from the aloe plant. Heating it with a microwave or bonfire will make aloe. It can also be ground up and used to make advanced regenerative mesh."
 	icon_state = "aloe"
 	filling_color = "#90EE90"
 	bitesize_mod = 5
@@ -547,5 +544,5 @@
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila
 
 /obj/item/reagent_containers/food/snacks/grown/aloe/microwave_act(obj/machinery/microwave/M)
-	new /obj/item/stack/medical/aloe(drop_location(), 2)
+	new /obj/item/stack/medical/mesh/aloe(drop_location(), 2)
 	qdel(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -127,7 +127,11 @@
 	"Engineering" = /obj/item/robot_module/engineering, \
 	"Medical" = /obj/item/robot_module/medical, \
 	"Miner" = /obj/item/robot_module/miner, \
-	"Service" = /obj/item/robot_module/butler)
+	"Service" = /obj/item/robot_module/butler,
+	"Assaultron" = /obj/item/robot_module/assaultron,
+	"Medical Assaultron" = /obj/item/robot_module/assaultron/medical
+	)
+
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
 	if(BORG_SEC_AVAILABLE)
@@ -807,11 +811,6 @@
 				audible_message("<span class='warning'>[src] sounds an alarm! \"SYSTEM ERROR: Module 2 OFFLINE.\"</span>")
 				to_chat(src, "<span class='userdanger'>SYSTEM ERROR: Module 2 OFFLINE.</span>")
 				playsound(loc, 'sound/machines/warning-buzzer.ogg', 60, 1, 1)
-			if(health < -maxHealth*0.5)
-				if(uneq_module(held_items[1]))
-					audible_message("<span class='warning'>[src] sounds an alarm! \"CRITICAL ERROR: All modules OFFLINE.\"</span>")
-					to_chat(src, "<span class='userdanger'>CRITICAL ERROR: All modules OFFLINE.</span>")
-					playsound(loc, 'sound/machines/warning-buzzer.ogg', 75, 1, 1)
 
 /mob/living/silicon/robot/update_sight()
 	if(!client)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -462,6 +462,7 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "peace"
 	moduleselect_icon = "standard"
+	borghealth = 300
 	hat_offset = -2
 
 /obj/item/robot_module/peacekeeper/do_transform_animation()

--- a/code/modules/projectiles/boxes_magazines/internal/bow.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/bow.dm
@@ -7,7 +7,7 @@
 
 /obj/item/ammo_box/magazine/internal/bow/xbow
 	name = "crossbow magazine"
-	max_ammo = 4
+	max_ammo = 3
 	start_empty = 1
 
 //Deathclaw Bow Ammo
@@ -23,7 +23,7 @@
 
 //Silver Bow Ammo
 /obj/item/ammo_box/magazine/internal/bow/silver
-	max_ammo = 5 // 6 shots in total
+	max_ammo = 3 // 6 shots in total
 
 //Crossbow Ammo
 /obj/item/ammo_box/magazine/internal/bow/cross

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -83,7 +83,6 @@
 	icon_state = "xbow"
 	item_state = "xbow"
 	icon_prefix = "xbow"
-	extra_damage = 3 //generally won't reduce TTK, but does increase performance against armor, especially with AP arrows
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/xbow
 	extra_speed = 400
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -38,9 +38,11 @@
 
 /obj/item/gun/energy/laser/cyborg
 	can_charge = FALSE
-	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
-	icon = 'icons/obj/items_cyborg.dmi'
-	icon_state = "laser_cyborg"
+	desc = "An energy-based laser gun that draws power from the Handy's internal energy cell directly. So this is what freedom looks like?"
+	fire_delay = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun/hitscan)
+	icon_state = "laser"
+	item_state = "laser-rifle9"
 	selfcharge = EGUN_SELFCHARGE_BORG
 	cell_type = /obj/item/stock_parts/cell/secborg
 	charge_delay = 3

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -83,7 +83,7 @@
 	damage = 20
 	sharpness = SHARP_EDGED
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/broadhead
-	embedding = list(embed_chance=100, fall_chance=0, jostle_chance=3, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.2, pain_mult=3, jostle_pain_mult=5, rip_time=25, projectile_payload = /obj/item/ammo_casing/caseless/arrow/broadhead)
+	embedding = list(embed_chance=50, fall_chance=60, jostle_chance=3, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.2, pain_mult=2, jostle_pain_mult=1, rip_time=25, projectile_payload = /obj/item/ammo_casing/caseless/arrow/broadhead)
 
 /obj/item/projectile/bullet/reusable/arrow/broadhead/on_hit(atom/target, blocked)
 	if(iscarbon(target))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -645,7 +645,7 @@
 	name = "Stable Mutation Toxin"
 	description = "A humanizing toxin."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	metabolization_rate = INFINITY //So it instantly removes all of itself
+	metabolization_rate = 0.5 * REM //So it instantly removes all of itself
 	taste_description = "slime"
 	value = REAGENT_VALUE_RARE
 	var/datum/species/race = /datum/species/human
@@ -899,7 +899,7 @@
 	H.visible_message("<b>[H]</b> suddenly transforms!")
 	randomize_human(H)
 
-/* Fortuna edit: disabled slime mutation toxins
+
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
 	description = "An advanced corruptive toxin produced by slimes."
@@ -910,7 +910,7 @@
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(method != TOUCH)
 		L.ForceContractDisease(new /datum/disease/transformation/slime(), FALSE, TRUE)
-*/
+
 
 /datum/reagent/gluttonytoxin
 	name = "Gluttony's Blessing"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -212,7 +212,7 @@ datum/chemical_reaction/rezadone
 	id = /datum/reagent/medicine/epinephrine
 	results = list(/datum/reagent/medicine/epinephrine = 6)
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1, /datum/reagent/hydrogen = 1)
-/* no. just no. the revive timer is 30 minutes(hopefully lowered soon); that is plenty of time. we do not need this.
+
 /datum/chemical_reaction/strange_reagent
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
@@ -224,7 +224,7 @@ datum/chemical_reaction/rezadone
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 2)
 	required_reagents = list(/datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
-*/
+
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"
 	id = /datum/reagent/medicine/mannitol
@@ -455,5 +455,5 @@ datum/chemical_reaction/rezadone
 /datum/chemical_reaction/bitterdrink
 	name = "Bitter drink"
 	id = /datum/reagent/medicine/bitter_drink
-	results = list(/datum/reagent/medicine/bitter_drink = 30)
+	results = list(/datum/reagent/medicine/bitter_drink = 15) //legion get a fuckton of these chems based on the potency of the plant
 	required_reagents = list(/datum/reagent/consumable/ethanol/salgam = 10 , /datum/reagent/consumable/ethanol/brocbrew = 10 , /datum/reagent/consumable/sunset = 10 , /datum/reagent/consumable/ethanol/yellowpulque = 10)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -49,7 +49,7 @@
 	..()
 
 //Green
-/* Fortuna edit: Disabled slime mutation toxins
+
 /datum/chemical_reaction/slime/slimemutate
 	name = "Mutation Toxin"
 	id = /datum/reagent/slime_toxin
@@ -81,7 +81,7 @@
 	required_reagents = list(/datum/reagent/water = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
-*/
+
 
 //Metal
 /datum/chemical_reaction/slime/slimemetal
@@ -424,7 +424,7 @@
 	..()
 
 //Black
-/* Fortuna edit: Mutation toxins disabled
+
 /datum/chemical_reaction/slime/slimemutate2
 	name = "Advanced Mutation Toxin"
 	id = /datum/reagent/aslimetoxin
@@ -432,7 +432,7 @@
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/black
-*/
+
 
 //Oil
 /datum/chemical_reaction/slime/slimeexplosion

--- a/code/modules/research/techweb/nodes/syndicate_nodes.dm
+++ b/code/modules/research/techweb/nodes/syndicate_nodes.dm
@@ -6,7 +6,6 @@
 	prereq_ids = list("adv_engi", "adv_weaponry")
 	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "donksofttoyvendor", "donksoft_refill", "syndiesleeper")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	hidden = TRUE
 
 /datum/techweb_node/syndicate_basic/New()		//Crappy way of making syndicate gear decon supported until there's another way.
 	. = ..()

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -22,7 +22,7 @@
 ///// Debride
 /datum/surgery_step/debride
 	name = "excise infection"
-	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCALPEL = 85, TOOL_SAW = 80, TOOL_WIRECUTTER = 60)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCALPEL = 100, TOOL_SAW = 80, TOOL_WIRECUTTER = 60)
 	time = 30
 	repeatable = TRUE
 
@@ -48,7 +48,7 @@
 			"<span class='notice'>[user] successfully excises some of the infected flesh from  [target]'s [parse_zone(target_zone)]!</span>")
 		log_combat(user, target, "excised infected flesh in", addition="INTENT: [uppertext(user.a_intent)]")
 		surgery.operated_bodypart.receive_damage(brute=3, wound_bonus=CANT_WOUND)
-		burn_wound.infestation -= 0.85
+		burn_wound.infestation -= 4
 		burn_wound.sanitization += 0.75
 		if(burn_wound.infestation <= 0)
 			repeatable = FALSE

--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -68,7 +68,7 @@
 		else
 			new /obj/item/salvage/crafting(usr_turf)
 	for(var/i3 in 1 to (1+modifier)) //this is just less lines for the same thing
-		if(prob(7.5))
+		if(prob(20))
 			new /obj/item/salvage/high(usr_turf)
 	uses_left--
 	inuse = FALSE //putting this after the -- because the first check prevents cheesing


### PR DESCRIPTION
1. Oli's cyborg modules were coded in, but unavailable. They are now available! Also enabled a tech module that lets you print laser guns for borgs, so they can be armed. Don't worry, they're still weaker than humans. (Cannot self heal, slower than humans, cannot use armor, lose modules as they take damage.)

2. Burn wounds were previously impossible to deal with due to how infection mechanics worked. Infection ticks up as time progresses, and manually ticks down when the wound is sanitized. Unlike clotting/bleeding wounds and puncture wounds, there's no way to instantly treat a burn wound-you have to apply ointment and bandage, then wait.

Normally this would be fine, but lasers deal critical laser wounds very easily. As a result, people get septic infections in four (4) minutes, which then accrue further infestation points over time. Usually someone will have a festering burn wound for upwards of 10 minutes, by which point they have over 100+ infestation points, and those only tick down, manually, by one, no matter how much ointment or so forth you apply-and on top of that, you have to WAIT for the sanitization to tick UP to exceed the infestation points first.

So basically assume someone had 100 infestation points. You have to wait for sanitization to go ALL THE WAY UP to 100 and pass it, and then wait for infestation to slowly, slowly drop. This basically lead to people who were burned being completely unrevivable.

That's now fixed. Gauze, bandages, ointment, regenerative mesh, and advanced regenerative mesh, and aloe cream all raise sanitization MUCH faster, as well as surgery being more effective at removing infestation. Even stims and bitter drink have a minor effect on burn wounds now! Not enough to beat them on their own, but enough to slow down the progression of an infection.

Aloe cream is now a regenerative mesh subtype, and is makeable through microwaving or bonfiring aloe plants. The legion can use this for ghetto burn cream treatment!

3. Fixes a href exploit relating to infinity metal forever.

4. Removes an unused variable rigbe asked me to remove.

5. Broadhead arrows were unfair. 100% embed, 0% dropchance, high damage. You could pelt someone to death with them and they'd bleed out even in PA. Now they're much less likely to embd and far more likely to fall out. Still usable and dangerous, though. Crossbows also received a nerf from 4 arrows to 3, because 4 fucking embedded arrows is instant death.

6. Salvaging sucks. This makes it not suck by removing some junk from the loot pile and making it easier to get what you want.

7. One of the chems I enabled had its metabolization rate set to infinity. I have undone this because it made it impossible for admins to actually use it in events.

8. Coconut bombs are back. People kept asking me for them, so...they're back lol. THey're 50 unit grenades, as opposed to the 600 unit ones the enclave and BOS can make.

9. Cyborg lasers are now hitscan like all lasers instead of old projectiles.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

