### PR TITLE
Fixes Parent AP

### DIFF
--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -307,7 +307,7 @@
 	force = 15
 	throwforce = 25
 	throw_speed = 4
-	armour_penetration = 0.2
+	armour_penetration = 0.07
 	max_reach = 2
 	embedding = list("embedded_impact_pain_multiplier" = 3)
 	custom_materials = null
@@ -326,7 +326,7 @@
 	icon_state = "spear-claw"
 	icon_prefix = "spear-claw"
 	force = 20
-	armour_penetration = 0.3
+	armour_penetration = 0.15
 	sharpness = SHARP_EDGED
 
 /obj/item/twohanded/spear/bonespear/deathclaw/ComponentInitialize()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1287,6 +1287,7 @@
 	burst_shot_delay = 2.2
 	spread = 14
 	extra_damage = 18
+	extra_penetration = 0
 //FN-FAL				Keywords: 7.62mm, Automatic, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1287,7 +1287,6 @@
 	burst_shot_delay = 2.2
 	spread = 14
 	extra_damage = 18
-	extra_penetration = 0.0001
 //FN-FAL				Keywords: 7.62mm, Automatic, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1287,7 +1287,7 @@
 	burst_shot_delay = 2.2
 	spread = 14
 	extra_damage = 18
-
+	extra_penetration = 0.0001
 //FN-FAL				Keywords: 7.62mm, Automatic, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"


### PR DESCRIPTION
Fixes parent AP on worn assault carbine, nerfs AP SLIGHTLY on deathclaw spear 



## About The Pull Request
General nerfs and oversight fixes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now the worn assault carbine isnt just an assault carbine.

## Pre-Merge Checklist

- [no need to test it when its values] You tested this on a local server.
- [no ] This code did not runtime during testing.
- [ yes] You documented all of your changes.



## Changelog
Fixes AP on worn assault carbine, was getting .25 from parent and now has .00001

:cl:

/:cl:


