### PR TITLE
nerfs the funny meta ammo

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -77,8 +77,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a556/uraniumtipped
 	name = "5.56 uranium-tipped bullet"
-	damage = -4
-	armour_penetration = 0.18
+	damage = -9
+	armour_penetration = 0
 	irradiate = 300
 
 
@@ -122,8 +122,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a762/uraniumtipped
 	name = "7.62 uranium-tipped bullet"
-	damage = -4
-	armour_penetration = 0.18
+	damage = -10
+	armour_penetration = 0
 	irradiate = 300
 
 /obj/item/projectile/bullet/a762/microshrapnel


### PR DESCRIPTION
uranium tipped rounds got a serious nerf so they're not straight upgrades anymore

they're still usable but they're not best ammo

trading real damage for reliable DOT that incapacitates a target