### PR TITLE
Preliminary oversight fixes

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -235,7 +235,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
 	overdose_threshold = 31
 	var/heal_factor = -3 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -4.5 //Multiplier if you have the right perk. //it's weaker than it used to be, because it's insanely easy to mass produce (availability based on plant potency, which scales upward)
+	var/heal_factor_perk = 5.2 //Multiplier if you have the right perk. //it's weaker than it used to be, because it's insanely easy to mass produce (availability based on plant potency, which scales upward)
 
 /datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
 	var/is_tribal = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -128,8 +128,7 @@
 	"Medical" = /obj/item/robot_module/medical, \
 	"Miner" = /obj/item/robot_module/miner, \
 	"Service" = /obj/item/robot_module/butler,
-	"Assaultron" = /obj/item/robot_module/assaultron,
-	"Medical Assaultron" = /obj/item/robot_module/assaultron/medical
+	"Gutsy" = /obj/item/robot_module/gutsy
 	)
 
 	if(!CONFIG_GET(flag/disable_peaceborg))
@@ -704,6 +703,9 @@
 
 /mob/living/silicon/robot/modules/miner
 	set_module = /obj/item/robot_module/miner
+
+/mob/living/silicon/robot/modules/gutsy
+	set_module = /obj/item/robot_module/gutsy
 
 /mob/living/silicon/robot/modules/assaultron //F13 stuff, better Handy.
 	name = "Assaultron"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -652,6 +652,27 @@
 			return FALSE
 	return ..()
 
+/obj/item/robot_module/gutsy
+	name = "Gutsy"
+	basic_modules = list( //Security borg
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/extinguisher/mini,
+		/obj/item/crowbar/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/borg/cyborghug,
+		/obj/item/megaphone,
+		/obj/item/melee/classic_baton/police,
+		/obj/item/gun/energy/laser/pistol/cyborg,
+		/obj/item/clothing/mask/gas/sechailer/cyborg,
+		/obj/item/pinpointer/crew)
+	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
+	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/security,
+		/obj/item/clockwork/weapon/ratvarian_spear)
+	borghealth = 300
+	cyborg_base_icon = "gutsy"
+	moduleselect_icon = "standard"
+	hat_offset = -2
+
 /obj/item/robot_module/assaultron
 	name = "Assaultron"
 	basic_modules = list( //Security borg

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -410,6 +410,7 @@
 	is_automatic = TRUE
 	autofire_shot_delay = 5
 	recoil = 1
+	automatic = 1
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -455,5 +455,5 @@ datum/chemical_reaction/rezadone
 /datum/chemical_reaction/bitterdrink
 	name = "Bitter drink"
 	id = /datum/reagent/medicine/bitter_drink
-	results = list(/datum/reagent/medicine/bitter_drink = 15) //legion get a fuckton of these chems based on the potency of the plant
+	results = list(/datum/reagent/medicine/bitter_drink = 30)
 	required_reagents = list(/datum/reagent/consumable/ethanol/salgam = 10 , /datum/reagent/consumable/ethanol/brocbrew = 10 , /datum/reagent/consumable/sunset = 10 , /datum/reagent/consumable/ethanol/yellowpulque = 10)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -612,7 +612,7 @@
 	id = /datum/reagent/colorful_reagent
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
-
+/*
 /datum/chemical_reaction/life
 	name = "Life"
 	id = "life"
@@ -621,7 +621,7 @@
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, multiplier)
 	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life") // Defaults to HOSTILE SPAWN
-/*
+
 //This is missing, I'm adding it back (see tgwiki). Not sure why we don't have it.
 /datum/chemical_reaction/life_friendly
 	name = "Life (Friendly)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -92,10 +92,11 @@
 /datum/techweb_node/engineering
 	id = "engineering"
 	display_name = "Industrial Engineering"
-	description = "A refresher course on modern engineering technology."
+	description = "A refresher course on modern engineering technology."e
 	prereq_ids = list("base")
-	design_ids = list("recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "siege cannon", "high_cell", "adv_matter_bin",
-	"atmosalerts", "atmos_control", "recycler", "constructionlathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine")
+	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin",
+	"atmosalerts", "atmos_control", "recycler", "autolathe", "autolathe_secure", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
+	"apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine", "rcd_ammo","oxygen_tank",
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 


### PR DESCRIPTION
1. turns out crystalnole actually commissioned the assaultron sexbots and nobody told me that when i put them in the game, so i replaced the borg module that let you be a sex assaultron with a gutsy instead. same equipment, etc. (admins can still spawn the sex assaultron, it's just not selectable by players by default. do not worry you can still fuck assaultron.)

2. pancor jackhammer had a bug that made it not automatic despite automatic being set to true. i fixed this.

3. legion asked me to revert a nerf i did to bitter drink. i did this.

4. life reaction disabled.

5. the engineering node was missing a lot of the stuff it said it should have-i noticed this when i was checking why the pipe dispenser wasn't selectable. i fixed this. (for some reason, allnodes.dm does not line up with nodes.dm, i'll have o go through and fix it later.)

## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->
