### PR TITLE
Soil plot removal (Not all of them!)

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -35,7 +35,6 @@
 /turf/open/water,
 /area/f13/bunker)
 "aes" = (
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
 "afS" = (
@@ -126,10 +125,6 @@
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"alX" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "aml" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -2516,11 +2511,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"dHj" = (
-/obj/machinery/hydroponics/soil,
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "dHs" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -2570,13 +2560,6 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"dKr" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/holofloor/carpet,
-/area/f13/legion)
 "dKv" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -2683,9 +2666,6 @@
 /area/f13/bunker)
 "dNZ" = (
 /obj/structure/stone_tile/block,
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	alpha = 0
-	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "dOb" = (
@@ -2695,10 +2675,6 @@
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
-"dOE" = (
-/obj/machinery/mineral/unloading_machine,
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "dOG" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3049,13 +3025,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"egh" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "mining_area"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "egq" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -3173,13 +3142,6 @@
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
-"eqx" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "mining_area"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "erd" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -4731,11 +4693,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"gFX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "gGK" = (
 /obj/structure/bookcase/manuals,
 /obj/item/book/granter/trait/midsurgery,
@@ -5294,12 +5251,6 @@
 	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
-"hwI" = (
-/obj/machinery/conveyor{
-	id = "mining_area"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "hxi" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5730,7 +5681,6 @@
 	},
 /area/f13/wasteland)
 "ify" = (
-/obj/machinery/hydroponics/soil,
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
@@ -6704,10 +6654,6 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
-"jGg" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall/f13/wood,
-/area/f13/underground/cave)
 "jHK" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
@@ -7080,10 +7026,6 @@
 	tag = "icon-floor5-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"kkd" = (
-/obj/machinery/mineral/processing_unit,
-/turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "klB" = (
 /obj/structure/flora/tree/cactus,
@@ -7480,12 +7422,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"kLt" = (
-/obj/machinery/conveyor_switch{
-	id = "mining_area"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "kLP" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -7697,13 +7633,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
-"lcT" = (
-/obj/machinery/hydroponics/soil,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "lcX" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -8622,7 +8551,6 @@
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
 "mnL" = (
-/obj/machinery/hydroponics/soil/crafted,
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -8776,11 +8704,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
-/obj/machinery/hydroponics/soil{
-	mutmod = 0;
-	name = "ancient fertile soil";
-	yieldmod = 1.3
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "mzy" = (
@@ -8854,7 +8777,6 @@
 	},
 /area/f13/bunker)
 "mCR" = (
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
 /area/f13/wasteland)
 "mDF" = (
@@ -8941,10 +8863,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"mIe" = (
-/obj/machinery/hydroponics/soil/crafted,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "mIo" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -9575,11 +9493,6 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
-"nGc" = (
-/obj/item/ammo_casing,
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/holofloor/carpet,
-/area/f13/legion)
 "nGs" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert{
@@ -10496,10 +10409,6 @@
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"oYe" = (
-/obj/machinery/mineral/stacking_unit_console,
-/turf/closed/wall/f13/wood,
-/area/f13/underground/cave)
 "oZo" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
@@ -11337,9 +11246,7 @@
 /area/f13/bunker)
 "qgr" = (
 /obj/structure/stone_tile/slab/cracked,
-/mob/living/simple_animal/hostile/deathclaw/mother{
-	alpha = 0
-	},
+/mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "qgB" = (
@@ -11350,14 +11257,6 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
-"qgW" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_area"
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "qgZ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -11769,10 +11668,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"qEW" = (
-/obj/machinery/mineral/stacking_machine,
-/turf/open/floor/f13/wood,
-/area/f13/underground/cave)
 "qFe" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "NCR No Mans Land Entrance";
@@ -11855,13 +11750,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
-"qKk" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "mining_area"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/underground/cave)
 "qKz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13190,14 +13078,6 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
-"suK" = (
-/obj/machinery/hydroponics/soil{
-	mutmod = 0;
-	name = "ancient fertile soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
 "svf" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -14998,13 +14878,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
-"vlw" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/ncr)
 "vmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -15397,10 +15270,6 @@
 "vOG" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/city)
-"vQO" = (
-/obj/machinery/power/smes,
-/turf/open/floor/plating/tunnel,
-/area/f13/underground/cave)
 "vQV" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/indestructible/vaultdoor,
@@ -15692,7 +15561,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "wtd" = (
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "wte" = (
@@ -15809,11 +15677,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
-"wEr" = (
-/obj/machinery/hydroponics/soil/crafted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wEM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15948,13 +15811,6 @@
 "wPz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
-"wPA" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
-/area/f13/ncr)
 "wQm" = (
 /obj/item/trash/can,
 /obj/effect/decal/cleanable/dirt,
@@ -16259,13 +16115,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
-"xoY" = (
-/obj/structure/cursed_slot_machine{
-	desc = "Gambling for the antisocial. This slot machine looks like it's been repaired.";
-	name = "slot machine"
-	},
-/turf/open/floor/carpet/green,
-/area/f13/underground/cave)
 "xpf" = (
 /obj/machinery/light{
 	dir = 4
@@ -24868,15 +24717,15 @@ bYA
 bYA
 vKV
 vOG
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
+lfU
+ksx
+ksx
 ksx
 dVc
 ksx
@@ -25382,15 +25231,15 @@ bYA
 bYA
 vKV
 vOG
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
+ksx
+ksx
+ksx
+ksx
+lfU
+ksx
+ksx
+ksx
+ksx
 ksx
 dVc
 ksx
@@ -25639,15 +25488,15 @@ bYA
 bYA
 vKV
 vOG
-mIe
-mIe
-mIe
-wEr
-mIe
-mIe
-mIe
+ksx
+ksx
+ksx
+faA
+ksx
+ksx
+ksx
 mnL
-mIe
+ksx
 ksx
 dVc
 ksx
@@ -25896,15 +25745,15 @@ bYA
 bYA
 vKV
 vOG
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
+ksx
+lfU
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
 ksx
 dVc
 ksx
@@ -26161,7 +26010,7 @@ ksx
 ksx
 siP
 ksx
-ksx
+lfU
 ksx
 xkT
 svf
@@ -26410,15 +26259,15 @@ bYA
 bYA
 vKV
 vOG
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
-mIe
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
+ksx
 ksx
 dVc
 ksx
@@ -28186,13 +28035,13 @@ yah
 yeX
 ksx
 ksx
-alX
 ksx
-alX
 ksx
-alX
 ksx
-alX
+ksx
+ksx
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -28443,13 +28292,13 @@ oyK
 yeX
 ksx
 ksx
-alX
+ksx
 cDn
-alX
 ksx
-alX
 ksx
-alX
+ksx
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -28511,8 +28360,8 @@ gYQ
 gXe
 jBR
 kfV
-giG
-qKD
+jBR
+frr
 frr
 gYQ
 utv
@@ -28702,11 +28551,11 @@ xVt
 mXj
 mCR
 unM
-alX
 ksx
-alX
 ksx
-alX
+ksx
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -28771,7 +28620,7 @@ gYQ
 frr
 frr
 qKD
-qKD
+frr
 gYQ
 rdA
 qKV
@@ -28961,9 +28810,9 @@ tyO
 xBp
 aes
 ksx
-alX
 ksx
-alX
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -29218,9 +29067,9 @@ tyO
 dOk
 wtd
 ksx
-alX
 ksx
-alX
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -29282,7 +29131,7 @@ qpl
 slU
 uqg
 gYQ
-qKD
+frr
 ihq
 ihq
 ihq
@@ -29475,9 +29324,9 @@ xAd
 tyO
 ify
 ksx
-alX
 ksx
-alX
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -29732,9 +29581,9 @@ ovl
 tyO
 wtd
 ksx
-alX
 ksx
-alX
+ksx
+ksx
 ksx
 ksx
 ksx
@@ -29796,8 +29645,8 @@ gYQ
 gYQ
 uqg
 exB
-qKD
-nGc
+frr
+xNV
 frr
 frr
 bvS
@@ -30053,8 +29902,8 @@ qqE
 hMO
 uqg
 exB
-qKD
-dKr
+frr
+eoh
 eoh
 frr
 gYQ
@@ -31864,7 +31713,7 @@ anj
 xPV
 ksx
 ksx
-dHj
+ksx
 ksx
 ygO
 ndi
@@ -32119,9 +31968,9 @@ qMS
 ndi
 xle
 ksx
-alX
+ksx
 lfU
-lcT
+ksx
 ksx
 mQl
 bYA
@@ -33147,7 +32996,7 @@ ndi
 ndi
 xle
 ksx
-alX
+ksx
 ksx
 ksx
 mtT
@@ -41280,7 +41129,7 @@ yeX
 pzA
 xiC
 xiC
-vlw
+qTX
 wFC
 yeX
 lwE
@@ -41536,7 +41385,7 @@ heT
 yeX
 bbJ
 xiC
-wPA
+haq
 nqt
 haq
 yeX
@@ -47479,11 +47328,11 @@ cbg
 cbg
 rui
 ksx
-alX
 ksx
 ksx
 ksx
-alX
+ksx
+ksx
 ksx
 ygO
 ndi
@@ -47993,11 +47842,11 @@ uUH
 xHW
 scf
 ksx
-alX
 ksx
-alX
 ksx
-alX
+ksx
+ksx
+ksx
 ksx
 ygO
 ndi
@@ -50857,11 +50706,11 @@ heT
 heT
 mxq
 hbs
-vRf
-xtW
 jBA
-kMS
-vxn
+jBA
+jBA
+bbg
+bbg
 peF
 mxq
 heT
@@ -50869,14 +50718,14 @@ heT
 mxq
 xHO
 bqG
-kMS
-xtW
+bbg
+jBA
 wEM
 jBA
-xtW
-kMS
-vRf
-vxn
+jBA
+bbg
+jBA
+bbg
 jBA
 jBA
 bbg
@@ -51114,11 +50963,11 @@ heT
 heT
 mxq
 tIn
-vRf
-vxn
+jBA
 bbg
-xoY
-xtW
+bbg
+bbg
+jBA
 bqG
 mxq
 heT
@@ -51126,8 +50975,8 @@ heT
 mxq
 bqG
 bbg
-kMS
-xtW
+bbg
+jBA
 jBA
 jBA
 vxn
@@ -51387,10 +51236,10 @@ vRf
 vxn
 eeP
 bbg
-vxn
-vRf
-vRf
-xtW
+bbg
+jBA
+jBA
+jBA
 lIb
 rBw
 xtW
@@ -51650,8 +51499,8 @@ kMS
 xtW
 jBA
 jBA
-xtW
-vRf
+jBA
+jBA
 hEp
 peF
 mxq
@@ -51901,10 +51750,10 @@ vKu
 nxU
 jlI
 ual
-vxn
-vRf
-kMS
-xtW
+bbg
+jBA
+bbg
+jBA
 bbg
 hEp
 xtW
@@ -52160,12 +52009,12 @@ bbg
 bqG
 mVs
 bbg
-vRf
-vxn
+jBA
 bbg
 bbg
-vxn
-kMS
+bbg
+bbg
+bbg
 jBA
 mVs
 mxq
@@ -52417,8 +52266,8 @@ bbg
 bbg
 mVs
 nxU
-kMS
-xtW
+bbg
+jBA
 bGR
 bbg
 xtW
@@ -52678,8 +52527,8 @@ pQo
 jBA
 jBA
 uyI
-vxn
-vRf
+bbg
+jBA
 jBA
 mVs
 mxq
@@ -52935,8 +52784,8 @@ bqG
 bqG
 dpj
 bbg
-xtW
-kMS
+jBA
+bbg
 bbg
 tIn
 mxq
@@ -53192,8 +53041,8 @@ jBA
 bqG
 bbg
 jfH
-vxn
-kMS
+bbg
+bbg
 jBA
 pQo
 mxq
@@ -55292,13 +55141,13 @@ bYA
 bYA
 bYA
 bRI
-dOE
+uoN
+lKA
+cbg
+uoN
+lKA
 cbg
 cbg
-kLt
-oYe
-qgW
-gFX
 wPz
 wPz
 wPz
@@ -55549,13 +55398,13 @@ bYA
 bYA
 bYA
 bRI
-egh
-gFX
-jGg
-gFX
-gFX
-qEW
-gFX
+uoN
+lKA
+cbg
+uoN
+lKA
+cbg
+cbg
 wPz
 wPz
 wPz
@@ -55727,7 +55576,7 @@ jBA
 sKJ
 jBA
 bzW
-orS
+bbg
 mxq
 mVs
 iaA
@@ -55806,13 +55655,13 @@ bYA
 bYA
 bYA
 bRI
-eqx
-hwI
-kkd
-hwI
-hwI
-qKk
-gFX
+cbg
+mFp
+cbg
+cbg
+mFp
+cbg
+cbg
 wPz
 wPz
 wPz
@@ -55982,13 +55831,13 @@ chf
 hzY
 jBA
 bqG
-smV
+bbg
 rBw
 jBA
 fAw
 hEp
 jBA
-xxw
+mVs
 mxq
 ycX
 ycX
@@ -56233,11 +56082,11 @@ heT
 mxq
 qvi
 bbg
-jIK
+jBA
 bHu
 uqI
 gQR
-jIK
+jBA
 mCx
 pSz
 jIK
@@ -56495,7 +56344,7 @@ fvN
 xIs
 chf
 bbg
-tyq
+bqG
 jBA
 rNI
 jBA
@@ -59062,8 +58911,8 @@ heT
 mxq
 mVs
 bbg
-vRf
-vxn
+jBA
+bbg
 jBA
 mVs
 nxU
@@ -59319,8 +59168,8 @@ heT
 mxq
 sev
 bbg
-vRf
-vxn
+jBA
+bbg
 bbg
 bbg
 mVs
@@ -59837,7 +59686,7 @@ kMS
 xtW
 jBA
 sdv
-vxn
+bbg
 tSv
 mVs
 jBA
@@ -60090,12 +59939,12 @@ heT
 mxq
 mVs
 bbg
-vRf
-xtW
+jBA
+jBA
 bbg
 jBA
-xtW
-vRf
+jBA
+jBA
 eBF
 mVs
 jBA
@@ -60347,13 +60196,13 @@ heT
 mxq
 mVs
 jBA
-vRf
-vxn
 jBA
 bbg
-vxn
-vRf
-kMS
+jBA
+bbg
+bbg
+jBA
+bbg
 bqG
 bqG
 jfH
@@ -60608,10 +60457,10 @@ vRf
 xtW
 bbg
 cdZ
-vxn
-vRf
-kMS
-xtW
+bbg
+jBA
+bbg
+jBA
 bqG
 mVs
 kDf
@@ -61118,14 +60967,14 @@ heT
 mxq
 bqG
 bqG
-kMS
-xtW
+bbg
+jBA
 wEM
 jBA
-xtW
-vRf
-kMS
-xtW
+jBA
+jBA
+bbg
+jBA
 bbg
 bbg
 xtW
@@ -61385,8 +61234,8 @@ vRf
 xtW
 jBA
 bbg
-vxn
-vRf
+bbg
+jBA
 jBA
 bqG
 mxq
@@ -61394,11 +61243,11 @@ heT
 heT
 mxq
 mVs
-vRf
-xtW
+jBA
+jBA
 mtl
-vRf
-vxn
+jBA
+bbg
 bqG
 mxq
 heT
@@ -61633,17 +61482,17 @@ heT
 mxq
 bqG
 bqG
-vxn
+bbg
 bbg
 jBA
-vxn
-kMS
-vRf
-xtW
+bbg
+bbg
 jBA
 jBA
-xtW
-kMS
+jBA
+jBA
+jBA
+bbg
 bqG
 bqG
 mxq
@@ -61651,11 +61500,11 @@ heT
 heT
 mxq
 wZU
-vRf
-xtW
 jBA
-kMS
-vxn
+jBA
+jBA
+bbg
+bbg
 meG
 mxq
 heT
@@ -64441,7 +64290,7 @@ heT
 heT
 heT
 hIH
-vQO
+dOb
 dnm
 dOb
 dOb
@@ -64955,7 +64804,7 @@ heT
 heT
 heT
 hIH
-vQO
+dOb
 dOb
 dOb
 dOb
@@ -75516,11 +75365,11 @@ hdA
 fyx
 wuw
 tvF
-rqD
 fyx
-rqD
+fyx
+fyx
 wuw
-kTA
+wuw
 fyx
 vHC
 vHC
@@ -75773,11 +75622,11 @@ vHC
 luG
 fyx
 wuw
-kTA
+wuw
 duV
 kTA
 wuw
-kTA
+wuw
 fyx
 vHC
 vHC
@@ -76030,11 +75879,11 @@ vHC
 coG
 dnZ
 fyx
-kTA
+wuw
 fyx
 rqD
 wuw
-kTA
+wuw
 vGQ
 vHC
 vHC
@@ -76287,11 +76136,11 @@ vHC
 vkb
 wuw
 fyx
-rqD
+fyx
 fyx
 kTA
 fyx
-kTA
+wuw
 fyx
 vHC
 vHC
@@ -80455,8 +80304,8 @@ txX
 txX
 pCj
 ksx
-suK
-suK
+ciK
+ciK
 qAl
 rwB
 dLl
@@ -80713,7 +80562,7 @@ hIQ
 ksx
 ksx
 myr
-suK
+ciK
 qAl
 kix
 osf

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -2648,10 +2648,6 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
-"lM" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "lN" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -8168,11 +8164,6 @@
 /obj/item/paper/crumpled,
 /turf/open/floor/plating/tunnel,
 /area/f13/ncr)
-"Ix" = (
-/obj/machinery/hydroponics/soil,
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "Iz" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -61715,9 +61706,9 @@ PL
 kC
 Jk
 Pw
-lM
+Gy
 Vy
-lM
+Gy
 HU
 Fj
 jc
@@ -61972,9 +61963,9 @@ kC
 kC
 Ht
 xx
-Ix
+Vy
 nq
-lM
+Gy
 Ht
 eV
 xb
@@ -62229,9 +62220,9 @@ kC
 kC
 Ht
 nS
-lM
 Gy
-lM
+Gy
+Gy
 Oz
 SZ
 SZ

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -769,10 +769,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
-"apt" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "apw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/rag/towel,
@@ -1399,14 +1395,6 @@
 /obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aDx" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#9c9c9c"
-	},
-/area/f13/village)
 "aDA" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3563,15 +3551,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"bvA" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "bvP" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/barber{
@@ -3592,7 +3571,6 @@
 /area/f13/building)
 "bwg" = (
 /obj/machinery/light/small/broken,
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "bwn" = (
@@ -3794,7 +3772,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bBk" = (
-/obj/machinery/hydroponics/soil,
 /mob/living/simple_animal/chick,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -9328,10 +9305,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
-"dTv" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "dUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10301,7 +10274,6 @@
 /area/f13/wasteland)
 "emN" = (
 /obj/machinery/light/small,
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt{
 	barefootstep = "sand";
 	clawfootstep = "sand";
@@ -12574,7 +12546,6 @@
 	},
 /area/f13/wasteland)
 "fgb" = (
-/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt{
 	barefootstep = "sand";
 	clawfootstep = "sand";
@@ -12949,13 +12920,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
-"fpv" = (
-/obj/machinery/hydroponics/soil,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "fpJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -21412,7 +21376,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iyc" = (
-/obj/machinery/hydroponics/soil,
 /obj/structure/flora/wasteplant/wild_broc{
 	pixel_y = 4
 	},
@@ -23490,12 +23453,6 @@
 	dir = 8
 	},
 /turf/open/floor/f13,
-/area/f13/building)
-"jkA" = (
-/obj/machinery/mineral/processing_unit_console{
-	machinedir = 1
-	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "jkB" = (
 /obj/structure/chair/comfy{
@@ -29794,10 +29751,6 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"lRX" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
 "lRZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -31276,13 +31229,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/building)
-"mtC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mtK" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -36675,15 +36621,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"oDv" = (
-/obj/machinery/conveyor/auto{
-	dir = 6
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "oDG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37233,16 +37170,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
-"oRu" = (
-/obj/machinery/mineral/processing_unit{
-	input_dir = 8;
-	output_dir = 4
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "oRE" = (
 /obj/structure/chair/wood,
 /obj/structure/nest/raider{
@@ -39541,13 +39468,6 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"pPX" = (
-/obj/machinery/mineral/unloading_machine,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
 "pQb" = (
@@ -43417,12 +43337,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
-"rzz" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 5
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/building)
 "rzE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -44084,10 +43998,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"rOj" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
 "rOm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old{
@@ -47215,7 +47125,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tcm" = (
-/obj/machinery/hydroponics/soil,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -47380,16 +47289,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
-"thv" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "thw" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -51334,10 +51233,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"uJr" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "uJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -52343,11 +52238,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
-"veF" = (
-/obj/machinery/hydroponics/soil,
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "veG" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -55064,14 +54954,6 @@
 /obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"woN" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/building)
 "woP" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/dirt,
@@ -61497,9 +61379,9 @@ gcK
 gcK
 gcK
 mwp
-apt
 mwp
-apt
+mwp
+mwp
 mwp
 gcK
 gcK
@@ -61754,9 +61636,9 @@ gcK
 gcK
 mwp
 mwp
-apt
 mwp
-apt
+mwp
+mwp
 mwp
 mwp
 mwp
@@ -61957,9 +61839,9 @@ aji
 fyf
 tBN
 mvv
-rjH
 mvv
-rjH
+mvv
+mvv
 mvv
 bpD
 fyf
@@ -62214,9 +62096,9 @@ aji
 fyf
 tBN
 mvv
-rjH
 mvv
-rjH
+mvv
+mvv
 mvv
 doX
 wDc
@@ -62268,9 +62150,9 @@ gcK
 gcK
 mwp
 mwp
-apt
 mwp
-apt
+mwp
+mwp
 mwp
 mwp
 mwp
@@ -62525,9 +62407,9 @@ gcK
 gcK
 mwp
 mwp
-apt
 mwp
-apt
+mwp
+mwp
 mwp
 gcK
 gcK
@@ -65914,8 +65796,8 @@ koD
 gcK
 gcK
 dCV
-pPX
-dCV
+mZD
+mZD
 lTw
 mZD
 dCV
@@ -66021,8 +65903,8 @@ fyf
 fyf
 thG
 tUk
-rOj
-rOj
+tUk
+tUk
 tUk
 thG
 fyf
@@ -66171,8 +66053,8 @@ koD
 gcK
 gcK
 dCV
-bvA
-mNT
+mZD
+mZD
 rXj
 rXj
 hkA
@@ -66428,8 +66310,8 @@ koD
 gcK
 gcK
 dCV
-oRu
-jkA
+mZD
+mZD
 mZD
 rXj
 hkA
@@ -66535,8 +66417,8 @@ fyf
 fyf
 thG
 tUk
-rOj
-rOj
+tUk
+tUk
 tUk
 thG
 fyf
@@ -66685,9 +66567,9 @@ koD
 gcK
 gcK
 dCV
-bvA
-mNT
-rzz
+mZD
+mZD
+mZD
 cEJ
 dCV
 rXj
@@ -66942,9 +66824,9 @@ koD
 gcK
 gcK
 dCV
-oDv
-thv
-woN
+mZD
+mZD
+mZD
 oIm
 dCV
 rXj
@@ -67049,8 +66931,8 @@ gcK
 fyf
 thG
 pbX
-rOj
-rOj
+tUk
+tUk
 pbX
 thG
 fyf
@@ -70585,8 +70467,8 @@ fyf
 fyf
 tBN
 skt
-rjH
-rjH
+mvv
+mvv
 gcK
 uqa
 uqa
@@ -71100,7 +70982,7 @@ fyf
 tBN
 mvv
 iyc
-rjH
+mvv
 gcK
 gcK
 gcK
@@ -71810,9 +71692,9 @@ rpu
 rpu
 rpu
 yjG
-dTv
 fyf
-dTv
+fyf
+fyf
 thG
 kxQ
 fyf
@@ -72326,7 +72208,7 @@ rpu
 rCQ
 fyf
 vSS
-dTv
+fyf
 thG
 fyf
 fyf
@@ -72582,7 +72464,7 @@ rpu
 xtL
 uqa
 xtx
-dTv
+fyf
 coD
 uqa
 fyf
@@ -73825,9 +73707,9 @@ ktB
 ktB
 ktB
 uqa
-wOp
+cbr
 xJz
-mtC
+usW
 sYX
 pCn
 wLC
@@ -75346,9 +75228,9 @@ gcK
 gcK
 gcK
 rvo
-rjH
 mvv
-rjH
+mvv
+mvv
 kbF
 aMo
 peu
@@ -80485,11 +80367,11 @@ fyf
 fyf
 tBN
 ueA
-aDx
 aXu
-aDx
 aXu
-aDx
+aXu
+aXu
+aXu
 ueA
 fbq
 boN
@@ -84683,9 +84565,9 @@ ymi
 bRq
 mvv
 lwi
-rjH
 mvv
-rjH
+mvv
+mvv
 bpD
 xLY
 fyf
@@ -84901,11 +84783,11 @@ cWG
 cWG
 evk
 mvv
-rjH
 mvv
-rjH
 mvv
-rjH
+mvv
+mvv
+mvv
 hNT
 srL
 mvv
@@ -85344,11 +85226,11 @@ ijg
 mvv
 mvv
 soY
-lRX
 fbq
-lRX
 fbq
-lRX
+fbq
+fbq
+fbq
 oCA
 azC
 fyf
@@ -85415,11 +85297,11 @@ mvv
 mvv
 srL
 mvv
-rjH
+mvv
 mPS
-rjH
+mvv
 ttW
-rjH
+mvv
 sbD
 uqa
 uqa
@@ -85453,7 +85335,7 @@ tBN
 mvv
 mvv
 mvv
-veF
+fTG
 mvv
 mYO
 mvv
@@ -85601,11 +85483,11 @@ uRJ
 mvv
 mvv
 soY
-lRX
 fbq
-lRX
 fbq
-lRX
+fbq
+fbq
+fbq
 jdg
 azC
 xTK
@@ -85858,11 +85740,11 @@ uRJ
 xaF
 xaF
 luK
-lRX
 fbq
-lRX
 fbq
-lRX
+fbq
+fbq
+fbq
 hlA
 azC
 fyf
@@ -85899,11 +85781,11 @@ qEc
 dlS
 dCV
 xFV
+cbr
 wOp
 wOp
-wOp
-wOp
-wOp
+cbr
+cbr
 gDs
 gXt
 mRK
@@ -86156,11 +86038,11 @@ cOg
 cOg
 dCV
 nbJ
+cbr
 wOp
 wOp
-wOp
-wOp
-wOp
+cbr
+cbr
 mZn
 gYP
 mRK
@@ -86413,11 +86295,11 @@ tOF
 tOF
 dCV
 kiH
+cbr
 wOp
 wOp
-wOp
-wOp
-wOp
+cbr
+cbr
 pXv
 gZG
 xOq
@@ -86494,13 +86376,13 @@ fyf
 fyf
 thG
 tBN
-rjH
 mvv
-rjH
 mvv
-rjH
 mvv
-rjH
+mvv
+mvv
+mvv
+mvv
 qPQ
 tKZ
 fTG
@@ -87008,13 +86890,13 @@ fyf
 fyf
 xHN
 mvv
-rjH
 mvv
-rjH
 mvv
-rjH
 mvv
-rjH
+mvv
+mvv
+mvv
+mvv
 mvv
 tKZ
 amc
@@ -87526,9 +87408,9 @@ mvv
 mvv
 mvv
 ofL
-rjH
 mvv
-rjH
+mvv
+mvv
 mvv
 ucA
 qPQ
@@ -93062,7 +92944,7 @@ uRJ
 jnX
 uvC
 fbq
-lRX
+fbq
 azC
 fyf
 pcG
@@ -93318,7 +93200,7 @@ cbk
 gjP
 gjP
 fbq
-lRX
+fbq
 fbq
 azC
 qOV
@@ -93574,9 +93456,9 @@ uRJ
 xLK
 gjP
 qJB
-lRX
+fbq
 boN
-lRX
+fbq
 bNg
 daU
 pcG
@@ -96148,7 +96030,7 @@ uRJ
 oiu
 mvv
 soY
-lRX
+fbq
 fbq
 xVu
 tTV
@@ -96405,7 +96287,7 @@ uRJ
 srw
 amc
 soY
-lRX
+fbq
 fbq
 xVu
 gjP
@@ -96662,7 +96544,7 @@ uIT
 gjP
 xGH
 soY
-lRX
+fbq
 boN
 fbq
 hCp
@@ -99910,14 +99792,14 @@ qOV
 cWG
 cWG
 bVT
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
-rjH
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 fPU
 cWG
 cWG
@@ -100686,9 +100568,9 @@ mvv
 dys
 dOA
 hlz
-rjH
-rjH
-fpv
+mvv
+mvv
+iwR
 fQu
 mfD
 mfD
@@ -103247,7 +103129,7 @@ gcK
 aIr
 fyf
 fyf
-nme
+fyf
 fyf
 uqa
 qkI
@@ -109301,8 +109183,8 @@ jll
 mnG
 qSk
 waA
-uJa
-uJa
+ggK
+ggK
 ggK
 gcK
 gcK
@@ -109815,8 +109697,8 @@ ufM
 lYA
 ool
 mTd
-uJa
-uJa
+ggK
+ggK
 ggK
 gcK
 gcK
@@ -110567,7 +110449,7 @@ gjP
 fyf
 fyf
 fyf
-osj
+fyf
 fyf
 ptP
 gcK
@@ -110825,7 +110707,7 @@ pEv
 kpM
 kTx
 sLq
-osj
+fyf
 fyf
 gcK
 gcK
@@ -111080,8 +110962,8 @@ thG
 fyf
 fyf
 fyf
-osj
-osj
+fyf
+fyf
 fyf
 gcK
 gcK
@@ -111238,9 +111120,9 @@ jEb
 jSw
 mvv
 stD
-qTe
-qTe
-qTe
+mvv
+mvv
+mvv
 lFm
 mzO
 uXj
@@ -111753,9 +111635,9 @@ stD
 stD
 mvv
 mvv
-qTe
-qTe
-qTe
+mvv
+mvv
+mvv
 mvv
 mqp
 mzO
@@ -112267,9 +112149,9 @@ fff
 mvv
 mvv
 stD
-qTe
-qTe
-qTe
+mvv
+mvv
+mvv
 mvv
 dCL
 hCg
@@ -113296,7 +113178,7 @@ uqa
 uqa
 uqa
 lcl
-qTe
+mvv
 lGH
 gcK
 gcK
@@ -113660,10 +113542,10 @@ csQ
 nqj
 gts
 giZ
-rjH
-rjH
-uJr
-uJr
+mvv
+mvv
+afs
+afs
 uYY
 fyf
 fyf
@@ -114174,10 +114056,10 @@ sYX
 sYX
 giZ
 giZ
-rjH
-rjH
-wOp
-rjH
+mvv
+mvv
+cbr
+mvv
 bpD
 fyf
 fyf
@@ -117587,8 +117469,8 @@ hom
 mwZ
 xfy
 mvv
-rjH
-rjH
+mvv
+mvv
 cdL
 xjZ
 qSg
@@ -118872,8 +118754,8 @@ uqW
 gtS
 lGv
 mvv
-rjH
-rjH
+mvv
+mvv
 cdL
 dXo
 jIz

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -755,10 +755,6 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"ayr" = (
-/mob/living/simple_animal/hostile/rat,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
 "ayH" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -2447,14 +2443,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
-"btB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "btC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3961,10 +3949,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"cfP" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
 "cgk" = (
 /obj/structure/simple_door/metal/barred,
 /obj/item/mine/stun,
@@ -4345,10 +4329,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"crL" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "crT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4359,11 +4339,6 @@
 /area/f13/tcoms)
 "csj" = (
 /obj/structure/bed/mattress/pregame,
-/mob/living/simple_animal/mouse{
-	faction = list("Wastelander");
-	name = "Billy Bob Jr.";
-	social_faction = list("Raiders")
-	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "csw" = (
@@ -4882,12 +4857,6 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"cDC" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13/vault_floor/yellow{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/tunnel)
 "cDP" = (
 /turf/open/floor/carpet/black,
 /area/f13/caves)
@@ -5179,7 +5148,6 @@
 /area/f13/tunnel)
 "cLe" = (
 /obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/flour,
 /turf/open/floor/wood/f13/oak,
 /area/f13/caves)
 "cLG" = (
@@ -6924,13 +6892,6 @@
 /area/f13/brotherhood/mining)
 "dKk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/bunker)
-"dKn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -8831,9 +8792,6 @@
 	},
 /area/f13/bunker)
 "eHy" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 25
@@ -12174,10 +12132,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"gzm" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gzq" = (
 /obj/structure/disposalpipe/broken{
 	dir = 1
@@ -12228,13 +12182,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"gAz" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gAN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -12254,11 +12201,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/den)
-"gBE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "gBM" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -12296,10 +12238,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/bunker)
-"gCv" = (
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gCx" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -12859,10 +12797,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"gRD" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "gSh" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/subway{
@@ -13042,11 +12976,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gWY" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/cannabis,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "gXb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -17576,15 +17505,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
-"jYC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/supermutant/melee{
-	max_mobs = 3;
-	spawn_once = 1;
-	spawn_time = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/bunker)
 "jYE" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17624,11 +17544,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"jZq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "jZG" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17776,10 +17691,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/mining)
-"kbH" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "kbT" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
@@ -17966,14 +17877,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
-"khz" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/structure/reagent_dispensers/barrel/three,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "khG" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -18134,10 +18037,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/brotherhood/dorms)
-"kmA" = (
-/obj/effect/decal/cleanable/semen/femcum,
-/turf/open/floor/carpet/black,
-/area/f13/caves)
 "kmM" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -18153,10 +18052,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"knB" = (
-/obj/structure/campfire/barrel,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "kof" = (
 /obj/effect/decal/fakelattice{
 	pixel_y = -17
@@ -19535,10 +19430,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"ldK" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "ldM" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -19553,13 +19444,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"lew" = (
-/obj/machinery/chem_master/advanced,
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "lez" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -19567,7 +19451,6 @@
 /area/f13/caves)
 "leG" = (
 /obj/machinery/light/broken,
-/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -19586,13 +19469,6 @@
 	icon_state = "oakfloor4-broken"
 	},
 /area/f13/enclave)
-"lfg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/bunker)
 "lfj" = (
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/subway,
@@ -19856,12 +19732,7 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
-"llv" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "lly" = (
-/obj/machinery/seed_extractor,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -19871,11 +19742,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/river,
 /area/f13/building)
-"llZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bunker)
 "lmc" = (
 /obj/structure/lattice{
 	density = 1
@@ -19969,7 +19835,6 @@
 "lof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken,
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "loI" = (
@@ -20094,12 +19959,6 @@
 /obj/effect/landmark/start/f13/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"lrF" = (
-/obj/structure/nest/nightstalker{
-	radius = 5
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Sheriff's Quarters";
@@ -21954,10 +21813,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"mHs" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/f13/ruins,
-/area/f13/tunnel)
 "mHw" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -22127,7 +21982,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mNi" = (
-/obj/structure/campfire/barrel,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -22324,13 +22178,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"mTa" = (
-/obj/structure/spider/stickyweb{
-	icon_state = "stickyweb2"
-	},
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "mTF" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/mineral/random/low_chance/underground,
@@ -22396,10 +22243,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"mUS" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/bunker)
 "mVI" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
@@ -24991,12 +24834,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
-"ozj" = (
-/obj/structure/campfire/barrel,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
 "ozo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25206,13 +25043,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"oGA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "oGP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -25592,11 +25422,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"oVh" = (
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "rubblepillar"
-	},
-/area/f13/tunnel)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -29020,12 +28845,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/mob/living/simple_animal/hostile/ghoul/glowing{
-	desc = "Billy Bob was one of the first of the Den's residents - he doesn't really bother anyone, just lives in the back where he keeps his pet mouse. Nobody knows how he got here or why he cares so much about the mouse. He's the the senile old uncle of the Den.";
-	faction = list("Wastelander");
-	name = "Billy Bob";
-	social_faction = list("neutral")
-	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rcL" = (
@@ -30178,7 +29997,6 @@
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
-/obj/effect/decal/cleanable/cum,
 /turf/open/floor/carpet/black,
 /area/f13/caves)
 "rGt" = (
@@ -30801,10 +30619,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"rZw" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "rZx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -32785,10 +32599,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "tsj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/machinery/light{
 	dir = 4;
 	pixel_y = -16
@@ -34592,13 +34402,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/caves)
-"uzb" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/cult,
-/obj/effect/decal/cleanable/cum,
-/obj/effect/decal/cleanable/semen/femcum,
-/turf/open/floor/carpet/black,
-/area/f13/caves)
 "uzL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -35692,10 +35495,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/caves)
-"vlQ" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vlT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36211,11 +36010,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
-"vFf" = (
-/mob/living/simple_animal/hostile/gecko,
-/obj/structure/nest/gecko,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vFi" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -37624,14 +37418,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"wyk" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/bunker)
 "wyB" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -37796,11 +37582,6 @@
 	pixel_y = -13
 	},
 /turf/closed/wall/rust,
-/area/f13/caves)
-"wDy" = (
-/obj/structure/spider/stickyweb,
-/mob/living/simple_animal/hostile/poison/giant_spider,
-/turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wDz" = (
 /obj/structure/closet/crate,
@@ -49658,7 +49439,7 @@ vPg
 vPg
 cZR
 cDP
-kmA
+cDP
 cDP
 snp
 lRL
@@ -49914,7 +49695,7 @@ vPg
 vPg
 vPg
 jPC
-uzb
+rGi
 cDP
 rGi
 wwM
@@ -50423,7 +50204,7 @@ vPg
 vPg
 xaX
 xVz
-vlQ
+xVz
 xVz
 gCf
 jPC
@@ -50682,7 +50463,7 @@ jPC
 fxR
 xVz
 xVz
-vFf
+xVz
 jPC
 bLF
 xVz
@@ -52024,8 +51805,8 @@ vPg
 vPg
 vVE
 lnr
-hJV
-hJV
+lnr
+lnr
 hJV
 lnr
 vPg
@@ -52479,7 +52260,7 @@ vPg
 vPg
 fxR
 xVz
-vlQ
+xVz
 gCf
 caG
 jPC
@@ -52594,7 +52375,7 @@ vcf
 ovu
 ovu
 fPb
-wDy
+gGt
 tur
 ncl
 hkD
@@ -53104,7 +52885,7 @@ sKt
 dXE
 dXE
 dXE
-mTa
+vcf
 fiU
 mpo
 rtG
@@ -53308,7 +53089,7 @@ jfU
 jfU
 jfU
 jfU
-lbk
+jfU
 jfU
 jfU
 jfU
@@ -53840,7 +53621,7 @@ pmg
 wqW
 vPg
 lnr
-sNX
+lnr
 lnr
 vPg
 vPg
@@ -54593,7 +54374,7 @@ jfU
 jfU
 jfU
 jfU
-lbk
+jfU
 jfU
 jfU
 jfU
@@ -54638,7 +54419,7 @@ dXE
 wnQ
 wnQ
 cSE
-aWO
+cSE
 weW
 cSE
 cSE
@@ -54855,8 +54636,8 @@ jfU
 jfU
 jfU
 jfU
-tVu
-xgs
+jfU
+jfU
 jfU
 vPg
 vPg
@@ -54864,7 +54645,7 @@ vPg
 vPg
 vPg
 lnr
-sNX
+lnr
 lnr
 vPg
 vPg
@@ -55111,7 +54892,7 @@ jfU
 jfU
 jfU
 jfU
-tVu
+jfU
 jfU
 lib
 jfU
@@ -55368,8 +55149,8 @@ jfU
 mJG
 jfU
 jfU
-tVu
-xgs
+jfU
+jfU
 xgs
 vPg
 vPg
@@ -55616,7 +55397,7 @@ vPg
 jfU
 jfU
 lbk
-lbk
+jfU
 jfU
 lbk
 jfU
@@ -55668,7 +55449,7 @@ weW
 weW
 qcW
 ekr
-aWO
+cSE
 cSE
 cSE
 htO
@@ -55872,7 +55653,7 @@ xVz
 xVz
 jfU
 jfU
-lbk
+jfU
 jfU
 jfU
 jfU
@@ -56129,7 +55910,7 @@ xVz
 xVz
 jfU
 jfU
-lbk
+jfU
 jfU
 jfU
 jfU
@@ -56939,7 +56720,7 @@ tur
 dXE
 dXE
 atO
-lrF
+glr
 jaB
 dXE
 dXE
@@ -57981,7 +57762,7 @@ hQE
 wnQ
 cSE
 cSE
-aWO
+cSE
 cSE
 cSE
 dii
@@ -58719,7 +58500,7 @@ vPg
 lnr
 lnr
 vPg
-gQO
+lnr
 vPg
 vPg
 vPg
@@ -60001,7 +59782,7 @@ vPg
 lnr
 lnr
 lnr
-sNX
+lnr
 lnr
 vPg
 vPg
@@ -61241,7 +61022,7 @@ lnr
 vPg
 vPg
 vPg
-ldK
+lnr
 dUn
 vPg
 vPg
@@ -61497,9 +61278,9 @@ lnr
 fUZ
 vPg
 vPg
-oVh
-oGA
-khz
+lnr
+rxG
+rxG
 vPg
 vPg
 eoy
@@ -61753,10 +61534,10 @@ lnr
 vPg
 lnr
 oSc
-mHs
-lyh
 lnr
-crL
+lnr
+lnr
+lnr
 vPg
 vPg
 eoy
@@ -62268,7 +62049,7 @@ vPg
 vPg
 vPg
 rxG
-btB
+rxG
 eoy
 vPg
 vPg
@@ -62474,7 +62255,7 @@ vPg
 rex
 cJH
 bKK
-dKn
+dKk
 eHy
 cJH
 rex
@@ -62730,7 +62511,7 @@ vPg
 vPg
 rex
 cJH
-diX
+dKo
 dKk
 eIJ
 cJH
@@ -64028,7 +63809,7 @@ iQL
 iVt
 jWn
 iVt
-lew
+jwZ
 cJH
 rex
 vPg
@@ -64542,7 +64323,7 @@ iTA
 iVt
 jwZ
 jwZ
-lfg
+iVt
 cJH
 rex
 vPg
@@ -64667,7 +64448,7 @@ weW
 wWB
 aUb
 hQE
-ayr
+rjz
 qYy
 jbt
 hQE
@@ -66076,7 +65857,7 @@ dUp
 eMM
 dWN
 cJH
-gzm
+xSi
 gXU
 hIl
 fLU
@@ -66084,7 +65865,7 @@ iuL
 fLU
 jZg
 kCo
-llv
+xSi
 cJH
 rex
 vPg
@@ -66339,9 +66120,9 @@ xSi
 fLU
 gyZ
 fLU
-jZq
+ecp
 kCy
-llZ
+ecp
 cJH
 rex
 vPg
@@ -66598,7 +66379,7 @@ jau
 fLU
 kbf
 kEu
-llv
+xSi
 fLU
 rex
 vPg
@@ -66847,7 +66628,7 @@ dWN
 dWN
 fob
 cJH
-gAz
+edM
 hhi
 ecp
 fLU
@@ -66896,7 +66677,7 @@ myy
 myy
 myy
 jPC
-eNf
+rjz
 rjz
 bzQ
 jPC
@@ -67104,15 +66885,15 @@ dWN
 mir
 xSi
 cJH
-gBE
+ecp
 xSi
 hMA
 fLU
 jcG
 fLU
-kbH
+xSi
 ecp
-llv
+xSi
 cJH
 rex
 vPg
@@ -67361,7 +67142,7 @@ dYQ
 dTe
 fon
 cJH
-gCv
+xSi
 hhQ
 hME
 fLU
@@ -68008,7 +67789,7 @@ weW
 wWB
 sKt
 dXE
-knB
+uPr
 rrq
 dXE
 rDt
@@ -68443,7 +68224,7 @@ myy
 myy
 msZ
 rjz
-eNf
+rjz
 rjz
 jPC
 vPg
@@ -69042,9 +68823,9 @@ miI
 tlZ
 tur
 bve
-knB
+uPr
 tCQ
-ozj
+fJQ
 wyB
 wnQ
 weW
@@ -69977,7 +69758,7 @@ dwE
 dSX
 emB
 euZ
-emB
+euZ
 euZ
 jPC
 myy
@@ -70821,9 +70602,9 @@ tur
 fPo
 goz
 gtY
-gRD
 lnr
-gRD
+lnr
+lnr
 tur
 eLE
 wnQ
@@ -71078,9 +70859,9 @@ tur
 fPt
 gpa
 lnr
-gRD
 lnr
-gRD
+lnr
+lnr
 tur
 eLE
 wnQ
@@ -71335,9 +71116,9 @@ tur
 fQz
 gtY
 guO
-gWY
+gtY
 lnr
-gRD
+lnr
 tur
 eLE
 wnQ
@@ -71523,7 +71304,7 @@ eGX
 eXp
 eYd
 eWe
-eNf
+rjz
 dbs
 jPC
 vPg
@@ -71592,9 +71373,9 @@ tur
 fUu
 guO
 gEe
-gRD
 lnr
-gRD
+lnr
+lnr
 tur
 eLE
 wnQ
@@ -71849,9 +71630,9 @@ tur
 fXU
 gyB
 gEu
-gRD
 lnr
-gRD
+lnr
+lnr
 tur
 eLE
 wnQ
@@ -75791,7 +75572,7 @@ vPg
 vPg
 vPg
 vPg
-hLM
+xVz
 xVz
 xVz
 vPg
@@ -88525,7 +88306,7 @@ vPg
 vPg
 tur
 bUi
-cfP
+dxj
 fvp
 cAi
 tur
@@ -89041,7 +88822,7 @@ tur
 xqB
 xqB
 cxu
-cDC
+fvp
 tur
 aUb
 weW
@@ -95452,7 +95233,7 @@ vPg
 vPg
 xVz
 xVz
-rZw
+xVz
 vPg
 vPg
 vPg
@@ -95707,7 +95488,7 @@ wKL
 vPg
 vPg
 vPg
-rZw
+xVz
 xVz
 xVz
 vPg
@@ -98888,9 +98669,9 @@ vPx
 xLe
 rKY
 eSW
-mUS
-jYC
-wyk
+xiQ
+vHk
+rJB
 okK
 brv
 jBq
@@ -99145,9 +98926,9 @@ vPx
 uaL
 bch
 eSW
-mUS
+xiQ
 vHk
-wyk
+rJB
 lYP
 jBq
 xZm
@@ -99402,7 +99183,7 @@ vtN
 xLe
 bch
 eSW
-mUS
+xiQ
 xiQ
 tsj
 gDn


### PR DESCRIPTION
This remotes a bunch of the soil plots because they are reskinned hydroponics basins that are constantly taking up server resources while nobody is using them. If you want to have a plot of dirt to grow plants? Simply dig sand, use it in hand to make blocks and then use the blocks to craft plant plots. This should help cut down on heavy machine usage in our server.
