### PR TITLE
Khan bar

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1,4 +1,19 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aah" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"aaR" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "abc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22,6 +37,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"abO" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"ack" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "acN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
@@ -30,9 +56,23 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"acZ" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "adL" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
+/area/f13/bunker)
+"aep" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "aes" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -42,6 +82,34 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/underground/cave)
+"afY" = (
+/obj/effect/decal/cleanable/molten_object,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
+"ago" = (
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"ahz" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ahC" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -82,6 +150,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"ajF" = (
+/obj/item/am_containment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "ajK" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -107,6 +183,15 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"aku" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "akA" = (
 /obj/machinery/status_display{
 	desc = "A large glass display, used to show various types of information.";
@@ -125,6 +210,13 @@
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"alS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "aml" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -154,6 +246,7 @@
 "anj" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
 /area/f13/wasteland)
 "anu" = (
@@ -205,12 +298,38 @@
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"apS" = (
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"aqL" = (
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "aqU" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"arc" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "arg" = (
 /obj/effect/decal/cleanable/glass/plasma,
@@ -219,17 +338,36 @@
 "arv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9;
+	tag = "icon-tracks (NORTHWEST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"arA" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "arK" = (
 /obj/item/locked_box/armor/tier3,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"arM" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"ash" = (
+/obj/structure/campfire/stove,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "asW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -252,16 +390,44 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"atK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "atN" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"auk" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"aur" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "auu" = (
 /obj/item/reagent_containers/food/snacks/salad/ricepudding,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"auC" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/bunker)
 "auD" = (
 /obj/machinery/light{
 	dir = 1
@@ -310,6 +476,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"axQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "axU" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -330,6 +505,21 @@
 /obj/item/gun/ballistic/automatic/smg/greasegun,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"ayA" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"aze" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/machinery/chem_master/condimaster,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "azm" = (
 /obj/structure/sign/poster/prewar/vault_tec,
 /turf/closed/indestructible/vaultdoor,
@@ -338,6 +528,26 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"azD" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"azE" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "azF" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
@@ -359,6 +569,11 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"aDd" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "aDh" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/f13/wood{
@@ -378,19 +593,85 @@
 /obj/structure/debris/v3,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"aEI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"aEN" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"aFo" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/glowshroom/single,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"aFt" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
+"aFw" = (
+/obj/machinery/button/door{
+	id = "trap";
+	name = "Old Dusty Button"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"aFM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"aGe" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "aGr" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubble";
+	tag = "icon-rubble (WEST)"
 	},
 /area/f13/wasteland)
+"aGK" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "aGL" = (
 /obj/structure/sink/well{
 	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aGY" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "aHp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -399,10 +680,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aHG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 5
+	},
+/area/f13/bunker)
+"aIo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "aIt" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"aIB" = (
+/obj/item/clothing/under/f13/raiderharness,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "aIQ" = (
 /obj/structure/window/plastitanium{
@@ -441,6 +743,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"aJR" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "aKD" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -449,6 +757,16 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"aKI" = (
+/obj/structure/sign/departments/chemistry,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"aKO" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "aKU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -469,10 +787,23 @@
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"aLE" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "aMa" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
+"aMi" = (
+/obj/structure/sign/poster/official/help_others,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "aMK" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -485,6 +816,15 @@
 	},
 /obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"aNj" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "aNv" = (
 /obj/structure/debris/v3,
@@ -521,6 +861,24 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"aPz" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = 10
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = -11
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "aQB" = (
 /obj/structure/rack,
 /obj/item/storage/box/masks,
@@ -530,6 +888,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"aRk" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"aRP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"aSu" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "aSW" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/office/dark{
@@ -544,11 +922,20 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"aTC" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "aTJ" = (
 /obj/item/reagent_containers/food/snacks/salad/herbsalad,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"aTZ" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "aUl" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -569,17 +956,46 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "aUG" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/water,
 /area/f13/bunker)
+"aUM" = (
+/obj/structure/sign/departments/botany,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "aUN" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/blamco,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"aVd" = (
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"aVm" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"aVr" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "aVw" = (
 /obj/structure/chair/f13chair1,
@@ -601,6 +1017,7 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
 /area/f13/ncr)
 "aWS" = (
@@ -639,8 +1056,15 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
 	},
 /area/f13/wasteland)
+"aZY" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bac" = (
 /obj/item/ammo_casing/c10mm,
 /mob/living/simple_animal/hostile/ghoul,
@@ -652,6 +1076,13 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bap" = (
+/obj/structure/table/optable,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "bax" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/ruins,
@@ -660,6 +1091,10 @@
 /obj/structure/closet,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"baR" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bbg" = (
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
@@ -667,10 +1102,27 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bby" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "bbJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"bbN" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"bbR" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/turf/open/water,
+/area/f13/bunker)
 "bbW" = (
 /obj/structure/table,
 /obj/item/clothing/neck/petcollar,
@@ -691,6 +1143,11 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"bcV" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "bdg" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/mineral/random/low_chance,
@@ -702,6 +1159,10 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"bdF" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "ben" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -709,6 +1170,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"beq" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "beI" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -722,8 +1188,19 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
+"bff" = (
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "bgc" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -741,10 +1218,33 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bgM" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"bha" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bhn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bhz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "bhU" = (
 /obj/machinery/light/small{
@@ -752,6 +1252,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "bhW" = (
@@ -772,6 +1273,26 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"bip" = (
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/reagent_containers/blood/universal,
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"bit" = (
+/obj/machinery/door/window/southleft,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "biC" = (
 /obj/machinery/light,
 /obj/structure/rack,
@@ -779,6 +1300,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"biH" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "biS" = (
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/outside/desert,
@@ -797,12 +1327,27 @@
 "bji" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right";
+	tag = "icon-horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
+"bjm" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bjA" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
+	},
+/area/f13/bunker)
+"bjG" = (
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "bjJ" = (
@@ -811,9 +1356,42 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bjM" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"bkI" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"bkM" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 10
+	},
+/area/f13/radiation)
 "bkV" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
+	},
+/area/f13/bunker)
+"bkZ" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "ble" = (
@@ -825,6 +1403,23 @@
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"bli" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"blz" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/poddoor/shutters{
+	id = "stalin";
+	name = "Old Suspicous Wall"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "blC" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -838,6 +1433,20 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"bmp" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"bmx" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "bmR" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -846,6 +1455,45 @@
 "bnn" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
+/area/f13/bunker)
+"bns" = (
+/obj/structure/rack,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/belt/security,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/assembly/flash/handheld,
+/obj/item/restraints/handcuffs,
+/obj/item/gun/ballistic/automatic/pistol/n99,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/riot/vaultsec,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"bnE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"bnM" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/medical.dmi';
+	name = "Vault 223 Chemestry area"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "bnQ" = (
 /obj/structure/vault_door/old,
@@ -858,6 +1506,18 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"bph" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "bpv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -887,9 +1547,45 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"brl" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"bru" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "bsh" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"bsl" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
 "bsr" = (
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
@@ -903,16 +1599,73 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"bsM" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"bsU" = (
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "bsV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/brown/white,
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"btI" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"bug" = (
+/obj/effect/decal/waste,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "buO" = (
 /obj/item/ammo_casing/shotgun/dart/bioterror,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"buV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 102;
+	name = "Vault Door Security Checkpoint"
+	},
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/f13/bunker)
+"bvF" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "bvQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/nukashine,
@@ -922,6 +1675,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHWEST)"
 	},
 /area/f13/legion)
 "bvT" = (
@@ -932,9 +1686,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bwh" = (
+/obj/structure/table/wood,
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"bwt" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "bwD" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar";
+	tag = "icon-rubblepillar"
 	},
 /area/f13/wasteland)
 "bxh" = (
@@ -943,6 +1709,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "bxJ" = (
@@ -962,15 +1729,40 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"byr" = (
+/obj/structure/sign/warning/securearea,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "byC" = (
 /mob/living/simple_animal/cow/brahmin/calf,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"bzP" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "bzW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"bAv" = (
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bAx" = (
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
@@ -978,6 +1770,7 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "bBj" = (
@@ -1000,6 +1793,14 @@
 /obj/item/mop,
 /turf/open/floor/plating/f13,
 /area/f13/followers)
+"bCa" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "bCl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -1008,10 +1809,48 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"bCn" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"bCX" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"bDa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bDe" = (
+/obj/structure/table,
+/obj/item/storage/fancy/rollingpapers,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "bDr" = (
 /obj/structure/chair/wood/fancy,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"bDE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"bDN" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "bEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/ripped,
@@ -1023,6 +1862,11 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"bEP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/micro,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "bET" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
@@ -1030,9 +1874,11 @@
 "bFa" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
+	tag = "icon-tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
 "bFo" = (
@@ -1049,6 +1895,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"bGY" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"bHe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "bHu" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/green,
@@ -1068,11 +1929,40 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"bIx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"bIy" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "bJb" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/legion)
+"bJf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"bJu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "bJM" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -1084,6 +1974,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"bJP" = (
+/obj/machinery/button{
+	id = 666;
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "bKe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste,
@@ -1092,9 +1990,11 @@
 "bKn" = (
 /obj/structure/toilet{
 	dir = 4;
+	tag = "icon-toilet00 (EAST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
 /area/f13/ncr)
 "bKt" = (
@@ -1102,8 +2002,28 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"bKW" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
+"bLr" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/poddoor/shutters{
+	id = "meat";
+	name = "Old Suspicious Wall"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "bLt" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -1120,8 +2040,26 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/wasteland)
+"bMk" = (
+/obj/effect/decal/remains/human,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"bMu" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"bMA" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/sign/warning,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "bMG" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -1145,6 +2083,16 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bNJ" = (
+/obj/structure/table,
+/obj/item/ship_in_a_bottle,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "bNL" = (
 /obj/machinery/power/deck_relay,
 /turf/open/floor/plating/tunnel{
@@ -1159,6 +2107,18 @@
 /obj/structure/stone_tile/center/burnt,
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"bPe" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"bPr" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "bPz" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -1175,6 +2135,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bQk" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"bQB" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/caves)
+"bQC" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "bRa" = (
 /obj/machinery/light{
 	dir = 1;
@@ -1182,6 +2156,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bRr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "bRI" = (
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -1224,6 +2208,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "bVI" = (
@@ -1248,11 +2233,19 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
 "bWg" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bXn" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "bXr" = (
 /obj/structure/table/glass,
@@ -1273,6 +2266,7 @@
 "bYy" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken";
+	tag = "icon-ruinswindowbroken (NORTHEAST)"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -1289,6 +2283,7 @@
 "bYS" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
+	tag = "icon-tree_2"
 	},
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -1302,23 +2297,55 @@
 	},
 /turf/open/water,
 /area/f13/underground/cave)
+"cap" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"cav" = (
+/obj/structure/table/optable,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "caN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"caT" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cbg" = (
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"cbH" = (
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "cbT" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"cbU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "cce" = (
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
@@ -1327,6 +2354,28 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ccE" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ccH" = (
+/obj/item/bodypart/chest/monkey,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"cdh" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "suka";
+	name = "Old Suspicous Wall"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "cdl" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
@@ -1334,11 +2383,20 @@
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"cdw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "cdJ" = (
 /obj/structure/closet/fridge,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "cdZ" = (
@@ -1354,6 +2412,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"ceT" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"cfi" = (
+/obj/structure/weightlifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "cfE" = (
 /obj/item/flag/ncr,
 /obj/structure/obstacle/barbedwire{
@@ -1379,6 +2449,14 @@
 /obj/item/trash/f13/c_ration_3,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"cgc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "cgp" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -1388,6 +2466,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cgX" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
 /area/f13/bunker)
 "chf" = (
 /obj/structure/table/wood/poker,
@@ -1421,6 +2505,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"cim" = (
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cin" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -1452,6 +2541,12 @@
 /obj/item/trash/f13/rotten,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"cjv" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "cjV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
@@ -1461,15 +2556,76 @@
 "cka" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/followers)
+"ckj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "suka";
+	name = "Security shutters button"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cks" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ckz" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"cmk" = (
+/obj/machinery/vending/coffee,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"cnd" = (
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"cng" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "cno" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cny" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cnM" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "cnS" = (
 /obj/structure/table,
@@ -1485,9 +2641,27 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"coB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "coG" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cpl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/bunker)
 "cpr" = (
 /obj/structure/chair/left{
@@ -1507,6 +2681,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cqs" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "cqD" = (
 /obj/structure/barricade/wooden,
@@ -1531,10 +2712,79 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"crB" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "crE" = (
 /obj/machinery/power/deck_relay,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"crT" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"csk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"csx" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_y = 2
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = 17
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"csR" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"ctI" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/broken,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ctL" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -1554,6 +2804,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"cuK" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cuS" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/f13{
@@ -1576,6 +2832,22 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"cvO" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"cvX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "cwg" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -1589,6 +2861,17 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"cwo" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "cwK" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13{
@@ -1599,6 +2882,13 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"cxt" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "czm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1607,6 +2897,12 @@
 	max_mobs = 2
 	},
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"czn" = (
+/obj/structure/grille/broken,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "czt" = (
 /obj/structure/fence{
@@ -1647,6 +2943,10 @@
 "cCA" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/wasteland)
+"cCG" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "cDn" = (
 /obj/machinery/biogenerator,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1664,6 +2964,11 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"cEJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "cFa" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1671,6 +2976,12 @@
 "cFf" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"cFu" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "cFH" = (
 /obj/machinery/light/fo13colored/Red{
@@ -1683,6 +2994,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
 "cGh" = (
@@ -1690,6 +3002,15 @@
 /obj/machinery/light/broken,
 /obj/structure/bed/old,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"cGl" = (
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"cHm" = (
+/obj/structure/stacklifter,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "cHv" = (
 /obj/structure/table/abductor{
@@ -1702,6 +3023,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"cHM" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "cIc" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1710,15 +3037,33 @@
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"cIA" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "cIH" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/ncr)
+"cIR" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cJr" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
 "cJv" = (
@@ -1764,12 +3109,28 @@
 /obj/effect/decal/waste,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"cKC" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"cKF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cKN" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"cLw" = (
+/obj/structure/sign/poster/official/report_crimes,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "cLP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1785,14 +3146,33 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
+"cNj" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"cNT" = (
+/obj/structure/debris/v3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cOh" = (
 /obj/machinery/autolathe,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"cPh" = (
+/turf/closed/indestructible/rock,
+/area/f13/tunnel)
 "cPi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light,
@@ -1842,6 +3222,17 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"cRr" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "cRt" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/effect/decal/cleanable/dirt,
@@ -1861,6 +3252,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"cSd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/secure/science{
+	req_one_access_txt = "1"
+	},
+/obj/item/clothing/head/kitty/genuine{
+	desc = "Smells like fur and fills you with dread.";
+	max_integrity = 10000;
+	name = "horrific experiment"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "cSF" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -1907,6 +3311,7 @@
 "cVB" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbrokenvertical";
+	tag = "icon-ruinswindowbrokenvertical (NORTHEAST)"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
@@ -1929,6 +3334,11 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"cXg" = (
+/obj/machinery/vending/cola/starkist,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "cXn" = (
 /turf/open/floor/plasteel/dark/corner,
 /area/f13/bunker)
@@ -1939,6 +3349,14 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"cXH" = (
+/obj/item/clothing/glasses/meson,
+/obj/item/flashlight/lantern,
+/obj/item/storage/bag/ore,
+/obj/structure/table,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "cXI" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
@@ -1949,6 +3367,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"cYf" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cZC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cZT" = (
 /obj/structure/sink{
@@ -1962,6 +3390,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
+/area/f13/bunker)
+"dav" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "daB" = (
 /turf/open/floor/plasteel/dark/side,
@@ -2007,8 +3440,39 @@
 "dcB" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"dcE" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "dcJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"dcW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"ddc" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
 /area/f13/bunker)
 "ddp" = (
 /obj/structure/simple_door/metal/fence{
@@ -2016,6 +3480,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"ddL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"ddU" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "deq" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2042,6 +3516,30 @@
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"dfM" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"dfV" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"dgr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"dgW" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "dgX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/cards/singlecard,
@@ -2051,19 +3549,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/ncr)
+"dhj" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 5
+	},
+/area/f13/radiation)
 "dhq" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
 /area/f13/wasteland)
+"dhC" = (
+/obj/structure/closet,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dhH" = (
 /obj/structure/displaycase/trophy,
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/f13/old,
@@ -2077,6 +3589,17 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"dii" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"diE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "djo" = (
 /obj/structure/debris/v4,
@@ -2114,6 +3637,7 @@
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
@@ -2156,6 +3680,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"dlH" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "dlL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
@@ -2166,6 +3695,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "dlW" = (
@@ -2181,12 +3711,39 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"dmf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dmp" = (
 /obj/effect/decal/remains/human,
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
+"dmC" = (
+/obj/structure/timeddoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"dmM" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	network = list("Vault")
+	},
+/obj/machinery/button/door{
+	id = 103;
+	name = "Blast Doors"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "dmP" = (
 /obj/structure/bookcase,
 /obj/machinery/light{
@@ -2200,8 +3757,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
+"dmX" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dnm" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -2238,6 +3800,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "doS" = (
@@ -2251,6 +3814,7 @@
 "dpa" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop";
+	tag = "icon-verticaloutermaintop"
 	},
 /area/f13/wasteland)
 "dpj" = (
@@ -2266,6 +3830,29 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dpZ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"dqi" = (
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"dqS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
 "dqV" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -2294,6 +3881,16 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/bunker)
+"dtH" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "dub" = (
 /obj/machinery/autolathe,
@@ -2343,10 +3940,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dxC" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dxN" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dyl" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dyP" = (
 /obj/structure/table,
@@ -2355,14 +3967,49 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"dzc" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"dzy" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"dzB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dzY" = (
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
+"dzZ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dAE" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"dBc" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"dBA" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "dBJ" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -2380,6 +4027,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"dCf" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "dCt" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -2387,6 +4039,13 @@
 	},
 /obj/effect/spawner/lootdrop/f13/blueprintVHighPartsWeighted,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"dCz" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "dCA" = (
 /obj/machinery/light/small{
@@ -2398,6 +4057,16 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dDg" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "dDr" = (
 /obj/effect/decal/remains/human,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -2407,6 +4076,10 @@
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dDI" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "dDJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2440,13 +4113,33 @@
 "dDT" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
 	},
 /area/f13/ncr)
 "dFa" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/legion)
+"dFd" = (
+/obj/structure/table,
+/obj/item/clothing/head/soft/black,
+/obj/item/clothing/under/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"dFE" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dFM" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -2470,6 +4163,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"dGt" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
 "dHs" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -2478,6 +4176,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"dHN" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "dHW" = (
 /obj/structure/table/wood/settler,
 /obj/item/lighter,
@@ -2490,6 +4195,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"dIX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "dJb" = (
 /obj/structure/closet,
 /obj/item/instrument/guitar,
@@ -2531,6 +4243,7 @@
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 16;
+	tag = "icon-sink (NORTH)"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -2547,6 +4260,10 @@
 	dir = 4
 	},
 /area/f13/bunker)
+"dKT" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "dLd" = (
 /mob/living/simple_animal/hostile/cazador/young,
 /obj/structure/flora/junglebush/large,
@@ -2561,6 +4278,12 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
+/area/f13/bunker)
+"dLL" = (
+/obj/machinery/vending/clothing,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "dLS" = (
 /obj/structure/flora/grass/jungle,
@@ -2617,6 +4340,26 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dNl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"dNs" = (
+/obj/item/pen/fountain,
+/obj/item/clothing/accessory/lawyers_badge,
+/obj/item/storage/briefcase/lawyer,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dNU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -2644,6 +4387,20 @@
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"dPC" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"dPD" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "dPT" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -2668,17 +4425,60 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"dQt" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/construction/rcd,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"dQv" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "dQz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"dQD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"dQF" = (
+/obj/structure/glowshroom/single,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"dQK" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "dQM" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
 	id = "bigbunk"
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"dQS" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dQV" = (
 /obj/machinery/light{
@@ -2704,6 +4504,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "dRF" = (
@@ -2712,11 +4513,30 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dSb" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"dSB" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dSK" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"dSQ" = (
+/obj/structure/chair/comfy/brown,
+/obj/item/toy/plush/lizardplushie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "dSY" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -2727,6 +4547,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"dTE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "dTG" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2744,6 +4568,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dUV" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dVc" = (
 /obj/structure/fence{
@@ -2769,6 +4600,20 @@
 /obj/structure/chair/wood/worn,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"dWj" = (
+/obj/machinery/light{
+	dir = 8;
+	flickering = 1;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"dWx" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dXd" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/f13/old,
@@ -2777,6 +4622,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"dXQ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "dXT" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
@@ -2810,6 +4663,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
@@ -2823,10 +4677,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dZz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dZP" = (
+/obj/structure/debris/v3,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "dZU" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA";
+	tag = "icon-sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
@@ -2851,6 +4716,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/followers)
+"eaN" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eaR" = (
 /obj/machinery/light{
 	dir = 4
@@ -2881,6 +4754,12 @@
 /obj/structure/nest/securitron,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"ebC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ebF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2900,6 +4779,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ecm" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "ecK" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -2909,6 +4796,7 @@
 "edb" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbrokenvertical";
+	tag = "icon-ruinswindowbrokenvertical (NORTHEAST)"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ncr)
@@ -2931,10 +4819,30 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"eek" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/human/core,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "ees" = (
 /obj/effect/decal/riverbank,
 /turf/open/water,
 /area/f13/underground/cave)
+"eeN" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "eeP" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/green,
@@ -2956,6 +4864,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"efj" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "efu" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/grimy,
@@ -2972,6 +4886,11 @@
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"efL" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "efM" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -2987,6 +4906,31 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"egB" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"egR" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"ehQ" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "eil" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -3002,6 +4946,29 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"eix" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
+"eiQ" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"ejt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "ejE" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3016,6 +4983,13 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
+"ekr" = (
+/obj/machinery/button/door{
+	id = "suka";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "eky" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -3024,6 +4998,19 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ekX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"elq" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "elv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3038,6 +5025,10 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"emq" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "ems" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
@@ -3050,14 +5041,40 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"emO" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"ene" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "enj" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"enq" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"enC" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "enO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -3067,6 +5084,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"enP" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "enQ" = (
 /obj/item/ammo_casing/c10mm,
@@ -3080,6 +5103,13 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"eov" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "eoP" = (
 /obj/machinery/door/airlock/security/glass{
 	max_integrity = 9999;
@@ -3092,16 +5122,33 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"epl" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "epJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"erc" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "erd" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"eru" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "erC" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3132,6 +5179,15 @@
 /obj/item/ship_in_a_bottle,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
+"esi" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "esJ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -3139,6 +5195,7 @@
 	},
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
 "ete" = (
@@ -3148,6 +5205,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"euc" = (
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "eut" = (
 /obj/structure/bed,
 /obj/item/trash/cheesie,
@@ -3158,8 +5220,19 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
+"euw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/f13/bunker)
 "euH" = (
 /obj/structure/flora/tree/tall,
 /obj/structure/flora/grass/wasteland{
@@ -3171,6 +5244,12 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"evO" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "ewf" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/nest/cazador,
@@ -3187,6 +5266,7 @@
 "ewx" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs";
+	tag = "icon-stagestairs"
 	},
 /area/f13/ncr)
 "ewW" = (
@@ -3198,6 +5278,29 @@
 	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"exn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
+"ext" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
 /area/f13/bunker)
 "exB" = (
 /obj/structure/bookcase,
@@ -3220,6 +5323,42 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"eyp" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"eyv" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"eyw" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"eyC" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ezf" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"ezn" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/water,
+/area/f13/bunker)
 "ezw" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/item/ammo_box/c10mm,
@@ -3230,6 +5369,14 @@
 /obj/effect/decal/cleanable/cum,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"ezZ" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "eAa" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3241,6 +5388,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"eAH" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "eAJ" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -3267,6 +5422,22 @@
 /obj/item/clothing/suit/hooded/cloak/shunter,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"eBw" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/crafting/electronicparts/three,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/bunker)
 "eBE" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -3287,6 +5458,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"eCb" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "eDg" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3302,6 +5478,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "eDt" = (
@@ -3311,6 +5488,10 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"eDG" = (
+/obj/structure/weightlifter,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "eEe" = (
 /obj/effect/spawner/lootdrop/ammo,
@@ -3334,6 +5515,14 @@
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"eEW" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/f13/bunker)
 "eFc" = (
 /obj/machinery/shower{
@@ -3372,6 +5561,11 @@
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"eGW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "eHG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/securitron/sentrybot{
@@ -3396,6 +5590,28 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"eIq" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"eIA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eJd" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3404,10 +5620,42 @@
 /obj/structure/closet/crate/wicker,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"eJG" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"eJO" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "eKu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/popcorn,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"eKB" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"eKD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
 /area/f13/bunker)
 "eLs" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -3415,6 +5663,10 @@
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"eLP" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "eLS" = (
 /obj/machinery/door/airlock/grunge/abandoned,
@@ -3427,6 +5679,23 @@
 /obj/item/card/id/prisoner/seven,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"eNm" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"eNv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/bunker)
+"eNy" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "eNI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
@@ -3448,6 +5717,10 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
+"eOE" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "eOY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3485,6 +5758,35 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"eQz" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"eQI" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"eQV" = (
+/obj/structure/table/booth,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"eRC" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "eRS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -3496,10 +5798,30 @@
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"eSI" = (
+/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/water,
+/area/f13/bunker)
 "eSU" = (
 /obj/machinery/workbench,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"eSY" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"eTh" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "eTn" = (
 /obj/item/phone,
@@ -3516,6 +5838,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"eUo" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "eUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -3538,6 +5865,11 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"eVp" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "eVx" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
@@ -3550,9 +5882,19 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"eVP" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "eWx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/wasteland)
 "eXb" = (
@@ -3564,13 +5906,37 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"eXJ" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"eXY" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "eXZ" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/bunker)
+"eYb" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eYe" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3590,6 +5956,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"eYk" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "eYE" = (
 /obj/structure/rack,
 /obj/item/toy/cards/deck/cas,
@@ -3605,6 +5979,19 @@
 	faction = list("wastebot")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"eZc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
+"eZn" = (
+/obj/structure/decoration/rag,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fap" = (
 /obj/effect/decal/cleanable/blood,
@@ -3625,6 +6012,26 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"fbC" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"fcq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"fcE" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "fcM" = (
 /obj/effect/landmark/poster_spawner/pinup,
 /turf/closed/wall/f13/wood,
@@ -3650,6 +6057,7 @@
 "fee" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
+	tag = "icon-tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -3682,6 +6090,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ffN" = (
+/obj/item/storage/fancy/rollingpapers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"ffU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "fga" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/riverbank{
@@ -3703,6 +6121,11 @@
 	icon_state = "bluemark"
 	},
 /area/f13/followers)
+"fgf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "fgq" = (
 /obj/structure/table/wood/settler,
 /obj/item/papercutter,
@@ -3734,6 +6157,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"fiR" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "fiU" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -3744,15 +6173,44 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fme" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"fmB" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fmR" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "fnz" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/f13/tunnel,
+/area/f13/bunker)
+"fnE" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fod" = (
 /obj/structure/displaycase/trophy,
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -3762,6 +6220,26 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"foF" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"foL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "fpa" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plating/tunnel,
@@ -3769,15 +6247,18 @@
 "fpl" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
 "fpw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
 	},
 /area/f13/wasteland)
 "fpy" = (
@@ -3791,6 +6272,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"fqJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fqM" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -3802,6 +6291,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"fre" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "frr" = (
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
@@ -3811,11 +6308,38 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"frw" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"fsk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
+"fsQ" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "fsR" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"fuI" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/part_replacer,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/bunker)
 "fuP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3833,6 +6357,27 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"fvt" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"fvF" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"fvI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "fvN" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -3848,6 +6393,18 @@
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"fwr" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fwO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "fwW" = (
 /obj/machinery/status_display{
@@ -3880,9 +6437,34 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"fyB" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "fyC" = (
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fyQ" = (
+/obj/item/storage/belt/utility/full/engi,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"fzg" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "fzi" = (
 /turf/open/floor/f13{
@@ -3896,6 +6478,11 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fAf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fAj" = (
 /turf/closed/wall/f13/wood/house/broken,
@@ -3914,6 +6501,17 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"fBr" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "fCi" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer,
@@ -3921,6 +6519,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"fCp" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fDk" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "fDU" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -3929,6 +6540,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fEc" = (
+/obj/item/pen,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "fEu" = (
 /obj/effect/decal/remains/human,
@@ -3940,12 +6557,56 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old";
+	tag = "icon-floor5-old"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fFa" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"fFf" = (
+/obj/structure/flora/tree/jungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"fFg" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "fFh" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"fFv" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/empty_sleeper/nanotrasen{
+	desc = "A medical sleeper - this one appears broken. There are exposed bolts for easy disassembly using a wrench.";
+	name = "broken sleeper"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "fGd" = (
 /obj/machinery/light{
@@ -3964,6 +6625,17 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fHC" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"fIw" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "fIF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
@@ -3974,6 +6646,14 @@
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"fJy" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fJM" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/f13/old,
@@ -3983,6 +6663,25 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"fKS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"fLK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "fMc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4029,6 +6728,21 @@
 "fNB" = (
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"fNC" = (
+/obj/structure/table,
+/obj/item/papercutter{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"fNE" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "fNR" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt{
@@ -4036,12 +6750,33 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"fNZ" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "fOd" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
 	name = "prewar lounge chair"
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fOs" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fOA" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "fOC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4058,6 +6793,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"fPu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "fPA" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/microwave,
@@ -4068,6 +6811,27 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fPQ" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"fPZ" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"fQm" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "fQq" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -4088,12 +6852,35 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fRq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"fRw" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fRE" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"fRI" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fRM" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/dirt{
@@ -4127,6 +6914,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"fSD" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/rock,
+/area/f13/tunnel)
+"fTa" = (
+/obj/machinery/button/door{
+	id = 103;
+	name = "Blast Doors";
+	pixel_x = 26
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fTr" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood{
@@ -4142,6 +6945,7 @@
 "fTW" = (
 /obj/structure/chair/wood{
 	dir = 4;
+	tag = "icon-wooden_chair_settler (EAST)"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -4160,6 +6964,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"fUA" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "fUY" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/dirt,
@@ -4168,6 +6976,22 @@
 "fVi" = (
 /obj/item/crafting/fuse,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"fVp" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
+/area/f13/bunker)
+"fVE" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "fVQ" = (
 /obj/item/ammo_casing/c9mm,
@@ -4183,11 +7007,46 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
+"fWu" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	icon_state = "rightsecure"
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fWH" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
+	},
+/area/f13/bunker)
+"fXC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"fXG" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"fXT" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "fYq" = (
@@ -4216,6 +7075,7 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
 "fZG" = (
@@ -4231,6 +7091,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"gax" = (
+/obj/structure/campfire/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gaB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/vault_door/old{
@@ -4243,11 +7107,13 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/legion)
 "gaT" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs";
+	tag = "icon-stagestairs"
 	},
 /area/f13/legion)
 "gaZ" = (
@@ -4274,6 +7140,23 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gcN" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gda" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "gdc" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -4287,10 +7170,31 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"gdx" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"geb" = (
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "ger" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"geD" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "geJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -4303,6 +7207,21 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
+"gfn" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/bunker)
+"gfr" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "gfw" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -4316,11 +7235,39 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gfV" = (
+/obj/structure/table/wood,
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gfY" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/doorButtons/wornvaultButton,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"gga" = (
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "ggj" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ggp" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ggB" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4329,6 +7276,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubble";
+	tag = "icon-rubble (WEST)"
 	},
 /area/f13/wasteland)
 "ggY" = (
@@ -4336,6 +7284,15 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/tentwall,
+/area/f13/bunker)
+"ghu" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/goonplaque{
+	desc = "This is a plaque detailing and honoring the corporate dollars lost creating the vault. All craftsmanship is of the highest quality. The Business men are laughing. The Workers are crying. It menaces with spikes of gold."
+	},
 /area/f13/bunker)
 "ghW" = (
 /turf/open/floor/plasteel/f13{
@@ -4350,10 +7307,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"giq" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "giG" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/legion)
 "giN" = (
@@ -4366,16 +7328,46 @@
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gjJ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"gkh" = (
+/obj/structure/chair/office/light,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "gkl" = (
 /obj/machinery/light{
 	pixel_x = -16
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"gkM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "glz" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"glK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"glU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "gmc" = (
 /obj/effect/decal/remains/human,
 /turf/closed/wall/f13/supermart,
@@ -4397,12 +7389,29 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gnk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "gnH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/item/trash/f13/tin,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"gov" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"goD" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "goK" = (
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -4414,6 +7423,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "goV" = (
@@ -4424,6 +7434,13 @@
 /obj/machinery/computer/card,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"gpx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
 "gpY" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -4453,13 +7470,35 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
+"grM" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"gsa" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/wreck/trash/machinepiletwo{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gsb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gsl" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "gso" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
@@ -4468,10 +7507,23 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"gsx" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "gsV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/pill/radx,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"gta" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gtb" = (
 /obj/structure/fluff/fokoff_sign,
@@ -4480,6 +7532,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gtq" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gtL" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -4514,10 +7571,21 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gvx" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "gvJ" = (
 /obj/structure/closet/fridge/meat,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"gvS" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "gwd" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -4527,12 +7595,32 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
 	},
 /area/f13/wasteland)
+"gxj" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "gxP" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"gxU" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "gyJ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -4544,10 +7632,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gzs" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase,
+/obj/item/clothing/suit/armor/f13/ghostechoe,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "gzH" = (
 /obj/structure/simple_door,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gzV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "gAg" = (
 /obj/machinery/computer/terminal{
 	dir = 8
@@ -4555,6 +7664,15 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"gAL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "gAT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4573,6 +7691,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
 "gBm" = (
@@ -4595,11 +7714,54 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gCq" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "gCN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left";
+	tag = "icon-horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"gDd" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Raider"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gDr" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"gDD" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 20;
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"gDI" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"gEf" = (
+/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"gEz" = (
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gED" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -4617,6 +7779,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"gEJ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "gEX" = (
 /obj/machinery/light/fo13colored/Red{
@@ -4646,9 +7814,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gHp" = (
+/obj/item/bikehorn,
+/obj/structure/rack,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "gHO" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -4656,13 +7832,25 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"gIA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "gJi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
+/area/f13/bunker)
+"gJs" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "gKg" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -4702,6 +7890,24 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gMp" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"gMH" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "gMX" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13{
@@ -4713,15 +7919,30 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
 /area/f13/wasteland)
+"gNm" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "gNQ" = (
 /obj/machinery/deepfryer,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/wasteland)
+"gNS" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "gOB" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/old,
@@ -4747,6 +7968,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"gOW" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "gPr" = (
 /obj/item/candle/tribal_torch,
 /turf/open/water,
@@ -4759,6 +7985,7 @@
 "gQn" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1;
+	tag = "icon-comfychair (NORTH)"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -4769,6 +7996,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "gQB" = (
@@ -4784,6 +8012,26 @@
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gQZ" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"gRG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"gRL" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gTa" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -4796,9 +8044,23 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gTH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "gUA" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"gUQ" = (
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "gUT" = (
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
@@ -4810,6 +8072,24 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"gVj" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"gVk" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gVC" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -4844,6 +8124,12 @@
 	footstep = "wood"
 	},
 /area/f13/legion)
+"gXg" = (
+/obj/machinery/vending/snack/random,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gXm" = (
 /obj/structure/guncase,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -4851,6 +8137,21 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"gXq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"gXE" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "gYy" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4872,6 +8173,13 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
+/area/f13/bunker)
+"gYP" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "gYQ" = (
 /turf/open/floor/f13/wood,
@@ -4897,11 +8205,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gZR" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "haa" = (
 /obj/structure/stone_tile/slab,
 /obj/item/melee/transforming/cleaving_saw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"hac" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hae" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
@@ -4911,17 +8238,19 @@
 "haq" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "hbb" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "hbn" = (
 /obj/structure/toilet{
 	dir = 4;
+	tag = "icon-toilet00 (EAST)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -4949,6 +8278,25 @@
 "hbR" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"hcg" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"hcG" = (
+/obj/machinery/door/airlock{
+	name = "Hydroponics"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"hdf" = (
+/obj/machinery/chem_master/advanced,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "hdA" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -4973,6 +8321,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
 "hdS" = (
@@ -4990,6 +8339,11 @@
 "heT" = (
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"hfq" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hfv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5009,15 +8363,41 @@
 /obj/item/target/alien,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hgH" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hgX" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"hha" = (
+/obj/structure/bedsheetbin,
+/obj/structure/table,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hhe" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hhJ" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/bunker)
+"hhR" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "hiQ" = (
 /obj/structure/rack,
@@ -5027,12 +8407,52 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"hke" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hkf" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	network = list("Vault")
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"hkG" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hlB" = (
+/obj/structure/sign/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "hlU" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hmm" = (
+/obj/structure/guncase/shotgun,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
 /area/f13/bunker)
 "hmv" = (
 /obj/item/storage/firstaid/fire,
@@ -5046,10 +8466,45 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"hmJ" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/f13/mfp/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hmK" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"hne" = (
+/obj/item/dice/d20,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hnr" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "hns" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hnv" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hnz" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "hnK" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -5077,6 +8532,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"hps" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hpt" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5135,9 +8595,24 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hss" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "hte" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"huk" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "huE" = (
 /obj/machinery/rnd/server,
@@ -5145,6 +8620,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"huW" = (
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hvx" = (
 /obj/machinery/workbench,
@@ -5154,14 +8633,22 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/legion)
 "hwh" = (
 /obj/structure/chair{
 	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"hwn" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hwv" = (
 /obj/structure/fence{
 	dir = 8
@@ -5173,8 +8660,22 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"hwA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"hxg" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "hxi" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5191,6 +8692,12 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/bunker)
+"hxN" = (
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hzj" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -5201,6 +8708,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHWEST)"
 	},
 /area/f13/wasteland)
 "hzY" = (
@@ -5208,6 +8716,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hAi" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hAw" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"hAB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hBd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hBp" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hBr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5224,12 +8769,22 @@
 "hBE" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed";
+	tag = "icon-ruinswindowdestroyed (NORTHEAST)"
 	},
 /obj/structure/curtain{
 	color = "#845f58"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hCr" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/bunker)
 "hDa" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -5237,6 +8792,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"hDj" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "hDz" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -5249,6 +8812,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hEF" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -13
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "hFc" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -5262,6 +8839,11 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"hFI" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hFK" = (
 /obj/structure/sign/poster/contraband/pinup_shower,
 /turf/closed/wall/f13/wood/interior,
@@ -5286,6 +8868,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"hHo" = (
+/obj/structure/timeddoor,
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "hHs" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -5293,6 +8880,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubble";
+	tag = "icon-rubble (WEST)"
 	},
 /area/f13/wasteland)
 "hHy" = (
@@ -5309,6 +8897,7 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "hHJ" = (
@@ -5316,10 +8905,18 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"hIm" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "hIq" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "hIu" = (
@@ -5334,6 +8931,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"hIX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/water,
+/area/f13/bunker)
 "hJh" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -5345,12 +8949,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
+"hJo" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "hJx" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"hJN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hJQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "hJS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -5365,9 +8989,25 @@
 /obj/structure/chair/stool{
 	dir = 1;
 	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"hKl" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"hKP" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "hLj" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -5375,6 +9015,38 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"hLt" = (
+/obj/machinery/vending/donksofttoyvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"hLG" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hMd" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hMf" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hMs" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hMy" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -5393,6 +9065,19 @@
 /obj/item/reagent_containers/food/snacks/salad/jungle,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"hNu" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hNJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -5409,6 +9094,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"hPv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
+"hQn" = (
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "hRh" = (
 /obj/structure/rack,
@@ -5444,6 +9140,17 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"hSi" = (
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "hTa" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13/wood{
@@ -5454,6 +9161,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
 /area/f13/wasteland)
 "hTu" = (
@@ -5477,8 +9185,29 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerborder";
+	tag = "icon-outerborder (WEST)"
 	},
 /area/f13/wasteland)
+"hUw" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/f13/bunker)
+"hUA" = (
+/obj/structure/sign/poster/official/foam_force_ad,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"hUB" = (
+/obj/machinery/light,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "hUG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plating/tunnel{
@@ -5494,6 +9223,13 @@
 /obj/structure/sign/poster/ripped,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
+	},
+/area/f13/bunker)
+"hWb" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
 /area/f13/bunker)
 "hWJ" = (
@@ -5518,6 +9254,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
 "hYn" = (
@@ -5531,12 +9268,78 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"hZj" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"hZV" = (
+/obj/machinery/light/broken,
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"iaq" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "iaA" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"iaM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"iaZ" = (
+/obj/structure/table,
+/obj/item/wrench/power,
+/obj/item/weldingtool/experimental{
+	pixel_x = -27;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"ibj" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "suka";
+	name = "security shutters"
+	},
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"ibE" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"ibV" = (
+/obj/item/clothing/suit/toggle/lawyer,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "icA" = (
 /obj/machinery/light/sign/kebab,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5567,9 +9370,41 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"idI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/status_display/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "idP" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"idT" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ief" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"iel" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "ien" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -5579,13 +9414,36 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
 /area/f13/wasteland)
+"ieD" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 20;
+	pixel_y = 3
+	},
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "ieO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right";
+	tag = "icon-horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"ieP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "ifx" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5597,9 +9455,32 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
+"ifz" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"ifC" = (
+/obj/structure/rack,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "ifN" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ifW" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/electronic/toaster{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "igo" = (
 /obj/structure/flora/grass/wasteland{
@@ -5618,6 +9499,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"igu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"igT" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "igV" = (
 /obj/structure/chair{
 	dir = 4
@@ -5637,6 +9530,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"iiQ" = (
+/obj/structure/bodycontainer/crematorium{
+	id = 700
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "iiS" = (
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/molerat,
@@ -5661,6 +9561,26 @@
 /obj/item/reagent_containers/food/snacks/salad/desertsalad,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ikz" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ill" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/vault,
+/turf/open/water,
+/area/f13/bunker)
+"ilr" = (
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ilL" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
@@ -5693,6 +9613,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ine" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"inj" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "inP" = (
 /obj/structure/chair{
 	dir = 8
@@ -5703,6 +9634,24 @@
 "ioe" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"iow" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"ioA" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"iph" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ipi" = (
 /obj/structure/ore_box,
@@ -5733,12 +9682,14 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
 	},
 /area/f13/wasteland)
 "iqR" = (
 /obj/item/ammo_casing,
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
 "irk" = (
@@ -5748,34 +9699,111 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"irO" = (
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"irY" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/bikehorn/rubberducky,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "isf" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHEAST)"
 	},
 /area/f13/ncr)
 "isk" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4;
+	tag = "icon-tracks (EAST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"ite" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"itm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"itv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "iur" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/wasteland)
+"iuO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"ivc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"ivh" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"ivs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ivy" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"ivN" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"ivV" = (
+/obj/structure/sign/departments/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "iwI" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed";
+	tag = "icon-ruinswindowdestroyed (NORTHEAST)"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -5785,6 +9813,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ixR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "ixW" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
@@ -5793,6 +9828,7 @@
 /obj/item/ammo_casing,
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
 "izp" = (
@@ -5842,6 +9878,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "iBu" = (
@@ -5849,6 +9886,12 @@
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"iBL" = (
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "iCB" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -5925,16 +9968,49 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iFq" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/item/clothing/under/f13/vault,
+/turf/open/water,
+/area/f13/bunker)
 "iFv" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"iFz" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "iGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"iGt" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"iGy" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"iGQ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "iGW" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -5950,11 +10026,64 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
 /area/f13/ncr)
+"iJG" = (
+/obj/structure/rack,
+/obj/item/storage/box/donkpockets,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "iKc" = (
 /obj/item/candle/tribal_torch,
 /turf/open/water,
+/area/f13/bunker)
+"iKm" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"iKn" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"iLl" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"iLo" = (
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"iLD" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"iMz" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"iMJ" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "iMU" = (
 /mob/living/simple_animal/cow/brahmin,
@@ -5976,6 +10105,34 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iPf" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"iPl" = (
+/mob/living/simple_animal/hostile/jungle/leaper{
+	desc = "A massive beast that spits out highly pressurized bubbles containing a unique toxin, knocking down its prey and then crushing it with its girth.";
+	health = 500;
+	maxHealth = 500
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"iPG" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "iPY" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -5983,6 +10140,14 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"iQq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "iQt" = (
 /obj/structure/debris/v3{
@@ -5996,6 +10161,15 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"iQJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "iQK" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -6005,6 +10179,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"iQQ" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iQR" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -6018,11 +10200,24 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iRJ" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"iRK" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "iRR" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "iSk" = (
@@ -6031,6 +10226,23 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"iST" = (
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"iSX" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "iTf" = (
 /obj/structure/ore_box,
 /obj/machinery/light,
@@ -6057,12 +10269,37 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"iTU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "iUb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"iUg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"iUt" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "iUz" = (
 /obj/machinery/chem_master,
@@ -6073,20 +10310,65 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iVl" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "iVS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iWy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"iWA" = (
+/obj/machinery/vending/cola/space_up,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "iWD" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
+	tag = "icon-tree_2"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
+"iWU" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"iXm" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"iXB" = (
+/obj/machinery/button/crematorium{
+	id = 700;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "iXL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -6109,6 +10391,7 @@
 /obj/item/soap/homemade,
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
 "iZp" = (
@@ -6144,13 +10427,23 @@
 "jbc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old";
+	tag = "icon-floor6-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"jci" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "jcm" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "jcx" = (
@@ -6178,11 +10471,40 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jeb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"jej" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/bunker)
 "jeq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"jev" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"jeN" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "jfs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -6190,10 +10512,27 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jfF" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jfH" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jfI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"jga" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jgW" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer,
@@ -6223,6 +10562,25 @@
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"jio" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"jiq" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "jit" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -6237,10 +10595,44 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
+"jiI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
+"jiN" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jjN" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"jjP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "jkn" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"jks" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "jku" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /obj/structure/barricade/wooden/planks,
@@ -6291,6 +10683,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"jmK" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "jnh" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -6298,6 +10699,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jnm" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jns" = (
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
@@ -6327,6 +10733,22 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"joF" = (
+/obj/machinery/button/door{
+	id = "stalin";
+	name = "Overseer door button"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"joT" = (
+/obj/item/wallframe/button,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "joZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -6343,16 +10765,43 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
+"jpK" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 6
+	},
+/area/f13/radiation)
+"jqn" = (
+/obj/item/stack/crafting/electronicparts/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "jqq" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/wasteland)
+"jqD" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "jqP" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"jrr" = (
+/obj/machinery/door/airlock/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"jrs" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jrZ" = (
 /obj/structure/table,
 /obj/item/bodybag,
@@ -6371,6 +10820,12 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
+"jtv" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "jtF" = (
 /obj/structure/table,
 /obj/item/coin/diamond,
@@ -6392,6 +10847,13 @@
 /obj/structure/debris/v4,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"juy" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "juI" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /obj/effect/decal/cleanable/dirt,
@@ -6399,6 +10861,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"juO" = (
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "jvp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -6433,11 +10902,33 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/underground/cave)
+"jwn" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "jwo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v1,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jwM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
+"jxd" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "jxD" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -6455,6 +10946,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jyw" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "jzG" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6468,11 +10968,40 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"jzV" = (
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "jAh" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"jAk" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"jAn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"jBu" = (
+/obj/machinery/smartfridge/chemistry,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"jBx" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "jBz" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -6502,12 +11031,14 @@
 "jBR" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/legion)
 "jCo" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
 	},
 /area/f13/wasteland)
 "jCO" = (
@@ -6515,6 +11046,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jCQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "jCY" = (
 /obj/machinery/light{
@@ -6536,10 +11076,35 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"jDZ" = (
+/obj/machinery/vending/nukacolavendfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jEb" = (
+/obj/structure/rack,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"jEd" = (
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jEp" = (
 /obj/item/candle/tribal_torch,
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"jEt" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "jEY" = (
 /obj/machinery/light{
@@ -6549,16 +11114,49 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"jFA" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"jHJ" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "jHK" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"jHS" = (
+/obj/structure/table/reinforced,
+/obj/item/crafting/coffee_pot{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "jIj" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
+/area/f13/bunker)
+"jIo" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "jIE" = (
 /obj/machinery/door/poddoor{
@@ -6576,6 +11174,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"jIU" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jJS" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plating/tunnel{
@@ -6588,6 +11191,7 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
 "jKu" = (
@@ -6603,6 +11207,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jKX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"jLz" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "jLX" = (
 /obj/item/crafting/fuse,
 /obj/effect/decal/cleanable/dirt,
@@ -6613,6 +11232,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
 "jMO" = (
@@ -6627,6 +11247,16 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"jOq" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jPq" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6646,8 +11276,21 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
+"jRv" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"jRA" = (
+/obj/item/detective_scanner,
+/obj/structure/closet,
+/obj/item/clothing/under/hosparademale,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "jRE" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light{
@@ -6708,6 +11351,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jVf" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jVx" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -6715,6 +11370,12 @@
 /obj/item/card/id/prisoner/two,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"jVz" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/collectable/tophat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "jVL" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
@@ -6728,6 +11389,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
 "jWl" = (
@@ -6744,18 +11406,41 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"jXi" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "jXF" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"jYh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/crude/snow,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "jYk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"jYn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jYt" = (
 /obj/structure/chair/comfy/shuttle{
@@ -6769,6 +11454,18 @@
 /obj/structure/toilet,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"jYL" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jZf" = (
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jZj" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/wood/f13/old,
@@ -6780,6 +11477,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"jZz" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "kab" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -6799,10 +11501,51 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"kao" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"kap" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kaB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/mob/living/simple_animal/hostile/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "kbb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kbg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"kbR" = (
+/obj/machinery/door/airlock/command{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
 "kct" = (
 /obj/machinery/light{
@@ -6822,6 +11565,26 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"kcM" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner,
+/obj/machinery/light/floor,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"kdi" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kdm" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -6829,10 +11592,39 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kdq" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kdH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "kej" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"ket" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"key" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
 	},
 /area/f13/bunker)
 "keE" = (
@@ -6842,6 +11634,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"keN" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "kfe" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -6850,9 +11651,26 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kfo" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"kfF" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "kfV" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "kgd" = (
@@ -6863,6 +11681,12 @@
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kgC" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/bunker)
 "kgW" = (
 /obj/machinery/door/poddoor{
@@ -6900,6 +11724,15 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/bunker)
+"kjc" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kji" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -6913,16 +11746,40 @@
 "kkb" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old";
+	tag = "icon-floor5-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"kkk" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "klB" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"kmE" = (
+/obj/machinery/button/door{
+	id = "vaultshutters2";
+	name = "armory button";
+	pixel_x = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"kmS" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "kne" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -6960,12 +11817,23 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
+"kqc" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "kqh" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
 	},
 /turf/closed/wall/mineral/iron,
 /area/f13/legion)
+"kqQ" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "kqS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/item/clothing/gloves/ring/diamond,
@@ -6996,6 +11864,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"krY" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ksj" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "ksl" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -7011,6 +11891,7 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
 /area/f13/ncr)
 "ksA" = (
@@ -7019,6 +11900,22 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"ksK" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"kte" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ktm" = (
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7081,6 +11978,7 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/ncr)
 "kwc" = (
@@ -7094,6 +11992,7 @@
 "kwf" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -7104,9 +12003,20 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"kwG" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "kwO" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/ncr)
 "kwR" = (
@@ -7114,6 +12024,16 @@
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"kwW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "kxj" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -7124,6 +12044,12 @@
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"kyx" = (
+/obj/structure/window/plastitanium,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kyK" = (
 /turf/closed/wall/mineral/iron,
@@ -7149,6 +12075,27 @@
 /obj/item/reagent_containers/pill/patch/bitterdrink,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"kzY" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"kAO" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "kBa" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -7156,9 +12103,49 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kBl" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"kBv" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "kBJ" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kBR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/decal/remains/human,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kBW" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"kCA" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "kCN" = (
@@ -7168,6 +12155,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"kCS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_y = 32
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "kDf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -7175,6 +12179,55 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/underground/cave)
+"kEf" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/paper_bin,
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"kEn" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kFe" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"kFn" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/construction/rcd,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"kFr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"kFF" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kFI" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -7185,8 +12238,24 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
+"kFR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"kFW" = (
+/obj/machinery/button/door{
+	id = "vaultshutters";
+	name = "overseer button"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "kFX" = (
 /obj/item/ammo_casing/shotgun/rubbershot,
 /turf/open/floor/f13/wood{
@@ -7206,9 +12275,28 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"kGk" = (
+/obj/structure/closet,
+/obj/item/instrument/violin/golden,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"kGn" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "kGB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"kGH" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kGQ" = (
 /obj/item/ammo_casing/c9mm,
@@ -7226,6 +12314,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"kIk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "kIx" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -7261,6 +12357,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"kJk" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "kJx" = (
 /obj/structure/barricade/wooden{
 	max_integrity = 30;
@@ -7270,12 +12370,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kJy" = (
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "kJD" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /obj/machinery/light/floor,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"kJK" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"kJS" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "kJZ" = (
 /obj/structure/window{
 	dir = 8
@@ -7297,12 +12421,26 @@
 "kKx" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"kKF" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "kKQ" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kLr" = (
+/obj/structure/mirror,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "kLP" = (
 /turf/open/floor/f13{
@@ -7316,6 +12454,11 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"kMs" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kMS" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/green,
@@ -7332,12 +12475,31 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"kNG" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "kNL" = (
 /obj/structure/table,
 /obj/item/pda/security,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"kNV" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"kOs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "kOP" = (
@@ -7348,6 +12510,18 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"kOS" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kPa" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "kPn" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -7365,6 +12539,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"kPE" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "kPF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
 	color = null;
@@ -7379,12 +12561,26 @@
 "kQb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/followers)
+"kQv" = (
+/obj/machinery/vending/hydronutrients,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "kRA" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
 /area/f13/wasteland)
+"kRM" = (
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "kSo" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/combat/sneakboots{
@@ -7395,30 +12591,68 @@
 /obj/item/clothing/glasses/night/syndicate,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"kSO" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "kSZ" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"kTu" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kTA" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kTC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "kUp" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/f13,
 /area/f13/followers)
+"kUS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kUW" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"kVA" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "kVV" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/ncr)
 "kWd" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
+	tag = "icon-tree_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -7428,12 +12662,33 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"kWK" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "kWT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"kXn" = (
+/obj/structure/sink,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kXt" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kXD" = (
 /obj/structure/window/fulltile/house{
@@ -7453,8 +12708,12 @@
 /obj/item/kitchen/knife/butcher,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
+"kZA" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "kZI" = (
 /obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
@@ -7483,6 +12742,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"lbA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/bunker)
 "lbJ" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7492,11 +12756,24 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
 "lbQ" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"lcL" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/structure/mirelurkegg,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/bunker)
 "lcN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -7515,9 +12792,16 @@
 	icon_state = "stagestairs"
 	},
 /area/f13/followers)
+"ldB" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "lex" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbrokenvertical";
+	tag = "icon-ruinswindowbrokenvertical (NORTHEAST)"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -7568,6 +12852,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"lgk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "lgD" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -7579,6 +12870,11 @@
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lgX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/locker,
+/turf/open/water,
+/area/f13/bunker)
 "lhe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -7593,6 +12889,21 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"lhC" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"lhN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	icon_state = "rightsecure";
+	req_access_txt = "10, 11"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "lhP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -7601,10 +12912,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"lhY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "lir" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/legion)
 "lit" = (
@@ -7618,12 +12935,14 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "lki" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/ncr)
 "lkz" = (
@@ -7636,6 +12955,28 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"lkU" = (
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"lkY" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"llg" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "lly" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7657,11 +12998,35 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"lnc" = (
+/obj/structure/table,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"lnu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"lnG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
+/area/f13/bunker)
 "lnL" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "lnQ" = (
@@ -7672,6 +13037,15 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"loh" = (
+/obj/machinery/biogenerator,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "loi" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -7687,11 +13061,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"loY" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lqa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"lqf" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "lqv" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -7705,6 +13088,15 @@
 	name = "temple wall"
 	},
 /area/f13/bunker)
+"lrk" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "lrD" = (
 /obj/structure/table,
 /turf/open/floor/wood/f13/old,
@@ -7715,6 +13107,24 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
+"lrW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "lsh" = (
 /obj/structure/chair/comfy/lime{
 	dir = 1
@@ -7755,6 +13165,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
@@ -7792,6 +13203,11 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"luy" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "luG" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -7806,6 +13222,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"lvh" = (
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "lvs" = (
 /obj/machinery/door/poddoor/preopen{
@@ -7830,6 +13251,40 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"lvN" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"lvP" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"lvQ" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"lvT" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "lwh" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert,
@@ -7845,6 +13300,7 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
 /area/f13/ncr)
 "lwL" = (
@@ -7859,10 +13315,44 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"lwW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
+"lxx" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lyG" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lza" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"lzb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lzD" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "lzU" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -7885,10 +13375,12 @@
 "lAI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
 "lBe" = (
@@ -7897,6 +13389,15 @@
 /obj/item/clothing/shoes/sneakers/orange,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"lBf" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/closet/crate/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "lBC" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -7907,9 +13408,27 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"lBE" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lBN" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "lBO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"lBW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
 /area/f13/bunker)
 "lCx" = (
 /obj/structure/decoration/rag,
@@ -7932,14 +13451,41 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"lDk" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"lDP" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "lDQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"lEl" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"lEr" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "lEw" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -7948,6 +13494,21 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"lEE" = (
+/obj/structure/chair/e_chair,
+/obj/effect/mob_spawn/human/corpse/vault/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"lEF" = (
+/obj/effect/landmark/poster_spawner/prewar,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"lFy" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "lFA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -7966,6 +13527,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
 "lFS" = (
@@ -7975,6 +13537,7 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
 "lGv" = (
@@ -7992,6 +13555,17 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lHo" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"lHx" = (
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "lIb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -8019,6 +13593,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"lJv" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "lJw" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -8040,11 +13623,29 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"lLD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/securitron/sentrybot{
+	color = "#FFFF00";
+	desc = "A pre-war military robot equipped with a high-yield gatling laser and improved dual fusion cores setup to detonate in the event of the robot's destruction. This one looks armored up and powered up to an exponential degree. Oh, fuck.";
+	extra_projectiles = 5;
+	health = 3500;
+	maxHealth = 3500;
+	melee_queue_distance = 15;
+	name = "legendary sentry bot"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "lLW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"lMu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "lMw" = (
 /obj/structure/ladder/unbreakable{
 	desc = "A long march back to the camp down-river... fun...";
@@ -8057,10 +13658,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lNk" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "lNt" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "lNN" = (
@@ -8074,6 +13681,20 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"lNZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"lOg" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lOk" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -8084,8 +13705,35 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
+"lOL" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"lOU" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"lOY" = (
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"lPd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "lPk" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
@@ -8105,18 +13753,33 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lPV" = (
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "lQn" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "lQv" = (
 /obj/machinery/light/sign/kebab,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lQy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "lQJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -8126,12 +13789,26 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"lQY" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "lRh" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"lRo" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "lSd" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -8171,6 +13848,28 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"lUr" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"lUs" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lUQ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
 "lVb" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -8185,6 +13884,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"lVS" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "lWf" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/wood/f13/old,
@@ -8198,6 +13907,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"lWu" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lWU" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/megaphone/sec,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "lXy" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
@@ -8219,20 +13942,40 @@
 "lXR" = (
 /obj/structure/toilet{
 	dir = 4;
+	tag = "icon-toilet00 (EAST)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/ncr)
+"lYy" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "lZe" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
 	icon_state = "rubble";
+	tag = "icon-rubble (EAST)"
 	},
 /area/f13/ncr)
 "lZr" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"lZy" = (
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"lZJ" = (
+/obj/structure/timeddoor,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "lZM" = (
 /obj/structure/table,
@@ -8248,6 +13991,14 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"mai" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "mal" = (
 /obj/structure/chair/wood/worn{
@@ -8286,9 +14037,56 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"mbd" = (
+/obj/structure/table/glass,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"mbt" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/corner{
+	dir = 1
+	},
+/area/f13/bunker)
+"mbv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
+"mbB" = (
+/obj/structure/stacklifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"mbN" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mbP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"mca" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
 /area/f13/bunker)
 "mcj" = (
 /obj/machinery/light{
@@ -8318,9 +14116,37 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"mcJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"mcZ" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mdr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"mdw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mdG" = (
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "mep" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
@@ -8348,6 +14174,11 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"meS" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "meV" = (
 /obj/structure/chair{
 	dir = 4
@@ -8358,6 +14189,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mfb" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"mfq" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "mgb" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_tr,
@@ -8366,6 +14207,7 @@
 /obj/structure/fireplace,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
 "mig" = (
@@ -8378,6 +14220,37 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"miI" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/water,
+/area/f13/bunker)
+"mjm" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"mkM" = (
+/obj/structure/destructible/tribal_torch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mlh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/drawer,
+/turf/open/water,
+/area/f13/bunker)
 "mlw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button{
@@ -8394,23 +14267,60 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"mlT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mmd" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"mmt" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "mmG" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"mmN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "mnc" = (
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
+"mnH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "mnL" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mnS" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"moq" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "moC" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -8425,11 +14335,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"mpf" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mpp" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
 /area/f13/underground/cave)
+"mpH" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "mpM" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
@@ -8442,6 +14367,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"mqe" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "mqp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -8451,12 +14383,22 @@
 "mqE" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"mra" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "mrI" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mrM" = (
+/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "mrQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button{
@@ -8480,6 +14422,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"msF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"msZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
 /area/f13/bunker)
 "mtl" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
@@ -8510,6 +14466,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"mtH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
 "mtM" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8520,20 +14483,61 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mud" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
 "mvo" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mvq" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "mvA" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
+"mvI" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/bunker)
+"mvZ" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "mwn" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mwo" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "mwO" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -8541,11 +14545,24 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/bunker)
+"mxb" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mxq" = (
 /turf/closed/indestructible/wood{
 	desc = "A wall with wooden plating. Stiff, and knocking on it indictates that the wood is just a covering for some heavily-reinforced machinery."
 	},
 /area/f13/underground/cave)
+"mxU" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "myb" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/f13/wood{
@@ -8575,6 +14592,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"mAg" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mAl" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -8601,12 +14623,34 @@
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"mBB" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mBD" = (
 /obj/structure/fence/corner{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mBL" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/ammo_casing/c9mm,
+/obj/item/ammo_casing/c9mm,
+/obj/item/ammo_casing/c9mm,
+/obj/item/storage/fancy/heart_box,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "mBR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -8636,6 +14680,19 @@
 "mCR" = (
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
 /area/f13/wasteland)
+"mDd" = (
+/obj/effect/decal/remains/human,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"mDx" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mDF" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
@@ -8652,6 +14709,14 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker)
+"mEa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "mEI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -8665,6 +14730,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"mEQ" = (
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "mFp" = (
 /obj/structure/chair/wood{
@@ -8694,6 +14762,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mGJ" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"mGM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "mHn" = (
 /obj/structure/debris/v4{
 	pixel_x = -10;
@@ -8714,11 +14793,27 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mHE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "mHH" = (
 /obj/effect/turf_decal/loading_area/white,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"mHU" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"mIl" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "mIo" = (
 /obj/structure/table/reinforced,
@@ -8727,12 +14822,48 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mIR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"mJk" = (
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"mJC" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mJU" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mKv" = (
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"mKZ" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mLb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/flask/survival,
+/turf/open/water,
 /area/f13/bunker)
 "mLd" = (
 /obj/machinery/light/small{
@@ -8741,6 +14872,32 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"mLo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"mLN" = (
+/obj/structure/table,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"mMg" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"mNc" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mNp" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -8764,12 +14921,19 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "mNU" = (
 /obj/structure/debris/v3,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"mPk" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mQi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -8786,15 +14950,18 @@
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA";
+	tag = "icon-sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown";
+	tag = "icon-sheetbrown"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetblue";
+	tag = "icon-sheetblue"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -8802,11 +14969,23 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"mQU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/turf/open/water,
+/area/f13/bunker)
 "mRc" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mRK" = (
+/obj/structure/table/glass,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "mRW" = (
 /obj/effect/decal/remains/human,
@@ -8840,10 +15019,21 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mST" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "mSV" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mTp" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck/syndicate,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "mTv" = (
 /obj/structure/flora/junglebush/c,
@@ -8852,11 +15042,16 @@
 "mTB" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/legion)
+"mTF" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "mUs" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "mUu" = (
@@ -8864,6 +15059,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mUB" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"mVr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "mVs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8884,10 +15090,25 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"mWd" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "mWv" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mWB" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mXh" = (
 /obj/structure/closet/bus,
 /obj/structure/ladder/unbreakable{
@@ -8930,6 +15151,28 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"mYz" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"mYR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"mYW" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "mZy" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -8938,6 +15181,13 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"mZS" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nat" = (
 /obj/effect/decal/cleanable/robot_debris/old{
 	icon_state = "gib5"
@@ -8970,11 +15220,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar";
+	tag = "icon-rubblepillar"
 	},
 /area/f13/wasteland)
+"nci" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nck" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"ncs" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "ncz" = (
 /obj/effect/decal/cleanable/blood,
@@ -8990,18 +15253,99 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ncB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "ndi" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ndo" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"ndQ" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ndU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"neu" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/f13/bunker)
 "neE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"neI" = (
+/obj/item/soap,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"neM" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/broken,
+/obj/structure/flora/junglebush/b,
+/obj/structure/mirelurkegg,
+/mob/living/simple_animal/hostile/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"nfW" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"ngx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"ngS" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"ngY" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
 /area/f13/bunker)
 "nha" = (
 /obj/structure/ladder/unbreakable{
@@ -9016,6 +15360,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -9027,16 +15372,77 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"nhw" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "nif" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"nim" = (
+/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"niB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"niF" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"niL" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/compact/combat,
+/obj/item/stock_parts/cell/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"niR" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "niU" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"nja" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/dresser,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "nkX" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -9044,6 +15450,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"nlK" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "nma" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -9079,6 +15491,11 @@
 "nmQ" = (
 /turf/closed/indestructible/wood,
 /area/f13/city)
+"nnz" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "nnF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9087,6 +15504,23 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"nnY" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"nof" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "noR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9111,6 +15545,24 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"npl" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"npu" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nqo" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -9136,6 +15588,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"nra" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "nrc" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/structure/table,
@@ -9153,11 +15612,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"nrG" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/bunker)
+"nrH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "nrK" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"nrR" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "nsh" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
@@ -9168,6 +15648,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"nsH" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "ntG" = (
 /obj/effect/turf_decal{
@@ -9189,6 +15674,27 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nuf" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
+"nup" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"nus" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "nux" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -9209,10 +15715,30 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nvy" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"nvM" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "nvZ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"nwe" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
 "nwg" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/f13/old,
@@ -9253,6 +15779,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"nyp" = (
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"nyN" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nyV" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -9270,14 +15810,46 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
 	},
 /area/f13/wasteland)
+"nAg" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nAr" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
 	},
 /area/f13/wasteland)
+"nAW" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"nBf" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"nBJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "nBS" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/light,
@@ -9298,6 +15870,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"nCk" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nCm" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
@@ -9306,6 +15884,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"nCM" = (
+/obj/structure/table,
+/obj/item/crafting/board,
+/obj/item/crafting/board,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nDb" = (
 /obj/machinery/light{
 	dir = 1;
@@ -9313,10 +15898,38 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
+"nDt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
+"nDx" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 14
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"nDy" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"nDQ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/remains/human,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "nED" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"nEF" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "nFl" = (
 /obj/structure/rack,
@@ -9340,18 +15953,62 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"nFZ" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nGs" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
+"nHP" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nIh" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
+"nIw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
+"nIQ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"nJr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
+"nJs" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -9362,6 +16019,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"nKO" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "nLF" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -9370,11 +16035,13 @@
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "nMx" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar";
+	tag = "icon-rubblepillar"
 	},
 /area/f13/ncr)
 "nMG" = (
@@ -9396,6 +16063,26 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"nMU" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"nNh" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "nNv" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/carpet/green,
@@ -9406,12 +16093,23 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"nNV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "nOq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
+"nOJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "nOK" = (
 /obj/structure/rack,
 /obj/item/stack/medical/gauze/cyborg,
@@ -9433,6 +16131,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4;
+	tag = "icon-tracks (EAST)"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -9445,6 +16144,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"nSC" = (
+/obj/machinery/button/door{
+	id = "stalin";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "nSW" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13/wood,
@@ -9467,19 +16173,79 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nUy" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"nUM" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nVa" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/obj/item/clothing/suit/f13/mfp/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nVq" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "nVX" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"nWt" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "nWv" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"nWz" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"nWS" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nXK" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nYg" = (
+/obj/structure/table/reinforced,
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/water,
+/area/f13/bunker)
 "nYi" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -9493,6 +16259,18 @@
 	icon_state = "mattress2"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"nYA" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "nZl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9512,6 +16290,7 @@
 "nZK" = (
 /obj/structure/toilet{
 	dir = 4;
+	tag = "icon-toilet00 (EAST)"
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
@@ -9581,6 +16360,14 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"oeC" = (
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "oeT" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -9613,10 +16400,20 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"ohq" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc1";
+	name = "Cell 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "ohr" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
 "ohu" = (
@@ -9634,16 +16431,46 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ohS" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oih" = (
 /obj/item/flag/ncr,
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oil" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"ois" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "oiD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "oiE" = (
@@ -9676,6 +16503,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"okg" = (
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "oks" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -9706,10 +16542,28 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"okF" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "okY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ola" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "olH" = (
 /obj/machinery/doorButtons/vaultButton,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -9738,12 +16592,31 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground,
 /area/f13/wasteland)
+"onO" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "onX" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"ool" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oom" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oov" = (
 /obj/item/ammo_casing/c9mm,
 /obj/machinery/door/poddoor{
@@ -9751,6 +16624,26 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"ooO" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"opV" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"oqz" = (
+/obj/structure/sign/poster/official/do_not_question,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "oqP" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/f13{
@@ -9767,10 +16660,17 @@
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ork" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "orG" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "orS" = (
@@ -9788,6 +16688,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/bunker)
+"osk" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "osu" = (
 /obj/effect/turf_decal{
 	dir = 6
@@ -9795,6 +16700,45 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"osv" = (
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "rubblepillar"
+	},
+/area/f13/bunker)
+"osI" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"osM" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"osS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
+"otm" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "otN" = (
 /obj/structure/chair/f13chair1{
@@ -9816,6 +16760,11 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"ouP" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "ovl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -9831,10 +16780,62 @@
 /obj/item/paper,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"ovP" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"ovU" = (
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"owf" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"owC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/water,
+/area/f13/bunker)
 "oxt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"oxF" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
+"oye" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"oyu" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Vault1"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "oyK" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -9853,11 +16854,13 @@
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "ozL" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken";
+	tag = "icon-ruinswindowbroken (NORTHEAST)"
 	},
 /obj/structure/curtain{
 	color = "#845f58"
@@ -9892,6 +16895,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"oCy" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oCD" = (
 /obj/machinery/light{
 	dir = 1
@@ -9914,11 +16923,67 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"oDU" = (
+/obj/item/wallframe/button,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "oDW" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oEB" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"oES" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "oET" = (
 /obj/structure/chair/bench,
@@ -9928,6 +16993,21 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oFE" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/guides/jobs/engi/solars{
+	info = "<h1>Welcome</h1><p>At Vault-Tec, your survival is our number one priority, enclosed within is a notice on your Casp System.</p><p>Thank you for joining in Vault-Tec's mandatory testing of the brand new C.A.S.P. system! The CASP, or Computerized Auto-Synthesis Protofabricator, is a new high tech design using a simple 'points' system to create anything you need! Simply feed the requested high priority items orany day to day crates and metals to synthesize points.</p><p>That's all there is to it!</p>";
+	name = "paper- 'Your very first C.A.S.P. system!'"
+	},
+/obj/item/stamp/qm,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"oFR" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/bunker)
 "oGm" = (
 /obj/machinery/light{
@@ -9944,6 +17024,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"oGS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"oHa" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"oHw" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"oIw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/human/core,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/bunker)
 "oIQ" = (
 /obj/machinery/door/airlock/hatch{
@@ -9975,6 +17084,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"oJr" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oJH" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -9982,6 +17096,24 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oKo" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"oKr" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "oKy" = (
@@ -10002,6 +17134,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"oLz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "oLN" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -10017,6 +17156,24 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"oLU" = (
+/obj/item/storage/wallet/random,
+/obj/structure/table,
+/obj/item/crafting/wonderglue,
+/obj/item/coin/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"oMC" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "oMF" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -10070,6 +17227,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"oMV" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "oNj" = (
 /obj/structure/mirror,
 /obj/effect/decal/cleanable/dirt,
@@ -10085,14 +17250,36 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
+"oOB" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "oOD" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"oOI" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "oPl" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -10104,6 +17291,19 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"oPz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"oPE" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oPI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -10121,9 +17321,33 @@
 "oQq" = (
 /obj/structure/fence{
 	dir = 4;
+	tag = "icon-metal_fence3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oQD" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oRg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "oRr" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -10139,8 +17363,16 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/wasteland)
+"oRW" = (
+/obj/structure/window/plastitanium,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "oSe" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -10152,6 +17384,58 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"oSg" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"oSo" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oSr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"oSx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/bunker)
+"oTX" = (
+/obj/structure/sign/departments/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"oUa" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"oUc" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/structure/toilet,
+/obj/item/seeds/apple/gold,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "oUE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10177,6 +17461,9 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"oUX" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "oVd" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck{
@@ -10189,6 +17476,26 @@
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"oVr" = (
+/obj/structure/table,
+/obj/item/stamp/hos,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/figure/hos,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"oVJ" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"oVK" = (
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "oVO" = (
 /obj/structure/chair,
@@ -10220,6 +17527,28 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"oXm" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oXy" = (
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"oXC" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "oXI" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
@@ -10236,11 +17565,23 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "oXY" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"oYe" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oYL" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "oZo" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -10249,6 +17590,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"oZx" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oZP" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -10296,6 +17643,28 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"paF" = (
+/obj/structure/table/reinforced,
+/obj/item/electropack/shockcollar/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"paT" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"pbd" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pbx" = (
 /obj/item/ammo_box/magazine/m762/empty,
 /obj/effect/decal/cleanable/dirt,
@@ -10312,10 +17681,39 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pcj" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "pck" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pco" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pcr" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pcM" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "pcO" = (
 /obj/machinery/light{
@@ -10327,8 +17725,29 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
+"pdv" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/item/bodypart/l_arm/monkey,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "pez" = (
 /obj/structure/chair{
 	dir = 4
@@ -10353,6 +17772,16 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"pfs" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "pfx" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10361,15 +17790,41 @@
 /obj/effect/landmark/poster_spawner/ncr,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
+"pfV" = (
+/obj/machinery/button/door{
+	id = "meat";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"pgc" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/nest/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "pgv" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"pgM" = (
+/obj/machinery/vending/coffee{
+	pixel_y = 1
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "phh" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "phB" = (
@@ -10380,6 +17835,7 @@
 "phP" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -10419,6 +17875,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"pjf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"pjh" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pjm" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -10433,6 +17897,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"pjB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "pjT" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10443,11 +17912,24 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/bunker)
+"pkb" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "pkU" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pkW" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "plc" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -10455,6 +17937,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"pll" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "plm" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -10475,6 +17964,34 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"plX" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "vaultshutters";
+	max_integrity = 999999999999;
+	resistance_flags = 242
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"pmr" = (
+/obj/item/storage/toolbox/electrical,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"pms" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "pmQ" = (
 /obj/effect/decal/fakelattice,
@@ -10511,12 +18028,27 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"poL" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "ppb" = (
 /obj/structure/urinal{
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ppc" = (
+/obj/structure/bed/dogbed,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "ppg" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -10563,9 +18095,54 @@
 /obj/machinery/light,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"pqH" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc2";
+	name = "Cell 2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"prO" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"prS" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "psd" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
+"psz" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"psQ" = (
+/obj/structure/chair/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ptN" = (
+/obj/machinery/camera/autoname{
+	dir = 9;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "pup" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/security,
@@ -10573,10 +18150,30 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"pvk" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "pvG" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"pvQ" = (
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"pvX" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "pwd" = (
 /obj/structure/rack,
 /obj/machinery/light,
@@ -10585,12 +18182,41 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"pxm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"pxB" = (
+/obj/machinery/door_timer{
+	id = "vaultc1";
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"pxG" = (
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pxQ" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pyu" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"pyU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "pzh" = (
 /obj/structure/rack,
@@ -10628,6 +18254,13 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pzO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pBl" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -10651,6 +18284,35 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pCH" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"pCM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"pCY" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pDi" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pDu" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -10658,10 +18320,22 @@
 "pDE" = (
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
+"pDI" = (
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "pDP" = (
 /obj/item/soap,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"pEb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/scorpion,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "pEc" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -10670,6 +18344,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/bunker)
+"pEi" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "pEQ" = (
@@ -10682,6 +18362,14 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pFz" = (
+/obj/structure/kitchenspike,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "pGc" = (
 /obj/machinery/light{
 	dir = 8
@@ -10699,16 +18387,33 @@
 /obj/item/flag/bos,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"pGO" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "pHl" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"pHv" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pHw" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"pHO" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pII" = (
 /obj/item/soap/deluxe,
 /obj/effect/decal/cleanable/dirt,
@@ -10721,17 +18426,52 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"pJj" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
 "pJp" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"pJG" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"pJI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "pKe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pKg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "pKj" = (
 /obj/structure/closet/crate/bin{
 	name = "trash-point"
@@ -10739,6 +18479,14 @@
 /obj/item/crafting/reloader,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pKM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "pLe" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -10803,6 +18551,13 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"pOl" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "pOm" = (
 /turf/open/floor/f13{
 	icon_state = "purplefull"
@@ -10840,6 +18595,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"pQa" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pQo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -10857,6 +18619,11 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"pRe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "pRW" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -10864,6 +18631,18 @@
 /obj/item/target/alien,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pSm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
 "pSu" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -10900,6 +18679,19 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
 /area/f13/bunker)
+"pTg" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"pTl" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "pTK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10916,10 +18708,24 @@
 /mob/living/simple_animal/hostile/handy/robobrain,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"pUz" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "pUI" = (
 /obj/structure/fireaxecabinet,
 /turf/closed/indestructible/wood,
 /area/f13/city)
+"pUV" = (
+/obj/structure/timeddoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "pVg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -10930,11 +18736,29 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pWn" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "pWp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pWr" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
 /area/f13/bunker)
 "pWt" = (
 /obj/structure/table,
@@ -10944,11 +18768,30 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"pWx" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pWy" = (
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "pWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"pXD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "pYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10975,6 +18818,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/ncr)
 "pZu" = (
@@ -11002,6 +18846,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
 /area/f13/wasteland)
 "qbS" = (
@@ -11054,6 +18899,32 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"qdz" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
+"qeq" = (
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"qeW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor{
+	id = 103;
+	name = "Vault Blastdoor 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "qfH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -11140,6 +19011,10 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"qiW" = (
+/obj/structure/debris/v3,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "qjv" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
@@ -11148,6 +19023,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"qkl" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "qkZ" = (
 /obj/effect/landmark/poster_spawner/prewar,
@@ -11162,6 +19044,11 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"qlX" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "qlZ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11175,6 +19062,20 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qmp" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"qmO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qnc" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -11185,6 +19086,11 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"qnw" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "qnF" = (
 /obj/structure/flora/grass/wasteland{
@@ -11209,6 +19115,7 @@
 "qos" = (
 /obj/structure/chair{
 	dir = 8;
+	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -11217,12 +19124,35 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"qoC" = (
+/obj/structure/sign/poster/contraband/have_a_puff,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"qoU" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qpl" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qpH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/f13/bunker)
 "qqa" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11231,8 +19161,25 @@
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
+"qqd" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"qqg" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "qql" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -11257,6 +19204,14 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qqF" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/neck/apron/chef,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "qqP" = (
 /obj/structure/table/wood/settler,
 /obj/item/lock,
@@ -11272,6 +19227,14 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"qrq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
 "qrP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -11296,6 +19259,35 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qtE" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"qtF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/f13/bunker)
+"qtP" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "qtS" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/tentwall,
@@ -11304,6 +19296,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "qvi" = (
@@ -11326,12 +19319,28 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "qvE" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"qwo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"qww" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "qwQ" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11374,12 +19383,28 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qzG" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "qzL" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
+/area/f13/bunker)
+"qzQ" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "qzT" = (
 /obj/machinery/light/small{
@@ -11390,9 +19415,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qzV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "qAk" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -11403,6 +19434,14 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
+/area/f13/bunker)
+"qAv" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "qAC" = (
 /turf/closed/wall/f13/wood,
@@ -11457,6 +19496,13 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"qCM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qDm" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -11483,8 +19529,18 @@
 "qDX" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
 	},
 /area/f13/legion)
+"qEA" = (
+/obj/structure/table,
+/obj/item/kitchen/knife{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "qEN" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -11506,8 +19562,16 @@
 /obj/item/shard,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/legion)
+"qFY" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qGv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11519,6 +19583,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "qGS" = (
@@ -11539,6 +19604,22 @@
 "qHr" = (
 /obj/item/trash/f13/cram_large,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"qIb" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"qIk" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "qIK" = (
 /obj/machinery/light,
@@ -11562,6 +19643,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"qJw" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "qJF" = (
 /obj/effect/turf_decal/arrows,
 /obj/effect/decal/cleanable/dirt,
@@ -11573,6 +19658,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"qKx" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "qKz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11586,6 +19679,13 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"qKG" = (
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "qKV" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -11617,10 +19717,16 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"qMs" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qMB" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "qMQ" = (
@@ -11632,8 +19738,14 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
 	},
 /area/f13/wasteland)
+"qNA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
 "qOo" = (
 /obj/structure/statue/sandstone/gravestone,
 /turf/open/indestructible/ground/outside/desert,
@@ -11641,6 +19753,11 @@
 "qOQ" = (
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"qOT" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "qOX" = (
 /obj/structure/nest/securitron{
@@ -11656,17 +19773,58 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"qPl" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"qPt" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"qPF" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "qPN" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"qTb" = (
+/obj/structure/table/reinforced,
+/obj/item/cautery,
+/obj/item/hemostat,
+/obj/item/retractor,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "qTX" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
+"qUa" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "qUi" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing/corner{
@@ -11683,6 +19841,12 @@
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qVd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "qVq" = (
 /obj/structure/rack,
 /obj/item/paper/crumpled/bloody/docsdeathnote{
@@ -11700,6 +19864,20 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"qVT" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "qWe" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -11717,15 +19895,23 @@
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA";
+	tag = "icon-sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qYC" = (
+/obj/structure/glowshroom/single,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "qYU" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/f13/wood,
@@ -11742,9 +19928,39 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qZV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"rah" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"rar" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "raL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/bunker)
+"rbK" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
 "rbT" = (
@@ -11764,6 +19980,7 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "rcu" = (
@@ -11784,6 +20001,23 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"rcM" = (
+/obj/structure/table,
+/obj/item/crafting/resistor,
+/obj/item/crafting/resistor,
+/obj/item/crafting/resistor,
+/obj/item/crafting/buzzer,
+/obj/item/crafting/capacitor,
+/obj/item/crafting/capacitor,
+/obj/item/crafting/diode,
+/obj/item/crafting/diode,
+/obj/item/crafting/diode,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rcW" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/f13/store,
@@ -11798,12 +20032,25 @@
 "rdA" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/legion)
+"rdI" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "rdL" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"ree" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "reI" = (
 /obj/structure/table,
@@ -11817,6 +20064,7 @@
 "reZ" = (
 /obj/structure/toilet{
 	dir = 4;
+	tag = "icon-toilet00 (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -11873,6 +20121,26 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rgY" = (
+/obj/structure/flora/rock/pile/largejungle,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"rgZ" = (
+/obj/machinery/door_timer{
+	id = "vaultc2";
+	pixel_y = 32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "rhc" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bed/mattress/pregame,
@@ -11892,6 +20160,10 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"rhW" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rim" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11901,12 +20173,20 @@
 "riz" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
 	},
 /area/f13/wasteland)
+"riR" = (
+/obj/machinery/light/broken,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "riZ" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
 	icon_state = "rubble";
+	tag = "icon-rubble (EAST)"
 	},
 /area/f13/wasteland)
 "rjm" = (
@@ -11929,6 +20209,22 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"rkb" = (
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"rki" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "rkn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11942,6 +20238,13 @@
 	},
 /turf/open/water,
 /area/f13/underground/cave)
+"rls" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "rlS" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -11957,9 +20260,27 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/legion)
+"rmM" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rni" = (
 /obj/item/soap/homemade,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"rnw" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "roj" = (
 /obj/structure/table,
@@ -11993,11 +20314,35 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"roE" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"roI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "roT" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"rpm" = (
+/obj/structure/debris/v3{
+	pixel_y = -10
+	},
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rpF" = (
 /obj/structure/dresser,
 /turf/open/floor/f13{
@@ -12012,6 +20357,7 @@
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark";
+	tag = "icon-redmark (SOUTHWEST)"
 	},
 /area/f13/legion)
 "rpO" = (
@@ -12020,6 +20366,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"rpW" = (
+/obj/structure/table,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rqh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -12047,6 +20403,23 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
+/area/f13/bunker)
+"rqT" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"rqY" = (
+/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask,
+/obj/structure/rack,
+/obj/item/stack/crafting/electronicparts/three,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "rri" = (
 /turf/open/water,
@@ -12085,6 +20458,28 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"rtO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/effect/mob_spawn/human/corpse/vault,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"rtT" = (
+/obj/structure/table,
+/obj/item/storage/book/bible{
+	pixel_y = 2
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/soap{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "rtW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12092,11 +20487,23 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"rue" = (
+/obj/structure/table/booth,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "rui" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"ruj" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "ruq" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/supermart,
@@ -12137,6 +20544,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/water,
 /area/f13/underground/cave)
+"rvx" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rvF" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/wood/f13/old,
@@ -12151,6 +20562,16 @@
 "rwB" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/bunker)
+"rwU" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rwX" = (
 /obj/structure/rack,
 /obj/item/clothing/under/syndicate/combat,
@@ -12161,6 +20582,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rxq" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "rxs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12176,6 +20605,23 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rxN" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"ryb" = (
+/obj/structure/bed/mattress,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rym" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
@@ -12191,12 +20637,53 @@
 "rzu" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"rzE" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"rzR" = (
+/obj/structure/toilet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rzV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"rAt" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rAx" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"rBi" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"rBq" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rBw" = (
 /obj/item/ammo_casing/a762,
@@ -12213,6 +20700,7 @@
 "rBF" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/wasteland)
 "rBI" = (
@@ -12230,6 +20718,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"rBW" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rCn" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12248,14 +20750,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"rDz" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "rDD" = (
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 16;
+	tag = "icon-sink (NORTH)"
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "rDE" = (
@@ -12292,14 +20804,30 @@
 "rGc" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken";
+	tag = "icon-ruinswindowbroken (NORTHEAST)"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rGB" = (
+/obj/structure/table,
+/obj/item/crafting/duct_tape,
+/obj/item/crafting/duct_tape,
+/obj/item/crafting/lunchbox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rGG" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"rGN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "rHr" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12310,9 +20838,30 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
+"rHF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "rHH" = (
 /obj/structure/stone_tile/center/cracked,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"rHJ" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"rId" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "rIo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12334,6 +20883,14 @@
 /obj/item/target/alien,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rIZ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "rJi" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/water,
@@ -12344,6 +20901,12 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"rJO" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "rKj" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light{
@@ -12352,6 +20915,11 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rKu" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "rLw" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/vault{
@@ -12363,6 +20931,7 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "rMd" = (
@@ -12372,6 +20941,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"rMq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "meat";
+	name = "Meat Storage"
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "rMr" = (
 /obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/salad/oatmeal,
@@ -12382,6 +20960,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab";
+	tag = "icon-rubbleslab"
 	},
 /area/f13/ncr)
 "rNh" = (
@@ -12399,11 +20978,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"rOj" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "rOn" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rPc" = (
+/obj/structure/sign/poster/official/obey,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"rPq" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"rPw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rPD" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -12413,10 +21019,18 @@
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"rQa" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "rQc" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
 /area/f13/wasteland)
 "rQl" = (
@@ -12426,6 +21040,12 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"rQq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rQD" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -12438,6 +21058,15 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"rRf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/caution{
+	dir = 9
+	},
+/area/f13/radiation)
 "rRw" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/vault{
@@ -12451,6 +21080,7 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "rRN" = (
@@ -12463,6 +21093,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
 "rSo" = (
@@ -12476,6 +21107,7 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "rSx" = (
@@ -12499,11 +21131,46 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rSZ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"rTr" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "rTw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/ncr)
+"rUg" = (
+/obj/structure/sign/poster/official/science{
+	pixel_y = 32
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"rUs" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"rUv" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rUC" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12515,6 +21182,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rUM" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rUP" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -12522,6 +21198,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"rVe" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"rVg" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "rVh" = (
 /obj/effect/decal/riverbank,
 /turf/open/water,
@@ -12530,6 +21220,29 @@
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"rVF" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/medspray{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/medspray{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/chem_grenade/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "rVH" = (
 /obj/structure/nest/protectron{
@@ -12541,6 +21254,7 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate";
+	tag = "icon-rubbleplate"
 	},
 /area/f13/wasteland)
 "rWt" = (
@@ -12564,6 +21278,12 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"rXp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "rXv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12577,6 +21297,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"rYI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rYL" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -12588,6 +21314,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"rYY" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "rZh" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -12596,6 +21329,41 @@
 "rZx" = (
 /obj/structure/sign/poster/prewar/poster82,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"saK" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"saP" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"saS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"sbx" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "sbC" = (
 /obj/effect/decal/cleanable/dirt{
@@ -12617,12 +21385,29 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"sbY" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "scf" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
+	tag = "icon-skulls"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
+"sch" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "scI" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -12632,16 +21417,52 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
+"scU" = (
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"scW" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"sdg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sdj" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"sdp" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sdv" = (
 /obj/item/ammo_casing/shotgun/rubbershot,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"sdw" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sdJ" = (
 /obj/structure/simple_door/house,
 /turf/closed/mineral/random/low_chance,
@@ -12669,6 +21490,13 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"seT" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "sfn" = (
 /obj/structure/sink{
 	dir = 8;
@@ -12717,6 +21545,17 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"siq" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "sir" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/vault{
@@ -12756,6 +21595,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"sjz" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "skB" = (
 /obj/machinery/shower{
 	dir = 1
@@ -12777,18 +21653,47 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"slc" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "slq" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"slv" = (
+/obj/structure/sign/departments/custodian,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"slF" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "slU" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"smn" = (
+/obj/structure/sign/departments/botany,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"smG" = (
+/obj/effect/decal/cleanable/molten_object/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "smN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
@@ -12801,6 +21706,7 @@
 "sne" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
+	tag = "icon-tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -12818,6 +21724,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"soJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "overseerexit";
+	name = "overseer button"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"spj" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "sqf" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -12828,6 +21748,21 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"sqz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"sqE" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "sqO" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
@@ -12845,11 +21780,25 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sqZ" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "ssJ" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"sti" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"stD" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "stO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -12875,6 +21824,15 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"suC" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/seedling{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
 /area/f13/bunker)
 "svf" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -12914,13 +21872,74 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"swr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "swv" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"swJ" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "sxd" = (
 /obj/item/trash/f13/cram,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sxf" = (
+/obj/structure/sign/poster/official/build{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
+"sxm" = (
+/obj/machinery/door/airlock,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"sxq" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"sxx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/closed/indestructible/fakedoor{
+	name = "Impassable Airlock"
+	},
+/area/f13/bunker)
+"syA" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"syB" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "szp" = (
 /obj/structure/wreck/trash/machinepile,
@@ -12931,12 +21950,29 @@
 "szC" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/wasteland)
+"sAu" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "sAQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"sBt" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "sBA" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12953,15 +21989,27 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"sCq" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "sCV" = (
 /obj/structure/closet,
 /obj/item/mop{
 	icon_state = "mopbucket";
+	tag = "icon-mopbucket"
 	},
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"sDc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "sDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/protectron{
@@ -12969,6 +22017,29 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/bunker)
+"sDA" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"sDY" = (
+/obj/machinery/door/airlock{
+	name = "Vault 223 Janitorial storage"
+	},
+/obj/structure/timeddoor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sEn" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
 /area/f13/bunker)
 "sEC" = (
@@ -12988,6 +22059,7 @@
 /obj/structure/window/reinforced{
 	dir = 1;
 	icon_state = "twindowold";
+	tag = "icon-twindowold (NORTH)"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
@@ -13007,6 +22079,27 @@
 /obj/item/defibrillator,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"sFw" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"sGf" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"sGt" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "sHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13018,6 +22111,11 @@
 /obj/structure/chair/bench,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"sIv" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "sIC" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
@@ -13026,6 +22124,12 @@
 "sJn" = (
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
+"sJu" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "sJy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13060,6 +22164,10 @@
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"sMh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "sMj" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /obj/item/stack/sheet/mineral/sandbags,
@@ -13071,10 +22179,50 @@
 /obj/item/flag/oasis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"sMB" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
+"sMD" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "sMO" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"sMS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sMX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "sNh" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -13089,10 +22237,23 @@
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"sOI" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "sPi" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/r_wall/rust,
 /area/f13/underground/cave)
+"sPm" = (
+/obj/item/folder/blue,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "trap";
+	name = "Old Dusty Button"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sPs" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -13115,6 +22276,38 @@
 /obj/item/clothing/under/pants/black,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"sPS" = (
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"sQi" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"sQp" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "sQs" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -13172,14 +22365,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/f13/underground/cave)
+"sTf" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"sTw" = (
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "sTM" = (
 /obj/structure/table,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"sTS" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "sTT" = (
 /obj/structure/chair/bench,
 /obj/item/soap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"sUx" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "sUy" = (
 /obj/structure/chair/office/dark,
@@ -13194,6 +22414,15 @@
 /obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"sUN" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "sUU" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
@@ -13206,6 +22435,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"sVN" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"sWc" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"sWS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
 "sXf" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
@@ -13216,6 +22475,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
 	},
 /area/f13/wasteland)
 "sXW" = (
@@ -13226,8 +22486,20 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
+"sYD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"sYF" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "sZI" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13240,6 +22512,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"taY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tbM" = (
+/obj/machinery/light,
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "tcd" = (
 /obj/structure/chair/bench,
@@ -13255,6 +22541,13 @@
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"tcI" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "tdc" = (
 /obj/structure/chair/bench,
 /obj/machinery/light/small{
@@ -13262,6 +22555,14 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"tdm" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tdJ" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -13269,12 +22570,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"ted" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "teX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"tff" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tfu" = (
 /obj/structure/spider/stickyweb,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -13291,6 +22605,22 @@
 /obj/item/flag/ncr,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"tfF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "overseerloot"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"tgh" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "thb" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/candle/infinite{
@@ -13326,6 +22656,34 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"tjj" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"tjn" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"tju" = (
+/obj/structure/sign/barsign,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"tjI" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tjO" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
@@ -13334,6 +22692,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHWEST)"
 	},
 /area/f13/wasteland)
 "tjZ" = (
@@ -13386,6 +22745,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"tms" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "tmG" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
@@ -13414,6 +22778,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"tox" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "toC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -13434,6 +22804,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"tqK" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tqN" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13447,6 +22828,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"tra" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "trz" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13454,10 +22843,20 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"trA" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "trL" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"trS" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "trX" = (
 /obj/machinery/light{
 	dir = 1
@@ -13469,8 +22868,21 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"tsb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush/b,
+/turf/open/water,
+/area/f13/bunker)
+"tsl" = (
+/obj/structure/sign/departments/medbay,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "tsJ" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
@@ -13492,6 +22904,35 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ttW" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"tug" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
+"tus" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"tuw" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "tvF" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -13503,6 +22944,7 @@
 "two" = (
 /obj/structure/simple_door/room{
 	icon_state = "glass";
+	tag = "icon-glass"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
@@ -13526,9 +22968,41 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"tyt" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tyy" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"tyC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "tyO" = (
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"tzb" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tzc" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt{
@@ -13559,14 +23033,45 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"tAP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"tBp" = (
+/obj/structure/timeddoor,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "tCf" = (
 /obj/structure/stone_tile/block,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"tCD" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "tDi" = (
 /obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"tDq" = (
+/obj/structure/table/booth,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "tDK" = (
 /obj/effect/decal/remains/human,
@@ -13586,6 +23091,21 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"tEc" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/bunker)
+"tFR" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "tFY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -13595,6 +23115,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"tGs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"tGt" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "tHp" = (
 /obj/structure/table/wood/settler,
@@ -13606,8 +23139,14 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
+"tHF" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tHP" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
@@ -13617,6 +23156,16 @@
 /area/f13/bunker)
 "tHQ" = (
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"tHW" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "tIn" = (
 /obj/item/ammo_casing/c9mm,
@@ -13652,8 +23201,24 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"tJZ" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"tKf" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tKq" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -13674,6 +23239,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"tLf" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "tMi" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -13704,6 +23276,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"tNG" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "tNR" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13711,12 +23290,57 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tNX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"tOH" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"tOQ" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"tPg" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tPu" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"tPC" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "meat";
+	name = "Meat Storage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tPK" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"tPS" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tQv" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/desert,
@@ -13727,6 +23351,24 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"tRJ" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"tSa" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "tSh" = (
 /obj/structure/simple_door/house{
 	icon_state = "roomopening"
@@ -13736,10 +23378,12 @@
 "tSi" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
 "tSp" = (
@@ -13780,6 +23424,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"tUq" = (
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "tUH" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -13791,6 +23440,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"tUK" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "tUL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -13818,6 +23473,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"tWy" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tWI" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -13834,11 +23496,23 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"tXF" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "tXS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2";
+	tag = "icon-horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
+"tYp" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tZn" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -13851,12 +23525,27 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
+"tZv" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "tZG" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"tZZ" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "ual" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -13886,10 +23575,88 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"udC" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"udF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"udL" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uec" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "uel" = (
 /obj/structure/table,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ueq" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"uev" = (
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"ueJ" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"ueR" = (
+/obj/structure/table/reinforced,
+/obj/item/scalpel,
+/obj/item/surgical_drapes,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"ufD" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "uhP" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -13897,6 +23664,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "uhU" = (
@@ -13925,12 +23693,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uie" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "uiv" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "ujb" = (
@@ -13946,12 +23722,54 @@
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ujs" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"ujv" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Crematorium"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ujR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ujT" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"ujU" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"ujW" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"ukY" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ulp" = (
 /obj/structure/chair/bench,
 /turf/open/floor/holofloor/carpet,
@@ -13964,8 +23782,23 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
+"umS" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"unb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "unv" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13987,6 +23820,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"uoi" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "uoN" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -14009,6 +23846,26 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"upA" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/f13/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/structure/window/reinforced,
+/obj/item/grenade/chem_grenade/teargas,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/item/grenade/flashbang,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "uqg" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/legion)
@@ -14022,6 +23879,16 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"uqS" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uqU" = (
+/obj/machinery/light/broken,
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uro" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -14033,10 +23900,32 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"usV" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"usW" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "usZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"utr" = (
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "rubblepillar"
 	},
 /area/f13/bunker)
 "utv" = (
@@ -14090,6 +23979,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"uvZ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "uwh" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -14099,6 +23999,29 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"uwA" = (
+/obj/structure/timeddoor,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
+"uxC" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"uym" = (
+/obj/structure/table,
+/obj/item/pizzabox/mushroom{
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "uyw" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
@@ -14111,6 +24034,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"uyM" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "uyP" = (
 /obj/structure/table,
 /obj/item/trash/chips,
@@ -14119,12 +24047,66 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uzr" = (
+/obj/structure/table/reinforced,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uzA" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "uzL" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
+"uzQ" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = 102;
+	name = "Window Shutters"
+	},
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"uAl" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
+"uAp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "uAt" = (
 /obj/machinery/door/poddoor{
 	id = "lock3";
@@ -14140,6 +24122,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
 "uAv" = (
@@ -14147,6 +24130,7 @@
 /obj/structure/sink/kitchen{
 	dir = 4;
 	pixel_x = -15;
+	tag = "icon-sink_alt (EAST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -14176,8 +24160,14 @@
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
 /area/f13/wasteland)
+"uCI" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "uDi" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -14188,6 +24178,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"uDj" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "uDk" = (
 /obj/item/ammo_casing/a762,
 /turf/open/floor/pod/dark,
@@ -14202,13 +24201,41 @@
 "uEo" = (
 /turf/open/water,
 /area/f13/bunker)
+"uEt" = (
+/obj/structure/flora/ausbushes/palebush{
+	pixel_x = 9
+	},
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = 20
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = -3
+	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "uEv" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
+"uEG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "uES" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -14218,12 +24245,21 @@
 "uFe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder";
+	tag = "icon-outerborder"
 	},
 /area/f13/wasteland)
 "uFm" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"uFL" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
+"uFM" = (
+/obj/item/bodypart/l_leg/monkey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "uFW" = (
 /obj/structure/closet/wardrobe,
@@ -14234,6 +24270,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"uGb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"uGc" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 23;
+	pixel_y = -1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"uGv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "uGE" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -14241,6 +24295,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"uHf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "uHC" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -14273,6 +24334,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"uIO" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uJu" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -14288,6 +24356,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"uJX" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "uKs" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -14304,6 +24387,20 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"uKL" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"uLb" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uLK" = (
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14313,6 +24410,18 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"uMq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "uMG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -14326,6 +24435,11 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"uNq" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "uNI" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -14367,6 +24481,7 @@
 "uSh" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /obj/item/paper/crumpled{
 	desc = "Ran out food and had to hit Lyin' Todd's hideout, Lucky for us his whole crew was out and only left a couple kids that nearly shit themselves when we showed up, One kept whining something about a guy named Fat Man, aint never heard of him but hes welcome to come down and donate to the meat supply.";
@@ -14374,8 +24489,20 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
+"uSq" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "uSx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14383,6 +24510,11 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"uSF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "uSH" = (
 /obj/structure/closet{
 	name = "implants locker"
@@ -14407,6 +24539,13 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uTP" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "uUs" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -14466,6 +24605,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"uXA" = (
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uXJ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/decal/cleanable/dirt,
@@ -14480,10 +24624,57 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uYn" = (
+/obj/structure/easel,
+/obj/item/paper/pamphlet/ruin/originalcontent/yelling,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uYo" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uYu" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"uYN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"uYU" = (
+/obj/structure/table,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"uZA" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/effect/decal/remains/human,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"uZG" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "uZO" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -14491,6 +24682,14 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"uZR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "uZZ" = (
 /obj/machinery/light/small,
@@ -14516,6 +24715,25 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vba" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vbf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
+"vbr" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
 "vbv" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -14525,11 +24743,59 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/underground/cave)
+"vbV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "vdq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"vdE" = (
+/obj/structure/window/reinforced/spawner,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"vdR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/bunker)
+"vdT" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/storage/crayons,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"vdW" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "veh" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
@@ -14567,6 +24833,7 @@
 "vgM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
 /area/f13/wasteland)
 "vhE" = (
@@ -14590,12 +24857,24 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"viy" = (
+/obj/structure/chair/wood,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"viz" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "viF" = (
 /obj/structure/reagent_dispensers/compostbin,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubble";
+	tag = "icon-rubble (WEST)"
 	},
 /area/f13/wasteland)
 "viO" = (
@@ -14616,6 +24895,7 @@
 /obj/item/ammo_casing,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/legion)
 "vjR" = (
@@ -14647,6 +24927,12 @@
 /obj/effect/decal/waste,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"vmi" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "vmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -14670,6 +24956,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vnn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "vnr" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -14681,8 +24972,16 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
+"vnG" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "vor" = (
 /obj/item/flag/legion,
 /obj/structure/obstacle/barbedwire,
@@ -14717,6 +25016,12 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
 /area/f13/wasteland)
+"vpn" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "vpI" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -14751,6 +25056,17 @@
 /obj/structure/car/rubbish4,
 /turf/open/water,
 /area/f13/wasteland)
+"vrF" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"vrI" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "vrL" = (
 /obj/structure/flora/tree/cactus,
 /obj/structure/barricade/sandbags,
@@ -14759,6 +25075,12 @@
 "vrV" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"vst" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "vsB" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -14776,10 +25098,17 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"vtl" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "vtp" = (
 /obj/structure/chair/stool{
 	dir = 1;
 	icon_state = "bench";
+	tag = "icon-bench (NORTH)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -14798,6 +25127,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/underground/cave)
+"vtV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "vuk" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -14834,6 +25170,21 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"vuS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"vuX" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "vvv" = (
 /obj/structure/ladder/unbreakable{
@@ -14898,10 +25249,34 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"vyD" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vyK" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/bunker)
+"vyQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"vzw" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
 /area/f13/bunker)
 "vAk" = (
@@ -14911,19 +25286,57 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"vAv" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/structure/closet/crate/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "vAA" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
 	},
 /area/f13/wasteland)
 "vBc" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/wasteland)
+"vBw" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "vBy" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"vBR" = (
+/obj/structure/barricade/wooden/strong,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"vCG" = (
+/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"vCL" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"vDU" = (
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "vDV" = (
 /obj/structure/table,
@@ -14947,6 +25360,25 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vGb" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vGl" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "vGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14969,6 +25401,16 @@
 "vHC" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"vIj" = (
+/obj/structure/sign/poster/prewar/protectron,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "vIm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -14980,27 +25422,60 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "vIM" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA";
+	tag = "icon-sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheethos";
+	tag = "icon-sheethos"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"vIN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "vJb" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vJG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/seedling{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
+"vJV" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vKu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"vKO" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vKV" = (
 /turf/closed/indestructible/rock,
 /area/f13/city)
@@ -15009,6 +25484,19 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"vLr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"vLT" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vLX" = (
 /obj/structure/chair/stool/bar,
@@ -15026,13 +25514,52 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"vMA" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"vNn" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"vNs" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vNz" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "vOv" = (
 /obj/machinery/computer/robotics,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"vOw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vOG" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/city)
+"vPq" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vQV" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/indestructible/vaultdoor,
@@ -15042,9 +25569,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"vSi" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
+"vST" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"vTx" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "vTX" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"vUd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "vUl" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -15057,6 +25605,7 @@
 "vUY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "vVG" = (
@@ -15064,6 +25613,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "vWA" = (
@@ -15075,6 +25625,11 @@
 "vWV" = (
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"vYD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vYK" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -15100,6 +25655,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"vYS" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "vZf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -15111,11 +25672,19 @@
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/f13/supermart,
 /area/f13/bunker)
+"vZB" = (
+/obj/structure/sign/departments/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "vZV" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/legion)
 "waj" = (
@@ -15134,6 +25703,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"waN" = (
+/obj/machinery/camera/autoname{
+	dir = 9;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
 "wbu" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -15150,6 +25729,22 @@
 	},
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"wcm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"wdk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
 "wdl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -15157,6 +25752,17 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wdv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "wdw" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/brown,
@@ -15179,6 +25785,12 @@
 "wef" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/city)
+"wem" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wep" = (
 /obj/structure/fence{
 	dir = 8
@@ -15186,10 +25798,29 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "wex" = (
 /turf/closed/indestructible/rock,
+/area/f13/bunker)
+"weB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"weL" = (
+/obj/structure/sign/departments/examroom,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"wfk" = (
+/obj/structure/sign/poster/prewar/corporate_espionage,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/bunker)
 "wfM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -15206,10 +25837,28 @@
 /obj/item/ammo_box/magazine/m762/ext,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wgU" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wha" = (
 /obj/structure/chalkboard,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"whf" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"whL" = (
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/bunker)
 "wip" = (
 /obj/structure/closet,
@@ -15225,17 +25874,49 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/bunker)
+"wjP" = (
+/obj/machinery/door/window/brigdoor{
+	icon_state = "rightsecure";
+	req_access_txt = "31"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution,
+/area/f13/radiation)
 "wke" = (
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 15;
+	tag = "icon-sink (NORTH)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"wkp" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "wkP" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"wkS" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"wlc" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wlO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -15248,6 +25929,14 @@
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ncr)
+"wmu" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "wmD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
@@ -15257,6 +25946,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"wmT" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"woI" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "woL" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
@@ -15293,6 +25994,15 @@
 /obj/structure/chalkboard,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"wqA" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "wqO" = (
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
@@ -15304,6 +26014,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"wrC" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"wrS" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "wrY" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -15313,6 +26041,13 @@
 "wsE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wsI" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "wtb" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -15336,8 +26071,13 @@
 "wtF" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubble";
+	tag = "icon-rubble"
 	},
 /area/f13/wasteland)
+"wtQ" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wtZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -15345,12 +26085,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"wua" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "wus" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "wuw" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"wvu" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "wvy" = (
 /obj/structure/table/wood/settler,
@@ -15363,6 +26120,16 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
+"wvX" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wwf" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "wws" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
@@ -15376,8 +26143,14 @@
 "wxU" = (
 /turf/open/floor/f13{
 	icon_state = "purplefull";
+	tag = "icon-purplefull"
 	},
 /area/f13/legion)
+"wyI" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wyM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/desert,
@@ -15391,8 +26164,14 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
 	icon_state = "rubble";
+	tag = "icon-rubble (SOUTHWEST)"
 	},
 /area/f13/ncr)
+"wzb" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "wzm" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
@@ -15416,17 +26195,52 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"wAt" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/storage/box/syringes,
+/obj/structure/closet,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
+/obj/item/fermichem/pHmeter,
+/obj/item/fermichem/pHmeter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "wAv" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wAN" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "wCh" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wDI" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"wDS" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "wEk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15443,6 +26257,17 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wFi" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 6
+	},
+/area/f13/bunker)
 "wFC" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -15493,6 +26318,7 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "wGu" = (
@@ -15500,8 +26326,54 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
 	},
 /area/f13/wasteland)
+"wGC" = (
+/obj/machinery/door/airlock/freezer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"wHe" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wHL" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"wHQ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wHW" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_y = -3
+	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/genericbush{
+	pixel_x = -17
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "wIo" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -15521,6 +26393,11 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"wJu" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "wJM" = (
 /obj/structure/fence{
 	dir = 4
@@ -15529,6 +26406,26 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"wJT" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "wJZ" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15538,12 +26435,78 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"wKh" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "wKz" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wKO" = (
+/obj/structure/table,
+/obj/item/stamp/captain{
+	name = "overseer's rubber stamp";
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain/captain{
+	desc = "It's an expensive Oak fountain pen, engraved with the numbers 113. The nib is quite sharp.";
+	name = "overseer's fountain pen";
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"wLg" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"wLt" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution,
+/area/f13/radiation)
+"wLL" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"wMz" = (
+/obj/item/clothing/head/welding,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"wNi" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wNj" = (
 /obj/structure/car/rubbish2,
 /obj/structure/tires/two,
@@ -15560,6 +26523,22 @@
 /obj/structure/stone_tile/burnt,
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"wOn" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"wOC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "wPz" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -15588,6 +26567,13 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"wQQ" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "wRF" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/dirt,
@@ -15599,12 +26585,31 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"wSn" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "wSI" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wSZ" = (
+/obj/structure/flora/junglebush/b,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"wTK" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "wUa" = (
 /obj/effect/decal/riverbank{
@@ -15624,6 +26629,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "wUu" = (
@@ -15650,6 +26656,31 @@
 /obj/machinery/light,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"wVP" = (
+/obj/item/stack/sheet/glass/ten,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"wVW" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/multitool/uplink,
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"wWn" = (
+/obj/structure/frame/machine,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "wWq" = (
 /obj/structure/barricade/bars,
 /obj/effect/spawner/structure/window/reinforced,
@@ -15668,20 +26699,63 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"wWR" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wWU" = (
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
+/area/f13/bunker)
 "wXi" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wXr" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "wXE" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"wYf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"wYM" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/syndieminibomb/concussion/frag,
+/obj/item/grenade/syndieminibomb/concussion/frag,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"wZI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "wZS" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("bonnie")
@@ -15719,8 +26793,20 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
+"xcc" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"xcH" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "xdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -15730,10 +26816,27 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xdr" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"xdu" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "xdH" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"xdL" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "xdM" = (
 /turf/open/floor/f13{
@@ -15756,6 +26859,17 @@
 /obj/item/seeds/tower,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xfm" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "xfn" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -15797,6 +26911,24 @@
 "xiC" = (
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xjs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"xjJ" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"xjL" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "xkT" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
@@ -15804,12 +26936,14 @@
 "xle" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "xlu" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
 	icon_state = "sheetUSA";
+	tag = "icon-sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
@@ -15830,6 +26964,13 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xmg" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "xmi" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -15840,6 +26981,19 @@
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xmY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"xnc" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "xnL" = (
 /obj/structure/rack,
@@ -15863,16 +27017,72 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"xom" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xoF" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"xoL" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"xoY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "xpf" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"xpg" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "xps" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xpz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"xpA" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "xpJ" = (
 /obj/structure/simple_door/room,
@@ -15885,6 +27095,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"xpP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"xpR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/water,
+/area/f13/bunker)
 "xqd" = (
 /obj/effect/decal/riverbank,
 /obj/effect/decal/riverbank{
@@ -15892,11 +27114,39 @@
 	},
 /turf/open/water,
 /area/f13/underground/cave)
+"xqz" = (
+/obj/structure/barricade/wooden/planks,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "xqE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xre" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/crafting/abraxo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
+"xrl" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"xrn" = (
+/obj/structure/sign/departments/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "xrD" = (
 /obj/structure/bookcase/manuals/medical,
@@ -15913,6 +27163,19 @@
 /obj/effect/landmark/poster_spawner/ncr,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
+"xtq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"xtt" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "xtB" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 1
@@ -15936,18 +27199,63 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xuq" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/destructible/tribal_torch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xuH" = (
 /obj/effect/decal/riverbank{
 	dir = 4
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"xuW" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"xvj" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"xwm" = (
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "xwv" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"xww" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "xwF" = (
 /obj/effect/decal/remains/human,
 /turf/closed/indestructible/rock,
@@ -15970,6 +27278,7 @@
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "xxw" = (
@@ -15979,9 +27288,32 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"xxJ" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/timeddoor,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"xyD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "xzK" = (
 /turf/open/floor/plating/f13,
 /area/f13/followers)
+"xzU" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/vaultdoor{
+	icon_state = "open";
+	name = "busted vault door"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xAd" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -15991,6 +27323,11 @@
 "xAq" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ncr)
+"xAz" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "xAX" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -16027,14 +27364,48 @@
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"xCA" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex/nitrile{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/hooded/surgical{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"xCC" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "xCN" = (
 /obj/item/ammo_box/c9mm,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"xDM" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "xDP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xEr" = (
+/obj/item/crafting/reloader,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "xEZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16049,8 +27420,19 @@
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark";
+	tag = "icon-redmark (SOUTHWEST)"
 	},
 /area/f13/ncr)
+"xFo" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "xFY" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/desert,
@@ -16058,11 +27440,17 @@
 "xGD" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
 /area/f13/wasteland)
 "xGO" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"xGP" = (
+/mob/living/simple_animal/hostile/mirelurk/baby,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "xGU" = (
 /turf/open/floor/wood/f13/old,
@@ -16077,6 +27465,27 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"xHE" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"xHF" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "xHO" = (
 /obj/item/toy/cards/singlecard/cas,
 /turf/open/floor/f13/wood{
@@ -16087,11 +27496,27 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"xIm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "xIs" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xIx" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "xIW" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -16136,6 +27561,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xLz" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/machinery,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "xLL" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing{
@@ -16143,6 +27574,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"xLR" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "xMf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -16151,8 +27587,16 @@
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTHEAST)"
 	},
 /area/f13/wasteland)
+"xMS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xNc" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -16160,6 +27604,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"xNP" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xNR" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -16179,6 +27628,7 @@
 "xOr" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
 /area/f13/wasteland)
 "xOB" = (
@@ -16213,16 +27663,36 @@
 /obj/item/book/manual/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"xPT" = (
+/obj/machinery/light/broken,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "xPV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xQc" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "xQf" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"xQn" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "xQr" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -16233,12 +27703,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"xRC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "xRY" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
+"xSg" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "xSo" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -16253,12 +27747,46 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
+"xSO" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "xST" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"xTO" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8;
+	flicker_chance = 20;
+	light_color = "#e8eaff"
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"xUk" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"xUE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "xUL" = (
 /obj/structure/window/spawner,
@@ -16293,6 +27821,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"xXe" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
 "xXh" = (
 /obj/structure/table/glass,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -16300,11 +27840,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"xXn" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"xXR" = (
+/obj/structure/debris/v3{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "xYg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xYw" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "xZk" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
@@ -16317,6 +27881,11 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xZM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "xZS" = (
 /obj/machinery/light{
 	dir = 4
@@ -16331,10 +27900,18 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"yao" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "yaP" = (
 /obj/structure/chair/stool{
 	dir = 4;
 	icon_state = "bench";
+	tag = "icon-bench (EAST)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -16352,14 +27929,38 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"ybP" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/water,
+/area/f13/bunker)
 "ybQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"ybU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"ybW" = (
+/obj/structure/rack,
+/obj/item/grenade/empgrenade,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ycb" = (
 /obj/structure/table,
@@ -16391,6 +27992,26 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ydC" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ydV" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/bunker)
 "ydZ" = (
 /obj/structure/table/glass,
@@ -16447,6 +28068,7 @@
 "yfI" = (
 /obj/structure/toilet{
 	dir = 1;
+	tag = "icon-toilet00 (NORTH)"
 	},
 /obj/machinery/light/small,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
@@ -16468,6 +28090,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
 	},
 /area/f13/wasteland)
 "ygU" = (
@@ -16502,6 +28125,10 @@
 "yhU" = (
 /turf/closed/wall/mineral/iron,
 /area/f13/underground/cave)
+"yiC" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "yiE" = (
 /obj/effect/landmark/map_load_mark/dungeons/north,
 /turf/closed/indestructible/rock,
@@ -16519,21 +28146,46 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner"
 	},
 /area/f13/wasteland)
 "ykl" = (
 /obj/structure/chair/stool{
 	dir = 9;
 	icon_state = "bench_center";
+	tag = "icon-bench_center (NORTHWEST)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
 	},
 /area/f13/ncr)
+"ykm" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"yks" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ykL" = (
 /obj/structure/chair/stool{
 	dir = 8;
 	icon_state = "bench";
+	tag = "icon-bench (WEST)"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -16558,6 +28210,12 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"yma" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/bunker)
 "ymg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -16571,6 +28229,7 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+
 (1,1,1) = {"
 heT
 heT
@@ -16836,39 +28495,39 @@ iTE
 iTE
 iTE
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -17093,39 +28752,39 @@ uRG
 uRG
 iTE
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -17350,39 +29009,39 @@ dSY
 uRG
 iTE
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -17607,39 +29266,39 @@ uRG
 uRG
 iTE
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -17864,39 +29523,39 @@ iTE
 iTE
 iTE
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -18121,39 +29780,39 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -18372,47 +30031,47 @@ heT
 "}
 (8,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 awR
 aOa
@@ -18629,47 +30288,47 @@ heT
 "}
 (9,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 ato
 ato
@@ -18886,47 +30545,47 @@ heT
 "}
 (10,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -19143,47 +30802,47 @@ heT
 "}
 (11,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -19400,47 +31059,47 @@ heT
 "}
 (12,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -19657,24 +31316,17 @@ heT
 "}
 (13,1,1) = {"
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -19695,9 +31347,16 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -19917,14 +31576,14 @@ heT
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 dcB
 dcB
@@ -19945,6 +31604,8 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -19952,9 +31613,7 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
 heT
 heT
 heT
@@ -20209,9 +31868,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -20466,9 +32125,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -20723,9 +32382,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -20980,9 +32639,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -21237,9 +32896,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -21494,9 +33153,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -21751,9 +33410,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -22008,9 +33667,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -22265,9 +33924,9 @@ heT
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -22522,9 +34181,9 @@ bsL
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 vHC
@@ -22779,9 +34438,9 @@ bsL
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 aPg
@@ -23036,9 +34695,9 @@ fAG
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 aVG
@@ -23293,9 +34952,9 @@ dcB
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 bam
@@ -23550,9 +35209,9 @@ dcB
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 acN
@@ -23807,9 +35466,9 @@ dcB
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 bcg
@@ -24064,9 +35723,9 @@ heT
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 azm
 ben
@@ -24321,9 +35980,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 bgc
@@ -24578,9 +36237,9 @@ heT
 bYA
 bYA
 heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 vHC
@@ -24835,9 +36494,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 bhn
@@ -25092,9 +36751,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 aVG
@@ -25349,9 +37008,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 bjJ
@@ -25606,9 +37265,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 vHC
 vHC
@@ -25863,9 +37522,9 @@ heT
 heT
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -26120,9 +37779,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -26377,9 +38036,9 @@ heT
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -26634,9 +38293,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -26891,9 +38550,9 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -27147,10 +38806,10 @@ bYA
 bYA
 bYA
 bYA
-wxj
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -27405,7 +39064,7 @@ bYA
 bYA
 bYA
 bYA
-heT
+bYA
 heT
 heT
 heT
@@ -27662,7 +39321,7 @@ bYA
 bYA
 bYA
 bYA
-heT
+bYA
 heT
 heT
 heT
@@ -27919,7 +39578,7 @@ bYA
 bYA
 bYA
 bYA
-heT
+bYA
 heT
 heT
 heT
@@ -28176,7 +39835,7 @@ wxj
 wxj
 wxj
 bYA
-heT
+bYA
 heT
 heT
 heT
@@ -28433,7 +40092,7 @@ wxj
 wxj
 wxj
 bYA
-heT
+bYA
 heT
 heT
 aiq
@@ -28690,7 +40349,7 @@ wxj
 wxj
 wxj
 bYA
-heT
+bYA
 heT
 vHC
 acN
@@ -28947,7 +40606,7 @@ wxj
 wxj
 wxj
 bYA
-heT
+bYA
 heT
 acN
 vHC
@@ -29204,7 +40863,7 @@ bYA
 bYA
 bYA
 bYA
-heT
+bYA
 heT
 acN
 acN
@@ -29453,14 +41112,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 acN
@@ -29710,14 +41369,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 acN
@@ -29967,14 +41626,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 acN
@@ -30224,14 +41883,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 vHC
@@ -30481,14 +42140,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -30735,17 +42394,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -30992,17 +42651,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -31249,17 +42908,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -31506,17 +43165,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -31763,17 +43422,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -32020,17 +43679,17 @@ wxj
 wxj
 wxj
 wxj
-wxj
-wxj
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -32280,14 +43939,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -32537,14 +44196,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -32794,14 +44453,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -33051,14 +44710,14 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -33294,6 +44953,12 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -33308,14 +44973,8 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
 heT
 heT
 heT
@@ -33551,6 +45210,12 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -33565,14 +45230,8 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
 heT
 heT
 heT
@@ -33808,6 +45467,12 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -33822,14 +45487,8 @@ bYA
 bYA
 bYA
 bYA
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
 heT
 heT
 heT
@@ -34051,42 +45710,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -34308,42 +45967,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -34565,42 +46224,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -34822,42 +46481,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -35079,42 +46738,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -35336,42 +46995,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -35593,42 +47252,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -35850,42 +47509,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -36107,42 +47766,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -36364,42 +48023,42 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -36621,40 +48280,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -36878,40 +48537,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -37135,40 +48794,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -37392,40 +49051,40 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -37651,37 +49310,37 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -37908,37 +49567,37 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -38165,37 +49824,37 @@ heT
 heT
 heT
 heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
-heT
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
+bYA
 heT
 heT
 heT
@@ -41773,13 +53432,13 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -42020,23 +53679,23 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -42277,23 +53936,23 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -42534,23 +54193,23 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -42801,13 +54460,13 @@ bYA
 bYA
 bYA
 bYA
-bYA
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -43058,13 +54717,13 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -43315,13 +54974,13 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -43565,20 +55224,20 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -43825,17 +55484,17 @@ wxj
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -44082,17 +55741,17 @@ bYA
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -44336,20 +55995,20 @@ bYA
 bYA
 bYA
 bYA
-bYA
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 wxj
@@ -44593,20 +56252,20 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 wxj
 wxj
@@ -44850,19 +56509,19 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 wxj
 wxj
 bYA
@@ -45107,20 +56766,20 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
 wxj
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 wxj
 bYA
 bYA
@@ -45364,20 +57023,20 @@ wxj
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -45622,19 +57281,19 @@ wxj
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -45879,27 +57538,27 @@ bYA
 wxj
 wxj
 wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 heT
 heT
@@ -46149,14 +57808,14 @@ wxj
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 heT
 heT
@@ -46406,14 +58065,14 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 heT
 heT
@@ -46663,14 +58322,14 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -46920,14 +58579,14 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -47177,14 +58836,14 @@ bTS
 bRI
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -47434,14 +59093,14 @@ ujj
 bRI
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -47696,9 +59355,9 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -47953,9 +59612,9 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -48210,9 +59869,9 @@ wxj
 wxj
 bYA
 bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -48465,11 +60124,11 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -48722,11 +60381,11 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -48979,11 +60638,11 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -49236,11 +60895,11 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -49493,11 +61152,11 @@ bRI
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -49750,11 +61409,11 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 heT
@@ -50007,10 +61666,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 wxj
 bYA
 bYA
@@ -50255,17 +61914,17 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
 wxj
 wxj
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -50512,17 +62171,17 @@ bYA
 wxj
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 wxj
 wxj
 wxj
-bYA
-bYA
 wxj
-wxj
-bYA
-bYA
 bYA
 bYA
 bYA
@@ -50769,17 +62428,17 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 wxj
 wxj
 wxj
-bYA
-bYA
 wxj
-wxj
-bYA
-bYA
 bYA
 bYA
 bYA
@@ -51035,8 +62694,8 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -51292,8 +62951,8 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -51549,8 +63208,8 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -51806,8 +63465,8 @@ bYA
 bYA
 wxj
 wxj
-bYA
-bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -52045,8 +63704,8 @@ bYA
 wxj
 wxj
 wxj
-bYA
-bYA
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -52300,10 +63959,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -52557,10 +64216,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
 wxj
-bYA
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -52814,10 +64473,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -53071,10 +64730,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 wPz
@@ -53328,10 +64987,10 @@ wxj
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 ipi
 kIJ
@@ -53585,10 +65244,10 @@ wxj
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 iqx
 wPz
@@ -57194,10 +68853,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -57451,10 +69110,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -57708,10 +69367,10 @@ bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -57956,19 +69615,19 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -58213,19 +69872,19 @@ bYA
 bYA
 bYA
 bYA
-bYA
+wxj
+wxj
+wxj
 wxj
 bYA
 bYA
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -58470,19 +70129,19 @@ bYA
 bYA
 bYA
 bYA
+wxj
+wxj
+wxj
+wxj
+wxj
+bYA
+bYA
 bYA
 bYA
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
-bYA
+wxj
 bYA
 bYA
 wxj
@@ -58736,10 +70395,10 @@ wxj
 bYA
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 wxj
 wxj
@@ -58993,10 +70652,10 @@ wxj
 wxj
 bYA
 bYA
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 bYA
 bYA
@@ -59250,10 +70909,10 @@ bYA
 wxj
 wxj
 wxj
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 wxj
 wxj
@@ -59507,10 +71166,10 @@ bYA
 bYA
 bYA
 wxj
-bYA
-bYA
-bYA
-bYA
+wxj
+wxj
+wxj
+wxj
 bYA
 wxj
 wxj
@@ -81850,6 +93509,24421 @@ bsh
 heT
 "}
 (255,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(256,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(257,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(258,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hhR
+sAu
+tZv
+oAl
+oAl
+oAl
+yiC
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(259,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gfn
+gfn
+sYF
+cbH
+ldB
+oAl
+bMk
+gga
+dPD
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(260,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gfn
+gfn
+igT
+uGb
+uGb
+uSF
+gNm
+cbH
+vTx
+yiC
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(261,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gfn
+gfn
+gfn
+gfn
+gfn
+lvT
+cbH
+mYz
+gNm
+wcm
+qnw
+oAl
+oAl
+heT
+heT
+kZA
+kZA
+cRr
+kRM
+dhC
+iPG
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(262,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gfn
+gfn
+gfn
+gfn
+fPQ
+gga
+gNS
+cbH
+gga
+rHF
+sDA
+oAl
+oAl
+oAl
+kZA
+rVe
+tyn
+hAw
+tWy
+siS
+pDi
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(263,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gfn
+gfn
+wex
+pyu
+yiC
+yiC
+gga
+oAl
+xoF
+uGb
+gYP
+qUa
+bvF
+fDk
+aOa
+ilr
+siS
+lRo
+pDi
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(264,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+nwe
+lUQ
+oAl
+oAl
+oAl
+oAl
+oAl
+heT
+kZA
+xIx
+dlW
+rYI
+siS
+huk
+bkI
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(265,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+kZA
+hcg
+azE
+pfV
+bLr
+kZA
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(266,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+heT
+heT
+heT
+heT
+wex
+kZA
+kZA
+nSC
+vBR
+oAl
+wex
+wex
+wex
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(267,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+wXr
+mnH
+wex
+blz
+wex
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(268,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+oAl
+oAl
+oAl
+whf
+qwo
+qwo
+qwo
+saS
+niB
+oAl
+oAl
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(269,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+fsQ
+acN
+acN
+fsQ
+acN
+fsQ
+acN
+acN
+acN
+fsQ
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+fyQ
+foL
+aVd
+oAl
+bug
+vtV
+tHW
+geb
+sEn
+bIx
+eJO
+pjf
+vDU
+wMz
+nhw
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(270,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+jjP
+ujU
+ddL
+jAk
+ddL
+ujU
+jjP
+jAk
+jjP
+ddL
+jjP
+suC
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+nhw
+kWK
+xjJ
+kOs
+whf
+aIo
+dHN
+qPF
+vdE
+bIx
+kOs
+whf
+xYw
+eJO
+enP
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(271,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+jjP
+owC
+sUN
+ddL
+ebC
+gDI
+coB
+iMz
+jjP
+jjP
+jjP
+jjP
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+lBf
+bjG
+whf
+kOs
+whf
+uYN
+mGJ
+vAv
+bit
+fRq
+whf
+kOs
+kOs
+xfm
+mqe
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(272,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+fsQ
+jjP
+ddL
+ddL
+uDj
+ddL
+jjP
+ddL
+ujU
+jjP
+jzV
+iMz
+jAk
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+nhw
+iMJ
+kOs
+kOs
+kOs
+bMu
+vrF
+qPF
+aSu
+xRC
+xjJ
+kOs
+whf
+whf
+eJO
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(273,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+jjP
+ddL
+ddL
+xpz
+fme
+jjP
+jjP
+jjP
+xpz
+fFf
+ddL
+jjP
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+aOa
+aOa
+whf
+chu
+kOs
+okg
+ooO
+oEB
+sjz
+bIx
+xyD
+ekr
+nhw
+aaR
+eJO
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(274,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+fsQ
+bCa
+ujU
+egR
+ujU
+xpz
+iPl
+jjP
+jjP
+ujU
+elq
+ddL
+hIX
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cnd
+vbV
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+dns
+chu
+chu
+chu
+lHx
+bJu
+mLo
+jCQ
+jAn
+kOs
+whf
+oAl
+oAl
+oAl
+oAl
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(275,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+jjP
+jjP
+rgY
+ddL
+jjP
+xpz
+hMs
+ujU
+jjP
+ddL
+ddL
+ddL
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+vbV
+vbV
+mbv
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+cdh
+cdh
+cdh
+mDd
+fXT
+bJu
+wrC
+kOs
+tRJ
+fNE
+oAl
+heT
+oAl
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(276,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+hQn
+kwW
+pJI
+acN
+euc
+jjP
+jjP
+jjP
+grM
+ebC
+xpz
+jeN
+iMz
+ddL
+jjP
+oRg
+acN
+mnS
+mYR
+mYR
+mYR
+hLt
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+vbV
+eVp
+cnd
+vbV
+mbv
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+poL
+kZA
+poL
+poL
+poL
+kZA
+oAl
+heT
+heT
+heT
+kZA
+mST
+kZA
+oAl
+heT
+kZA
+kZA
+niF
+bJu
+kZA
+heT
+heT
+heT
+heT
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(277,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+lgk
+oXy
+lgk
+acN
+acN
+ddL
+jjP
+jjP
+fFf
+wSZ
+jjP
+bCa
+jjP
+jAk
+ujU
+acN
+acN
+lkU
+mYR
+mYR
+mYR
+bDe
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+vbV
+vbV
+vbV
+vbV
+cap
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+kXt
+wlc
+wHQ
+fmB
+mDx
+iph
+oAl
+oAl
+heT
+kZA
+nDQ
+chu
+lDP
+vst
+heT
+heT
+heT
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(278,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+xpR
+abO
+abO
+acN
+acN
+ujU
+jjP
+ddL
+jjP
+jzV
+jzV
+ujU
+wSZ
+jjP
+ujU
+acN
+hUA
+mYR
+mYR
+aqL
+mYR
+qPl
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+xNP
+lzD
+cap
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+diE
+kfo
+ccE
+xpA
+pQa
+vyD
+dzB
+eSY
+vPq
+oAl
+heT
+kZA
+bkZ
+chu
+chu
+kBW
+chu
+chu
+oAl
+heT
+heT
+oAl
+oAl
+oAl
+oAl
+qJw
+heT
+oAl
+oAl
+oAl
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(279,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+iow
+jjP
+nsH
+eCb
+jjP
+acN
+wSZ
+ujU
+ujU
+bCa
+egR
+ujU
+xpz
+jjP
+ujU
+ddL
+acN
+acN
+xEr
+mYR
+mYR
+mYR
+ago
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+diE
+poL
+oCy
+vPq
+kUS
+xMS
+mpf
+dUV
+kap
+oAl
+heT
+kZA
+hne
+dns
+oSg
+fEc
+pDI
+chu
+chu
+ief
+kBW
+cwo
+ueR
+wLL
+qTb
+qJw
+cnM
+uYU
+oAl
+oYL
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(280,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+kFW
+jzV
+jjP
+enq
+eCb
+gDI
+xpR
+jjP
+jAk
+ddL
+ujU
+jjP
+jjP
+ujU
+ujU
+gDI
+euc
+acN
+acN
+mBL
+eNy
+mYR
+mYR
+mYR
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+sxq
+poL
+gcN
+fnE
+dii
+vPq
+kap
+kUS
+vPq
+ruj
+oAl
+heT
+ndo
+oAl
+oAl
+oAl
+chu
+chu
+chu
+rkb
+lDP
+fFa
+epl
+hnz
+epl
+qJw
+gCq
+cFu
+kKF
+dQv
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(281,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+kFR
+vJG
+wSZ
+kEf
+oFE
+jjP
+czn
+wSZ
+jjP
+ujU
+euc
+ujU
+ujU
+ujU
+jjP
+iMz
+wSZ
+acN
+acN
+dFd
+mYR
+jqn
+mYR
+iLo
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+diE
+kZA
+egB
+fRI
+ted
+vPq
+vPq
+dyl
+mPk
+bPr
+oAl
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+dlW
+aOa
+chu
+oMC
+epl
+vpn
+pJG
+eOE
+uZG
+epl
+bCX
+gUQ
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(282,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+kFR
+mtH
+mtH
+wSZ
+ddL
+sWS
+wSZ
+jjP
+ujU
+ddL
+btI
+xpz
+ddL
+pJj
+ddL
+jjP
+ddL
+acN
+acN
+dSQ
+mYR
+iLo
+wzb
+mYR
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+iQJ
+kZA
+poL
+poL
+tPC
+tPC
+tPC
+poL
+qMQ
+poL
+poL
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+oAl
+qww
+ack
+evO
+eOE
+fPZ
+eOE
+eOE
+eOE
+bnM
+kZA
+rah
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(283,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kFR
+ddL
+euc
+eix
+jjP
+wkp
+acN
+hfq
+ujU
+jFA
+ujU
+lVS
+ujU
+uxC
+jjP
+wSZ
+jjP
+acN
+acN
+vCG
+mYR
+mYR
+mYR
+mYR
+pvk
+lHo
+mYR
+kFe
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+chu
+fUA
+vPq
+dzB
+dzB
+dzB
+dzB
+dzB
+jEd
+dzB
+cKC
+kZA
+cKC
+oAl
+oAl
+oAl
+heT
+oAl
+loY
+ack
+heT
+eOE
+vpn
+pvX
+pvX
+rqT
+epl
+vpn
+epl
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(284,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kFR
+kFR
+acN
+kFR
+kFR
+kFR
+acN
+eSI
+nYg
+wdk
+acN
+kFR
+ieP
+kFR
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+iLo
+mrM
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+chu
+tus
+cKF
+dzB
+vPq
+vPq
+vPq
+vPq
+dzB
+dzB
+vPq
+mNc
+vPq
+vPq
+hmJ
+oAl
+heT
+oAl
+uZA
+aFw
+oAl
+heT
+epl
+usW
+epl
+epl
+hnz
+epl
+mbd
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(285,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+ill
+jjP
+mYW
+msF
+jjP
+euc
+bwh
+cpl
+iFq
+mlh
+jjP
+cpl
+xpz
+jjP
+jjP
+cpl
+mQU
+qYC
+mlh
+cpl
+bbR
+jjP
+lgX
+msF
+bwh
+jjP
+jzV
+msF
+dav
+msF
+msF
+ybW
+rqY
+msF
+msF
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+cap
+mbv
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+fUA
+cKC
+vPq
+ool
+vPq
+kGH
+fJy
+dzB
+vPq
+vPq
+kZA
+nVa
+vPq
+wTK
+oZx
+oAl
+heT
+dZP
+dZP
+kVA
+kVA
+xmg
+lkY
+epl
+epl
+epl
+epl
+mRK
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(286,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+ybP
+itv
+pkb
+msF
+dgW
+eKD
+pkb
+cpl
+uAl
+wSZ
+osk
+cpl
+jzV
+ujU
+gxU
+cpl
+osk
+eKD
+pvQ
+cpl
+osk
+ddL
+tox
+msF
+pkb
+dQF
+pvQ
+msF
+mYR
+pxm
+msF
+wQQ
+hac
+tOQ
+msF
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+dzB
+vPq
+vPq
+kZA
+vPq
+pbd
+vPq
+aIB
+sPm
+heT
+kVA
+kVA
+kVA
+qiW
+bip
+epl
+rVg
+rar
+epl
+wDS
+xmg
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(287,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+eVP
+wSZ
+pWy
+msF
+sPS
+wSZ
+jEb
+msF
+iow
+jjP
+mLb
+cpl
+ujU
+nsH
+jeN
+msF
+eYk
+jjP
+sPS
+cpl
+jEb
+itv
+sPS
+msF
+eYk
+wSZ
+bwt
+msF
+azD
+mYR
+yks
+tYp
+uXA
+dSB
+msF
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+mEQ
+jtv
+bCn
+kqc
+rMq
+poL
+dzB
+vPq
+vPq
+kZA
+qiW
+kZA
+mNc
+kZA
+kZA
+kVA
+qiW
+iWU
+kZA
+kZA
+kZA
+kZA
+iRK
+kZA
+rah
+rah
+rah
+qiW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(288,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+msF
+qrq
+joT
+msF
+msF
+qrq
+oDU
+cpl
+cpl
+qrq
+msF
+msF
+cgc
+idI
+cgc
+msF
+joT
+qrq
+msF
+cpl
+oDU
+mud
+cpl
+cpl
+oDU
+mud
+cpl
+cpl
+msF
+mYR
+msF
+jYL
+ioA
+hpz
+msF
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+dCz
+mEQ
+mEQ
+cIA
+luy
+fUA
+vPq
+dzB
+dzB
+kGH
+rmM
+ket
+gVk
+arM
+kVA
+kVA
+bhz
+sTw
+dns
+ree
+dns
+aOa
+chu
+aOa
+dns
+ree
+awP
+vow
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(289,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+jzV
+jjP
+euc
+jjP
+ddL
+jjP
+jjP
+jjP
+ujU
+kmS
+jLz
+jjP
+ujU
+ujU
+ujU
+ujU
+jjP
+ddL
+ddL
+jjP
+ddL
+xpz
+ujU
+aFo
+hNu
+ujU
+jjP
+sMD
+sMD
+cpl
+lnu
+msF
+msF
+kCA
+msF
+msF
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+fUA
+pFz
+cIA
+uoi
+mEQ
+aGe
+poL
+wvu
+dzB
+vPq
+vPq
+qIk
+gVk
+xnc
+aOa
+kVA
+gvx
+awP
+aOa
+aOa
+chu
+dns
+aOa
+aOa
+nvM
+dns
+awP
+aOa
+vow
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(290,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+itv
+jjP
+ddL
+wSZ
+jjP
+iUt
+xpz
+wSn
+ddL
+ujU
+jjP
+ujU
+xpz
+ddL
+jjP
+iMz
+ujU
+ujU
+uEo
+jjP
+ujU
+jFA
+wSZ
+jjP
+sMD
+sMD
+mcZ
+mcZ
+mcZ
+msF
+mYR
+cpl
+glK
+tYp
+npu
+xQn
+acN
+acN
+acN
+cSd
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+fUA
+mTF
+mEQ
+mEQ
+mEQ
+mEQ
+poL
+rhW
+vPq
+vPq
+vPq
+kBR
+xnc
+vPq
+mJC
+kVA
+gvx
+dlW
+diE
+aOa
+vGl
+aOa
+vmi
+ree
+chu
+aOa
+mJC
+aOa
+wex
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(291,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+jjP
+wkp
+rAx
+aGK
+hfq
+msF
+cpl
+cpl
+cpl
+cpl
+cpl
+cpl
+msF
+ezn
+ezn
+miI
+msF
+msF
+cpl
+cpl
+msF
+msF
+msF
+msF
+dLL
+hha
+rPq
+iGt
+sMD
+msF
+iLo
+vIj
+eBw
+nyp
+ioA
+gEz
+acN
+acN
+acN
+siS
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+mbv
+cap
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+saK
+mEQ
+ggp
+tcI
+nDy
+fUA
+kGH
+dzB
+vPq
+qiW
+kZA
+giq
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+cgX
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(292,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+msF
+msF
+msF
+msF
+msF
+jjP
+jjP
+wSZ
+jjP
+qYC
+jjP
+msZ
+wSZ
+mjm
+ujU
+msZ
+jjP
+btI
+jjP
+ddL
+euc
+wSZ
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+dQD
+cpl
+eTh
+mNC
+nyN
+vBw
+acN
+acN
+tNX
+bRr
+tNX
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+mbv
+mbv
+cap
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+sbY
+mEQ
+mEQ
+mEQ
+bap
+fUA
+kGH
+dzB
+vPq
+kZA
+eDG
+lOU
+cHm
+lPB
+kZA
+ncs
+jZz
+bQk
+tra
+ddc
+bQk
+osv
+osv
+fIw
+sbx
+pll
+tJZ
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(293,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+msF
+jjP
+jjP
+ddL
+jjP
+wSZ
+cpl
+cpl
+msF
+cpl
+msF
+msF
+jjP
+ujU
+gsx
+cpl
+cpl
+cpl
+cpl
+cpl
+msF
+sWS
+lnG
+vST
+roI
+mYR
+mYR
+oLU
+msF
+dQD
+cpl
+glK
+tYp
+idT
+lPd
+acN
+acN
+hmm
+axQ
+iTU
+neu
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+nEF
+wGC
+inj
+nEF
+nEF
+fUA
+vPq
+dzB
+vPq
+poL
+sST
+jtJ
+sST
+sST
+kZA
+oKo
+fQm
+rJO
+jZz
+sTS
+jZz
+ceT
+osv
+kZA
+utr
+osv
+nVq
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(294,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+jzV
+jjP
+jjP
+jjP
+ddL
+msF
+cpl
+cpl
+sMD
+sMD
+vnG
+wSZ
+ddL
+ujU
+ujU
+jjP
+ujU
+ddL
+vnG
+swJ
+jjP
+cpl
+cpl
+msF
+msF
+msF
+nCM
+dQD
+pmr
+msF
+mYR
+msF
+cpl
+krY
+msF
+msF
+acN
+acN
+ext
+jfI
+ffU
+bsl
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+fUA
+vdR
+sST
+hwA
+sST
+xfD
+bdF
+vPq
+vPq
+vPq
+tUK
+cHm
+sST
+eDG
+sST
+poL
+oKo
+jZz
+jZz
+jZz
+jZz
+dSb
+jci
+cHM
+cgX
+vNz
+niR
+rJO
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(295,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gOW
+tug
+bDE
+msF
+cpl
+cpl
+sMD
+oSx
+sMD
+ujU
+ujU
+tEc
+ujU
+euc
+ddL
+btI
+jjP
+ujU
+ujU
+euc
+jjP
+jjP
+sMD
+cpl
+cpl
+msF
+rcM
+dQD
+rGB
+msF
+mYR
+cpl
+mvI
+nrG
+eRC
+qVd
+jej
+acN
+pWr
+tAP
+ffU
+aFt
+acN
+soJ
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+fUA
+mfb
+sqz
+xfD
+sST
+xdL
+kZA
+vPq
+vuX
+vuX
+kZA
+rAt
+sST
+sST
+sST
+kZA
+dpZ
+oGS
+ceT
+jZz
+tJZ
+jZz
+paT
+bQk
+kZA
+jZz
+uev
+ceT
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(296,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+lnG
+wWU
+msF
+cpl
+sqE
+sMD
+eZc
+sMD
+ujU
+sMD
+sMD
+jjP
+jjP
+xUE
+jjP
+jjP
+ddL
+jjP
+jjP
+ujU
+ujU
+ddL
+lvh
+sMD
+eeN
+msF
+msF
+dav
+msF
+msF
+dgr
+cpl
+qKG
+wgU
+ixR
+eXY
+fuI
+acN
+kCS
+nBJ
+fXC
+qtF
+exn
+jiI
+qpH
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+fUA
+vYS
+tjn
+sST
+hwA
+hwA
+eyv
+vPq
+dzB
+vPq
+eyv
+sST
+lPB
+aLE
+aLE
+tUK
+fBr
+tra
+bQk
+bQk
+cHM
+sGf
+qzG
+pTg
+fIw
+pcM
+jZz
+ceT
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(297,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+lBW
+lnG
+cpl
+sch
+sMD
+tsb
+ujU
+ujU
+sMD
+ujU
+msF
+msF
+cpl
+cpl
+cpl
+msZ
+msF
+cpl
+cpl
+msF
+jjP
+ujU
+ujU
+ujU
+sMD
+gXE
+msF
+dQD
+dQD
+dQD
+mYR
+cpl
+lQy
+wgU
+dTE
+cYf
+oFR
+acN
+vuS
+wYf
+dTE
+dTE
+dTE
+wYf
+xXe
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+xwF
+kZA
+aLE
+uec
+sST
+jtJ
+sST
+eyv
+vPq
+vPq
+rhW
+eyv
+sST
+lPV
+xAz
+xcH
+kZA
+fIw
+fIw
+kZA
+cgX
+cgX
+kZA
+fIw
+fIw
+kZA
+nVq
+rJO
+ceT
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(298,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kNG
+aNj
+wYM
+iPf
+sQp
+acN
+lBW
+msF
+cpl
+sMD
+sMD
+ujU
+sMD
+cjv
+msF
+oOI
+msF
+cpl
+rnw
+xGP
+jjP
+jLz
+ujU
+ddL
+neM
+msF
+msF
+sMD
+sMD
+ujU
+jjP
+sMD
+msF
+msF
+mYR
+mYR
+msF
+wfk
+lNZ
+dIX
+fPu
+dTE
+bsU
+acN
+upA
+sMB
+sMB
+xSg
+ork
+ork
+euw
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+wHL
+ouP
+dqi
+hwA
+eNv
+eyv
+vPq
+dzB
+vPq
+eyv
+sST
+lPV
+mTp
+sST
+kZA
+nVq
+jZz
+jZz
+gdx
+jZz
+bQC
+jZz
+fKS
+kZA
+mmt
+fLK
+ejt
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(299,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gVj
+uFM
+ccH
+gDr
+rTr
+ola
+jjP
+cpl
+vKO
+sMD
+ujU
+sMD
+sMD
+msF
+msF
+sMD
+dNs
+cpl
+iLD
+riR
+msF
+pgc
+xPT
+msF
+msF
+msF
+msF
+msF
+cjv
+mcZ
+ddL
+euc
+gXg
+msF
+xmY
+mYR
+msF
+hhJ
+mbt
+enC
+msF
+pyU
+pRe
+acN
+kFR
+kFR
+acN
+ivV
+lbA
+lbA
+ivV
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tUK
+rbK
+hCr
+hwA
+hwA
+tXF
+kZA
+udL
+vuX
+dzB
+poL
+sST
+lPV
+xAz
+xfD
+kZA
+bjM
+jyw
+pcM
+tJZ
+sTS
+jZz
+wkS
+cvO
+kZA
+hSi
+wVP
+oMV
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(300,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nKO
+wmu
+pdv
+wAN
+aze
+acN
+msF
+cpl
+sMD
+ujU
+sMD
+sMD
+sMD
+msF
+vJV
+ibV
+pms
+cpl
+foF
+btI
+msF
+crB
+ujU
+kaB
+ctI
+msF
+msF
+oqz
+kzY
+sMD
+ujU
+jjP
+cmk
+msF
+msF
+mYR
+cpl
+lUr
+dIX
+dTE
+ivh
+sVN
+xLz
+msF
+xLR
+hpz
+acN
+uTP
+kGB
+fAf
+vLT
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+uFL
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+aLE
+aLE
+aLE
+hwA
+hwA
+tjj
+dzB
+vPq
+vPq
+ngY
+xfD
+viy
+xAz
+lPB
+poL
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+pfs
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(301,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+jYh
+acN
+acN
+msF
+cjv
+sMD
+mcZ
+euc
+sMD
+msF
+msF
+msF
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+mca
+sMD
+ujU
+cjv
+iGt
+msF
+hIm
+cpl
+ivh
+dTE
+dIX
+dTE
+dTE
+gkM
+msF
+kdi
+tYp
+vHC
+tfF
+kGB
+kGB
+hkf
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+kZA
+kZA
+wex
+fUA
+xjL
+wHL
+wHL
+sST
+xfD
+poL
+dzB
+vPq
+vPq
+fUA
+sST
+sST
+sST
+sST
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+hMf
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(302,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+sGt
+mWd
+mMg
+kQv
+acN
+eXJ
+qqF
+uKL
+ehQ
+mVr
+jHS
+ifW
+msF
+sMD
+aTZ
+mcZ
+jjP
+msF
+msF
+ine
+mdr
+acN
+pCH
+dWj
+eJG
+gzs
+acN
+kgC
+igu
+lEl
+lEl
+dzc
+nIw
+csx
+xFo
+fre
+sMD
+ujU
+sMD
+lOg
+msF
+rpm
+msF
+rUg
+dTE
+wgU
+cYf
+wYf
+wqA
+cpl
+hpz
+ioA
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kLr
+kXn
+pxG
+eru
+kZA
+wex
+kZA
+qtE
+rbK
+vYS
+sST
+jtJ
+kZA
+kjc
+dzB
+vPq
+fUA
+sST
+xfD
+sST
+sST
+mST
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+diE
+hMf
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(303,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+loh
+bnE
+fcq
+mJk
+acN
+wDI
+lza
+mVr
+mVr
+mVr
+lza
+bJP
+msF
+sMD
+cjv
+biH
+sMD
+xcc
+dDg
+opV
+mdr
+acN
+bPe
+dTE
+gEf
+kAO
+acN
+gTH
+khO
+khO
+khO
+weB
+nIw
+hEF
+emO
+sMD
+tsb
+mcZ
+ddL
+sQi
+cpl
+lnu
+msF
+nnY
+dTE
+dIX
+dTE
+dTE
+qdz
+cpl
+wQQ
+tYp
+msF
+eyp
+qtP
+kGB
+kGB
+uzQ
+acN
+acN
+acN
+acN
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tUK
+rzR
+vPq
+vPq
+poL
+wex
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+vPq
+dzB
+jrs
+kZA
+tUK
+poL
+poL
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+chu
+kZA
+kZA
+kZA
+hMf
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(304,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+ecm
+kFr
+bnE
+wWn
+acN
+iST
+mVr
+aKO
+frw
+cdw
+mVr
+mVr
+nlK
+sMD
+sMD
+mcZ
+sMD
+fWu
+nIQ
+taY
+oVn
+acN
+ncB
+wYf
+ncB
+acN
+acN
+khO
+khO
+khO
+khO
+weB
+nIw
+wHW
+wNi
+jjP
+sMD
+mcZ
+jjP
+qoU
+cpl
+lHo
+msF
+aHG
+sDc
+sDc
+fVp
+sDc
+wFi
+cpl
+hpz
+tYp
+msF
+gfY
+kGB
+rSZ
+iLl
+dmM
+acN
+acN
+acN
+acN
+cap
+bsh
+bsh
+bsh
+xCC
+xCC
+vIN
+vIN
+vIN
+xCC
+bQB
+uFL
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+lBE
+dDI
+poL
+dDI
+kZA
+kZA
+hxg
+unb
+vzw
+psz
+kZA
+kGH
+vPq
+vPq
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+chu
+kZA
+heT
+kZA
+oOB
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(305,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xoL
+bnE
+xHF
+dNl
+acN
+mVr
+aGY
+bEP
+bIy
+jRv
+mVr
+lza
+lhN
+siS
+siS
+mcZ
+cjv
+msF
+trA
+ujW
+mdr
+acN
+ncB
+dTE
+ncB
+acN
+xww
+vLr
+bpv
+bpv
+khO
+mxU
+msF
+rQq
+msF
+eKB
+sMD
+mcZ
+jjP
+iGt
+cpl
+dav
+msF
+oTX
+wKh
+nCk
+sTf
+cim
+msF
+vZB
+tYp
+ivV
+hWb
+msF
+buV
+buV
+buV
+msF
+iFz
+acN
+acN
+acN
+byr
+fSD
+cPh
+cPh
+kJk
+oUX
+oUX
+oUX
+oUX
+mpH
+bQB
+uFL
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+wHe
+vPq
+vPq
+vPq
+vPq
+uIO
+tUK
+wrS
+hdA
+lYy
+hdA
+kZA
+kZA
+eyC
+vnn
+fUA
+kZA
+kZA
+bjm
+jnm
+aep
+vPq
+syB
+kZA
+qmp
+vPq
+kZA
+chu
+kZA
+heT
+kZA
+chu
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(306,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xoL
+bnE
+xHF
+aah
+acN
+mVr
+arc
+mVr
+kJS
+mVr
+stD
+mVr
+gsa
+hpz
+hpz
+hUw
+siS
+vOw
+mdr
+mdr
+nnz
+acN
+acN
+plX
+acN
+acN
+vCL
+khO
+fzg
+wKO
+cXM
+weB
+glU
+sMD
+cjv
+sMD
+sMD
+mcZ
+sMD
+cjv
+tKf
+nWt
+hpz
+uZR
+rPw
+tYp
+tYp
+tYp
+oXm
+sdg
+ioA
+qeW
+nDt
+cny
+dfM
+hpz
+nWz
+mlT
+efj
+acN
+xzU
+key
+bDa
+tBp
+oUX
+oUX
+dqS
+oUX
+oUX
+jeb
+oUX
+dCf
+bQB
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tUK
+nYA
+vPq
+rhW
+vPq
+vPq
+uqU
+poL
+keN
+hdA
+hdA
+poL
+vPq
+vPq
+vPq
+vPq
+vPq
+poL
+kZA
+lzb
+vPq
+vPq
+vPq
+vPq
+hnr
+vPq
+vPq
+kLr
+chu
+kZA
+heT
+kZA
+mST
+qoC
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(307,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+ckz
+hss
+fcq
+oil
+acN
+sxm
+acN
+gtq
+lQY
+lQY
+slF
+acN
+msF
+hpz
+tYp
+hpz
+nxW
+msF
+msF
+qZV
+msF
+msF
+lrW
+weB
+yma
+xZM
+khO
+ifz
+saP
+bpv
+cXM
+weB
+xZM
+bKW
+nWt
+nWt
+ghu
+siS
+nWt
+siS
+csk
+hpz
+tYp
+tYp
+tYp
+hpz
+crT
+hpz
+ioA
+rPw
+hpz
+qeW
+nDt
+hpz
+wsI
+hpz
+owf
+hFI
+tCD
+fyx
+tFR
+nDt
+qlX
+tBp
+xdr
+oUX
+dGt
+oUX
+oUX
+oUX
+oUX
+rUs
+bQB
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+cKC
+vPq
+vPq
+vPq
+psQ
+bjm
+kZA
+ksK
+hdA
+fUA
+dmX
+vPq
+uLb
+uLb
+uLb
+huW
+vPq
+tUK
+bha
+vPq
+vPq
+vPq
+vPq
+kZA
+vPq
+vPq
+mST
+chu
+kZA
+kZA
+kZA
+oPE
+cKC
+bjm
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(308,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xoL
+xHF
+bnE
+hss
+smn
+tLf
+bmp
+aFM
+bcV
+iWy
+iWy
+aFM
+wOn
+tgh
+tYp
+hpz
+cZC
+cpl
+ppc
+rKu
+nfW
+msF
+hlB
+kbR
+hlB
+msF
+kPE
+khO
+khO
+mLN
+cXM
+weB
+glU
+kIk
+hpz
+rPw
+tYp
+tYp
+hpz
+tYp
+oKr
+ioA
+hpz
+ikz
+hpz
+rPw
+pXD
+tYp
+hpz
+fTa
+hpz
+qeW
+nDt
+udC
+xom
+ptN
+woI
+hpz
+tCD
+acN
+tFR
+waN
+oLz
+tBp
+jeb
+oUX
+vbr
+oUX
+jeb
+oUX
+oUX
+cXH
+bQB
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+qiW
+kZA
+mNc
+kZA
+sti
+sti
+kZA
+qiW
+pkW
+poL
+vPq
+tHF
+wdv
+gMH
+gMH
+cKC
+vPq
+fUA
+kZA
+kZA
+mNc
+kZA
+kZA
+kZA
+jga
+jga
+kZA
+kZA
+kZA
+kZA
+wHe
+vPq
+dzB
+vPq
+vPq
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(309,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xoL
+xHF
+hss
+xHF
+lvP
+aFM
+cNj
+tLf
+tLf
+aFM
+cNj
+tLf
+ykm
+tYp
+fvt
+cZC
+pWx
+cpl
+viz
+oVr
+taY
+msF
+fvI
+whL
+ifC
+msF
+xww
+vLr
+bpv
+fNC
+vUd
+umS
+msF
+qNA
+msF
+jHJ
+hpz
+tYp
+hpz
+nxW
+msF
+nWS
+msF
+msF
+osS
+tsl
+ibE
+rOj
+msF
+msF
+meS
+msF
+hWb
+msF
+acN
+acN
+acN
+acN
+iFz
+acN
+acN
+acN
+byr
+fSD
+cPh
+cPh
+kJk
+oUX
+oUX
+oUX
+oUX
+cXH
+bQB
+uFL
+bsh
+uFL
+bsh
+bsh
+uFL
+uFL
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kZA
+kZA
+kZA
+vPq
+vPq
+vPq
+fUA
+vPq
+iph
+vPq
+vPq
+vPq
+tUK
+vPq
+gMH
+xnc
+dmX
+dQS
+gMH
+vPq
+fUA
+vPq
+jIU
+rhW
+vuX
+dzB
+dzB
+dzB
+dzB
+dzB
+dzB
+vPq
+kZA
+vPq
+vPq
+oJr
+joF
+rhW
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(310,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xoL
+bnE
+hss
+kFr
+aUM
+tLf
+bHe
+aFM
+tLf
+tLf
+bHe
+pGO
+hJN
+ydC
+hpz
+cZC
+rpW
+cpl
+trA
+ezf
+oVn
+msF
+kGk
+mdr
+whL
+msF
+msF
+khO
+khO
+khO
+khO
+weB
+nIw
+uEt
+qNA
+uYo
+hpz
+hpz
+tYp
+dxC
+msF
+prS
+msF
+syA
+sUx
+xTO
+uzA
+nMU
+rHJ
+msF
+nci
+dBA
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+bsh
+bsh
+bsh
+xCC
+xCC
+xqz
+xqz
+xqz
+xCC
+bQB
+bsh
+uFL
+bsh
+bsh
+bsh
+uFL
+uFL
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tUK
+ryb
+dzB
+mxb
+kyx
+vPq
+vPq
+vPq
+wem
+vPq
+vPq
+vPq
+vPq
+sdw
+mNc
+vPq
+mdG
+vPq
+qMs
+wtQ
+gMH
+vPq
+eyC
+vPq
+vPq
+dzB
+dzB
+vPq
+dzB
+dzB
+dzB
+dzB
+dzB
+dzB
+iQQ
+vPq
+vPq
+baR
+nUM
+jrs
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(311,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+rxq
+bnE
+hss
+gJs
+acN
+aEI
+pGO
+aFM
+aFM
+cNj
+wZI
+aFM
+msF
+tYp
+hpz
+hpz
+jdE
+cpl
+jRA
+ujW
+mdr
+msF
+juy
+lLD
+mdr
+nja
+msF
+weB
+khO
+vUd
+vUd
+weB
+nIw
+aPz
+qNA
+uYo
+hpz
+ioA
+tYp
+cng
+msF
+prS
+msF
+oVJ
+sUx
+kwG
+rQa
+gda
+mUB
+cpl
+tZZ
+mYR
+cEJ
+iJG
+mYR
+mYR
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+kLr
+iKm
+vPq
+dzB
+vPq
+kyx
+vPq
+huW
+vPq
+jev
+iph
+vPq
+kGH
+roE
+dmX
+poL
+vPq
+gMH
+qFY
+vPq
+fRw
+pcj
+vPq
+kZA
+vPq
+jIU
+vPq
+jIU
+vPq
+vPq
+rhW
+vPq
+vPq
+vPq
+vPq
+kZA
+wvu
+vPq
+rUv
+jZf
+vPq
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(312,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+uSq
+kFr
+hss
+bDN
+acN
+aFM
+qOT
+aFM
+pGO
+mvZ
+aFM
+nAW
+msF
+prO
+tYp
+hpz
+qmO
+cpl
+msF
+fmR
+aRk
+msF
+kPa
+nIQ
+taY
+whL
+msF
+nOJ
+oHw
+vrI
+vrI
+onO
+nIw
+qVT
+ivs
+tYp
+tYp
+rPw
+hpz
+gRL
+msF
+xXR
+msF
+msF
+ibE
+msF
+fbC
+rOj
+cpl
+msF
+iLo
+wzb
+acN
+gAL
+nci
+iLo
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+hnv
+hnv
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+kZA
+kZA
+poL
+fOs
+kFF
+poL
+jiN
+vPq
+iGy
+poL
+wvu
+vPq
+vPq
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+poL
+vPq
+hBd
+gMH
+gMH
+gMH
+cKC
+dmX
+poL
+kZA
+kZA
+mNc
+kZA
+kZA
+kZA
+jga
+jga
+kZA
+kZA
+kZA
+kZA
+vPq
+dzB
+rhW
+vPq
+vPq
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(313,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+ecm
+fcq
+bnE
+kBv
+acN
+qIb
+rue
+aFM
+aFM
+eQV
+aFM
+tDq
+msF
+sdp
+hpz
+ioA
+hpz
+hpz
+cpl
+msF
+msF
+msF
+bNJ
+wJT
+mdr
+rtO
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+tjI
+hpz
+hpz
+kgA
+tGt
+msF
+kJK
+msF
+wLg
+stO
+xpg
+bru
+stO
+xQc
+cpl
+xjs
+mYR
+acN
+acN
+acN
+dav
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+uFL
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+kZA
+usZ
+ujs
+dzB
+dzB
+mNc
+dzB
+dzB
+vPq
+pEi
+vPq
+vPq
+vPq
+eZn
+fCp
+xnc
+rhW
+iph
+kZA
+tUK
+fJy
+vPq
+uLb
+uLb
+uLb
+vPq
+vPq
+poL
+pHO
+vPq
+rhW
+vPq
+vPq
+kZA
+qmp
+vPq
+mST
+chu
+chu
+kZA
+kZA
+vPq
+vPq
+vPq
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(314,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+lMu
+hcG
+acN
+acN
+aFM
+qOT
+aFM
+tms
+jjN
+aFM
+aVm
+msF
+cpl
+hpz
+tYp
+hpz
+tYp
+kgA
+msF
+msF
+msF
+acN
+msF
+oSr
+msF
+acN
+hKP
+lHo
+lHo
+lHo
+gRG
+ekX
+sWc
+tYp
+hpz
+tYp
+hpz
+jDZ
+cpl
+msF
+qqd
+msF
+oES
+tNG
+hJo
+cqs
+tNG
+jEt
+cpl
+pxm
+mYR
+dav
+lHo
+pxm
+mmN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+kZA
+usZ
+tUK
+eIq
+mkM
+kZA
+oZx
+pCY
+dmX
+fUA
+dWx
+vPq
+vPq
+eZn
+fRw
+gVk
+xXn
+vPq
+kZA
+kZA
+kLr
+vPq
+vPq
+vPq
+vPq
+kdq
+kZA
+kZA
+lzb
+dzB
+dzB
+dzB
+vPq
+aDd
+dzB
+dzB
+kLr
+kZA
+chu
+chu
+kZA
+kZA
+mNc
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(315,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+osM
+bnE
+kFr
+ueJ
+acN
+pgM
+aFM
+aFM
+aFM
+tLf
+bHe
+cXg
+msF
+cpl
+hps
+tYp
+hpz
+tYp
+hpz
+cpl
+msF
+msF
+acN
+gZR
+fok
+fok
+acN
+lHo
+lHo
+lHo
+mYR
+ekX
+msF
+msF
+hpz
+hpz
+ioA
+hpz
+wvX
+cpl
+msF
+pKM
+msF
+lnc
+auk
+cqs
+lqf
+rIZ
+xQc
+msF
+ffN
+nci
+acN
+acN
+dav
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+xtq
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+kZA
+usZ
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+fUA
+kap
+pco
+oYe
+fUA
+tdm
+dZz
+dZz
+mdw
+kZA
+fOs
+tzb
+fUA
+vPq
+jEd
+vPq
+fUA
+chu
+mST
+nJs
+bjm
+uYn
+vPq
+hLG
+kZA
+dzB
+dzB
+kZA
+kZA
+kZA
+chu
+kZA
+cKC
+vPq
+vPq
+kZA
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(316,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+wwf
+ayA
+fcq
+bff
+acN
+ezZ
+pGO
+aFM
+bXn
+xSO
+bXn
+iWA
+msF
+cpl
+cpl
+hpz
+tYp
+ioA
+ioA
+hpz
+cpl
+msF
+acN
+oUc
+kmE
+skB
+acN
+lHo
+lHo
+wOC
+aRP
+msF
+msF
+vdW
+fvt
+hpz
+hpz
+tYp
+cpl
+msF
+msF
+msF
+aMi
+tNG
+eov
+stO
+stO
+stO
+qKx
+msF
+lHo
+mYR
+acN
+xjs
+mYR
+gHp
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+heT
+heT
+heT
+heT
+kZA
+usZ
+kZA
+heT
+heT
+fUA
+dzB
+cGl
+dzB
+kyx
+vPq
+vPq
+dzB
+pEi
+dzB
+ndU
+dzB
+dzB
+mNc
+dzB
+dzB
+tUK
+cKC
+vPq
+vPq
+kZA
+chu
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+chu
+mST
+vPq
+vPq
+vPq
+mST
+bYA
+bYA
+heT
+heT
+heT
+heT
+heT
+"}
+(317,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+tju
+jVz
+qzV
+bbN
+gfr
+pUz
+acN
+msF
+msF
+msF
+hBp
+hpz
+fvt
+hpz
+tYp
+hpz
+hpz
+slv
+acN
+acN
+acN
+acN
+cpl
+cpl
+cpl
+cpl
+cpl
+tYp
+hpz
+hpz
+hpz
+tYp
+aZY
+msF
+msF
+msF
+msF
+lDk
+stO
+xoY
+cpl
+cpl
+msF
+acN
+msF
+acN
+eQz
+acN
+mYR
+mYR
+vdT
+acN
+acN
+acN
+acN
+cap
+cap
+mbv
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+kZA
+usZ
+kZA
+heT
+heT
+poL
+uLb
+pjh
+cGl
+kyx
+dzB
+vPq
+kap
+poL
+cKC
+dzB
+dzB
+dzB
+dDI
+mAg
+oSo
+kZA
+kGH
+vPq
+vPq
+poL
+mST
+kZA
+dDI
+poL
+poL
+kZA
+kZA
+kZA
+kZA
+mbN
+cIR
+kZA
+heT
+kZA
+kZA
+mWB
+fVE
+hLG
+kZA
+bYA
+bYA
+heT
+heT
+heT
+heT
+heT
+"}
+(318,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+eEW
+hJQ
+qzV
+hJQ
+lOL
+acN
+tUq
+lNk
+msF
+msF
+ukY
+hpz
+hpz
+hpz
+tYp
+hpz
+tYp
+hpz
+rPw
+hpz
+tYp
+hpz
+kgA
+kMs
+rPw
+hpz
+hpz
+tYp
+rPw
+tYp
+oom
+cpl
+msF
+msF
+msF
+msF
+msF
+tNG
+eov
+nHP
+sMh
+jIo
+oXC
+acN
+acN
+acN
+acN
+dav
+cEJ
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+mbv
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+sOI
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+kZA
+usZ
+kZA
+kZA
+kLr
+poL
+dzB
+hwn
+dzB
+kZA
+ted
+kap
+bjm
+kZA
+vPq
+kGH
+dzB
+ohS
+kZA
+mST
+kZA
+kZA
+vPq
+vPq
+vPq
+tUK
+ghW
+gnh
+gnh
+gnh
+dzZ
+fUA
+gzV
+xHE
+ghW
+mEa
+mEa
+nAg
+kZA
+heT
+kZA
+kZA
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(319,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+ene
+hJQ
+hJQ
+qzV
+tuw
+iaM
+dQK
+dPC
+msF
+msF
+cpl
+cpl
+hpz
+tYp
+hpz
+ioA
+hpz
+ioA
+tYp
+ioA
+hpz
+tYp
+hpz
+hpz
+hpz
+fvt
+hpz
+hpz
+hAB
+msF
+msF
+msF
+msF
+msF
+msF
+mvq
+bph
+stO
+nus
+msF
+alS
+alS
+wmT
+acN
+acN
+ash
+mYR
+mYR
+fXG
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+kZA
+usZ
+oUa
+fOs
+kFF
+kZA
+dFE
+dzB
+dzB
+pEi
+vPq
+dzB
+vPq
+fUA
+kZA
+dzB
+dzB
+kZA
+kZA
+xpP
+usZ
+sJu
+rhW
+vPq
+vPq
+ibj
+ghW
+gEJ
+gnh
+gnh
+pcr
+slc
+fwO
+aku
+eiQ
+ghW
+ghW
+gEJ
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(320,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+trS
+jiq
+kfF
+uJX
+rxN
+acN
+jwn
+jwn
+msF
+fcE
+fcE
+uHf
+cvX
+cpl
+tPS
+jmK
+hpz
+hpz
+hpz
+fvt
+hpz
+hpz
+tYp
+ioA
+sMS
+wWR
+tGt
+cpl
+cpl
+msF
+msF
+msF
+msF
+msF
+msF
+fFv
+rIZ
+lqf
+eov
+msF
+qNA
+qNA
+qNA
+acN
+acN
+qEA
+pxm
+iBL
+gov
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+kZA
+kZA
+tUK
+dzB
+dzB
+mNc
+dzB
+dzB
+dzB
+tUK
+vPq
+dzB
+vPq
+fUA
+scU
+vPq
+dzB
+wJu
+kZA
+hMf
+kZA
+tUK
+vPq
+vPq
+dzB
+ibj
+gnh
+eiQ
+gnh
+gnh
+dzZ
+fUA
+tyC
+aku
+ghW
+itm
+itm
+nAg
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(321,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+msF
+msF
+msF
+dTE
+dTE
+iQq
+dIX
+cpl
+msF
+msF
+msF
+vbf
+msF
+eaN
+vtl
+xuW
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+lhY
+hJo
+kkk
+cqs
+weL
+bJf
+pjB
+sMh
+mfq
+acN
+uym
+atK
+mYR
+mZS
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+mbv
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+oSo
+xuq
+kZA
+iGy
+vPq
+gax
+poL
+vPq
+dzB
+dzB
+poL
+vPq
+bjm
+lWu
+dzB
+kZA
+lrk
+kLr
+fUA
+vPq
+vPq
+vPq
+ibj
+gnh
+gnh
+gnh
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+jVf
+vGb
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(322,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+dtH
+caT
+eAH
+msF
+dBc
+dIX
+dTE
+wgU
+dTE
+msF
+msF
+xre
+oIw
+nrH
+msF
+hpz
+kcM
+qCM
+ngS
+rBW
+xvj
+dcW
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+tNG
+eov
+gnk
+stO
+nHP
+sMh
+mra
+jqD
+cav
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+mbv
+bsh
+bsh
+bsh
+bsh
+aTC
+hnv
+pTl
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kZA
+qiW
+qiW
+eGW
+mGM
+mGM
+fUA
+vPq
+dzB
+vPq
+kZA
+dzB
+vPq
+vPq
+vPq
+fUA
+bGY
+rUM
+fUA
+wvu
+vPq
+vPq
+dDI
+gnh
+ghW
+gnh
+slc
+gnh
+gnh
+gnh
+gEJ
+lEF
+kZA
+kZA
+kZA
+kZA
+kZA
+tUK
+kZA
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(323,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+lBN
+ydV
+siq
+msF
+wgU
+mbB
+dIX
+mbB
+rdI
+msF
+msF
+lFy
+cbU
+oeC
+msF
+hpz
+hpz
+tYp
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+msF
+lEE
+neI
+msF
+msF
+msF
+tNG
+eov
+kBl
+kBl
+msF
+iaq
+oVK
+sMh
+gxj
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+mbv
+mbv
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+hnv
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+kGH
+dzB
+dzB
+dzB
+vPq
+ted
+dzB
+dzB
+vYD
+pEi
+dzB
+dzB
+dzB
+usV
+eyw
+kte
+dzB
+fUA
+dzB
+vPq
+usV
+pEi
+ghW
+gnh
+ghW
+kZA
+uzr
+gnh
+gnh
+jfF
+kZA
+poL
+cuK
+gnh
+ghW
+eNm
+gnh
+mST
+bYA
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(324,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+lcL
+auC
+qAv
+jxd
+dTE
+cfi
+dTE
+cfi
+dTE
+msF
+msF
+msF
+msF
+msF
+cLw
+oQD
+ioA
+oQD
+fgf
+gsl
+ddU
+uAp
+mIR
+nBf
+gvS
+msF
+qNA
+qkl
+msF
+msF
+msF
+ovP
+eov
+msF
+msF
+msF
+msF
+efL
+irO
+xCA
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+dzB
+dzB
+dzB
+dzB
+bjm
+bjm
+dzB
+dzB
+rhW
+kZA
+fwr
+dzB
+dzB
+vPq
+kZA
+mAg
+irY
+fUA
+cKC
+vPq
+rhW
+tUK
+gnh
+ghW
+gnh
+vNs
+ckj
+lvQ
+ghW
+paF
+kZA
+fUA
+vba
+gnh
+hgH
+eNm
+mBB
+fUA
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(325,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+csR
+qPt
+rwU
+msF
+dTE
+dTE
+ujT
+dTE
+iuO
+msF
+msF
+nrR
+dQt
+tbM
+msF
+hpz
+tYp
+hpz
+fgf
+bET
+uCI
+pCM
+ohq
+kGB
+kGB
+tSa
+rls
+rId
+msF
+msF
+msF
+hJo
+cqs
+nNV
+wAt
+iSX
+msF
+msF
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+hkG
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+poL
+iGy
+dzB
+vPq
+dzB
+bjm
+kap
+kOS
+mkM
+vPq
+fUA
+uqS
+gfV
+pHv
+hLG
+kZA
+sJu
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+jOq
+gnh
+ghW
+vNs
+apS
+gnh
+gnh
+uMq
+kZA
+tUK
+gEJ
+ghW
+xDM
+ghW
+ghW
+fUA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(326,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kJy
+mHU
+sYD
+tqK
+tYp
+rPw
+hpz
+fgf
+spj
+rzE
+mIl
+mIR
+iKn
+jKX
+acN
+lWU
+ttW
+acN
+acN
+acN
+okF
+rIZ
+iUg
+sMh
+uyM
+erc
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+cap
+cap
+cap
+bsh
+bsh
+bsh
+emq
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tUK
+dzB
+dzB
+kap
+poL
+kZA
+kZA
+kZA
+dDI
+fNZ
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+udF
+kZA
+heT
+heT
+heT
+heT
+dcE
+ghW
+gnh
+gnh
+kZA
+vNs
+vNs
+vNs
+kZA
+dDI
+dDI
+kZA
+slc
+poL
+rah
+rah
+qiW
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(327,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+rRf
+nNh
+nJr
+jXi
+kdH
+rXp
+kTC
+bkM
+fHC
+oye
+iVl
+xrn
+hpz
+tYp
+jks
+rPc
+acN
+acN
+acN
+acN
+pxB
+rDz
+acN
+acN
+acN
+acN
+acN
+acN
+eov
+gnk
+jBu
+nMU
+gkh
+hdf
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+uFL
+bsh
+bsh
+hnv
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+dmC
+pUV
+geD
+geD
+lZJ
+geD
+geD
+dzB
+lUs
+hxN
+kZA
+oPz
+usZ
+ivN
+usZ
+xpP
+usZ
+usZ
+usZ
+tHQ
+kZA
+heT
+heT
+heT
+poL
+ghW
+gEJ
+gnh
+gnh
+eiQ
+gnh
+gnh
+ghW
+gnh
+osI
+ghW
+eiQ
+ghW
+gnh
+ghW
+mwo
+mwo
+qiW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(328,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+oxF
+ivc
+ivc
+ngx
+wVW
+beq
+uEG
+wLt
+ite
+oye
+sYD
+dmf
+gta
+ioA
+hpz
+mHE
+sIv
+ddU
+qzQ
+mIR
+qqg
+rDz
+acN
+sCq
+eJG
+acN
+acN
+acN
+eov
+stO
+aKI
+nup
+rVF
+qeq
+acN
+acN
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+uFL
+bsh
+bsh
+bsh
+hnv
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+mGM
+dzB
+vPq
+dzB
+dzB
+vPq
+sDY
+dzB
+nof
+cKC
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+arA
+bmx
+eLP
+oAl
+heT
+heT
+fUA
+moq
+gnh
+ghW
+ghW
+pzO
+npl
+ghW
+lJv
+gnh
+gnh
+ghW
+ghW
+ghW
+gEJ
+ghW
+dXQ
+fOA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(329,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gpx
+afY
+jBx
+vSi
+rGN
+nim
+sqZ
+wLt
+scW
+kqQ
+bby
+acN
+ahz
+tYp
+oQD
+mHE
+bET
+bET
+ttW
+pqH
+fAf
+jKX
+acN
+wyI
+dIX
+acN
+acN
+acN
+eov
+stO
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+uFL
+bsh
+bsh
+bsh
+hnv
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+mGM
+nof
+vPq
+dzB
+dzB
+vPq
+geD
+mKZ
+rhW
+lxx
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+kZA
+oAl
+eLP
+pjq
+oAl
+heT
+kZA
+kZA
+kZA
+oRW
+eIA
+eQI
+kZA
+rah
+sxx
+rah
+kZA
+rah
+sxx
+rah
+kZA
+cNT
+ghW
+mwo
+qiW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(330,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gpx
+vSi
+pEb
+smG
+gXq
+uEG
+uEG
+wjP
+sYD
+sYD
+mKv
+acN
+hpz
+tYp
+tYp
+mHE
+hDj
+mIl
+bET
+mIR
+kGB
+nUy
+acN
+xrl
+dIX
+acN
+acN
+acN
+lvN
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+uFL
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+kZA
+kZA
+kZA
+vPq
+vPq
+mGM
+geD
+kZA
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+tHQ
+tHQ
+oAl
+oAl
+heT
+heT
+poL
+gnh
+gnh
+ghW
+poL
+xIm
+gnh
+gnh
+tUK
+ghW
+mBR
+ghW
+kZA
+mwo
+tff
+xdu
+qiW
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(331,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gpx
+hPv
+smG
+afY
+rGN
+nim
+aEN
+wLt
+kqQ
+sYD
+sYD
+acN
+hpz
+aJR
+ioA
+ivV
+acN
+kFR
+kFR
+acN
+rgZ
+kGB
+acN
+eUo
+dIX
+acN
+acN
+acN
+rQa
+esi
+tOH
+tOH
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+mbv
+mbv
+mbv
+mbv
+mbv
+mbv
+mbv
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+emq
+hke
+aTC
+fvF
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+kZA
+kZA
+kZA
+cKC
+vPq
+mGM
+hHo
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+tHQ
+tHQ
+pjq
+oAl
+oAl
+dKT
+xtt
+xDM
+xwm
+fUA
+sBt
+nFZ
+xwm
+kZA
+pWn
+iel
+xwm
+kZA
+fqJ
+ghW
+bAv
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(332,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+pSm
+vyQ
+kao
+ybU
+ajF
+lOY
+beq
+wLt
+kFn
+gIA
+mcJ
+acN
+rPw
+hpz
+tYp
+pKg
+kGB
+nvy
+kGB
+tSa
+kGB
+jKX
+iGQ
+dIX
+goD
+acN
+acN
+acN
+tyy
+fiR
+sMh
+hZV
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+kZA
+vPq
+vPq
+vPq
+vPq
+dzB
+hHo
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+tHQ
+eLP
+tHQ
+tHQ
+dKT
+kZA
+tUK
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+poL
+kZA
+kZA
+kZA
+kZA
+kZA
+kZA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(333,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+dhj
+jwM
+lwW
+sxf
+lwW
+nuf
+fsk
+jpK
+iaZ
+sYD
+ois
+acN
+hpz
+hpz
+hpz
+sMX
+jKX
+bgM
+jKX
+lZy
+dzy
+jKX
+swr
+hmK
+dIX
+acN
+acN
+acN
+hZj
+sMh
+tOH
+tOH
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+aTC
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+kZA
+gDd
+vPq
+dzB
+vPq
+dzB
+hHo
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+oAl
+tHQ
+dKT
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(334,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+fHC
+sYD
+aVr
+acN
+eaN
+rPw
+jks
+ivV
+acN
+acN
+acN
+acN
+kGB
+rDz
+acN
+kGn
+dIX
+acN
+acN
+acN
+brl
+sMh
+oVK
+sMh
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+cap
+bsh
+bsh
+hkG
+aTC
+hke
+aTC
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+kZA
+kZA
+poL
+dzB
+rvx
+mGM
+uwA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(335,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+hpz
+kMs
+hpz
+acN
+rYY
+bsM
+bli
+fFg
+dlH
+hUB
+acN
+iRJ
+dIX
+acN
+acN
+acN
+acN
+ujv
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+emq
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+heT
+heT
+heT
+heT
+geD
+geD
+geD
+geD
+geD
+geD
+geD
+uwA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(336,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+dcW
+otm
+dav
+hpz
+hpz
+hpz
+acN
+gjJ
+kGB
+iKn
+fAf
+kGB
+jKX
+acN
+mai
+dTE
+acN
+acN
+acN
+iXB
+uGv
+uGv
+niL
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(337,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+dcW
+dcW
+kFR
+oQD
+nxW
+oQD
+acN
+eYb
+qqg
+fyB
+kGB
+jKX
+kGB
+acN
+bns
+dTE
+acN
+acN
+acN
+iiQ
+ovU
+tPu
+rtT
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+cCG
+gDD
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(338,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+acN
+acN
+acN
+kFR
+kFR
+kFR
+acN
+acN
+acN
+acN
+acN
+kbg
+jYn
+acN
+acN
+acN
+acN
+acN
+acN
+uGv
+uGv
+uGv
+tGs
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+ieD
+aTC
+cCG
+uGc
+kTu
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+hnv
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(339,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+acN
+acN
+acN
+ufD
+iXm
+llg
+acN
+ueq
+kEn
+acN
+aur
+rki
+taY
+tyt
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+kNV
+aTC
+nDx
+emq
+hnv
+oHa
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+hnv
+ndQ
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(340,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+hMd
+cxt
+vMA
+acN
+pOl
+hpz
+kSO
+rBi
+nra
+mdr
+wua
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+seT
+aTC
+aTC
+aTC
+aTC
+bsh
+aTC
+cCG
+aTC
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(341,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+rBq
+lEr
+rBq
+uvZ
+hAi
+tYp
+acN
+uie
+xUk
+opV
+yao
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+cCG
+sFw
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+jio
+bsh
+bsh
+bsh
+bsh
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(342,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+acZ
+bzP
+gMp
+kFR
+acN
+jrr
+acN
+gQZ
+mdr
+mdr
+tPg
+acN
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+juO
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+jio
+bsh
+bsh
+bsh
+bsh
+aTC
+sOI
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(343,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+kFR
+kFR
+kFR
+acN
+acN
+eek
+acN
+hKl
+uNq
+lhC
+uNq
+acN
+acN
+acN
+acN
+acN
+cap
+cap
+cap
+cap
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+aTC
+cCG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+hnv
+bsh
+bsh
+bsh
+hke
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(344,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+ksj
+ksj
+xxJ
+ksj
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+hnv
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(345,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+ksj
+dfV
+dfV
+ksj
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+hnv
+bsh
+bsh
+bsh
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(346,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+ksj
+dfV
+vNn
+ksj
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+jio
+bsh
+bsh
+aTC
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(347,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+ksj
+oyu
+dfV
+ksj
+bsh
+bsh
+bsh
+uFL
+bsh
+uFL
+bsh
+bMA
+aTC
+aTC
+aTC
+aTC
+aTC
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(348,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+bsh
+bsh
+ksj
+ksj
+ksj
+ksj
+bsh
+bsh
+bsh
+uFL
+bsh
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+uFL
+uFL
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(349,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(350,1,1) = {"
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -203,6 +203,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/wasteland)
+"aS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "aT" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/warning,
@@ -216,6 +224,15 @@
 	name = "metal plating";
 	sunlight_state = 1
 	},
+/area/f13/wasteland)
+"aV" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
 "aX" = (
 /obj/structure/closet/crate,
@@ -254,6 +271,15 @@
 "bg" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
+	},
+/area/f13/building)
+"bh" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
 	},
 /area/f13/building)
 "bk" = (
@@ -309,6 +335,10 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood/surface)
+"bv" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "bw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -393,6 +423,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"bN" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "bO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/instacoffee{
@@ -474,6 +508,7 @@
 /obj/structure/fence/wooden{
 	dir = 4
 	},
+/obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "ci" = (
@@ -545,6 +580,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/surface)
+"cA" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
 "cB" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -630,6 +675,11 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"cP" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "cQ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -673,7 +723,7 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/building)
 "da" = (
 /obj/item/flashlight/lamp/green,
 /obj/structure/table/wood,
@@ -690,6 +740,10 @@
 "dc" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"dd" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "de" = (
 /turf/open/transparent/openspace,
 /area/f13/brotherhood/surface)
@@ -943,6 +997,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"el" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old{
@@ -968,6 +1028,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"ev" = (
+/obj/machinery/autolathe,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "ew" = (
 /obj/structure/chair/folding{
 	dir = 4
@@ -1016,6 +1081,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"eD" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "eE" = (
 /obj/structure/table/wood{
 	pixel_x = 2
@@ -1229,6 +1300,16 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"fw" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "fz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/trash,
@@ -1236,6 +1317,18 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"fD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "fE" = (
 /obj/structure/table,
 /obj/item/newspaper{
@@ -1274,6 +1367,14 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
+"fM" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "fN" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -1320,6 +1421,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"fX" = (
+/obj/structure/chair/stool/retro/backed,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "fY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1336,6 +1453,10 @@
 	},
 /turf/closed/wall/f13/store/constructed,
 /area/f13/ncr)
+"gb" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "ge" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -1807,6 +1928,17 @@
 	dir = 8
 	},
 /area/f13/building)
+"id" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "ie" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -1923,6 +2055,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"iN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "iO" = (
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
@@ -2099,6 +2235,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"jt" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/caves)
 "ju" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -2187,6 +2330,10 @@
 /obj/item/stack/wrapping_paper,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood/surface)
+"jP" = (
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "jQ" = (
 /obj/structure/fluff/paper/stack{
 	desc = "A stack of various papers, illegible scribbles scattered across each page.";
@@ -2374,6 +2521,13 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"ku" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "kv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2418,6 +2572,10 @@
 /obj/item/storage/box/ration/ranger_lunch,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"kK" = (
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "kM" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag,
@@ -2452,19 +2610,29 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
 "kR" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	},
-/obj/structure/fence/wooden{
+/obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "kS" = (
 /obj/structure/sign/poster/prewar/poster81,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"kT" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "kV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2515,6 +2683,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"le" = (
+/obj/structure/table,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lf" = (
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -2534,6 +2716,15 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"lk" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "ll" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -2588,6 +2779,12 @@
 	name = "grimy tile"
 	},
 /area/f13/brotherhood/surface)
+"lv" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "lx" = (
 /obj/structure/barricade/wooden,
 /obj/structure/fence/wooden{
@@ -2703,6 +2900,18 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/legion)
+"lQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "lS" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3008,6 +3217,18 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"mJ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "mK" = (
 /obj/machinery/light{
 	dir = 8
@@ -3141,6 +3362,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/wood_large,
 /area/f13/wasteland)
+"ng" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "nh" = (
 /obj/machinery/light{
 	dir = 4
@@ -3304,6 +3534,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nT" = (
+/obj/structure/simple_door/room/dirty,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "nU" = (
 /obj/structure/guncase{
 	anchored = 1
@@ -3335,6 +3569,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"nX" = (
+/obj/structure/window/fulltile/wood/broken,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "nY" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3378,6 +3622,13 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"od" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "oe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
@@ -3470,6 +3721,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"oq" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "or" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -3480,6 +3737,13 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"os" = (
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "ot" = (
 /obj/machinery/light{
 	dir = 8
@@ -3677,6 +3941,14 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"po" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "pr" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -3781,7 +4053,10 @@
 	},
 /area/f13/wasteland)
 "pN" = (
-/obj/structure/closet/crate/bin/trashbin,
+/obj/structure/table/booth,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
 	sunlight_state = 1
@@ -3828,12 +4103,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "pU" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "pV" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -3863,6 +4144,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qe" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
 "qf" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -3982,6 +4272,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qy" = (
+/obj/item/kirbyplants/random,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "qz" = (
 /obj/machinery/vending/cola/space_up,
 /obj/effect/decal/cleanable/dirt,
@@ -4111,6 +4405,10 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"ri" = (
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "rj" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
@@ -4162,6 +4460,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"rx" = (
+/turf/closed/wall/f13/tentwall,
+/area/f13/wasteland)
 "rz" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -4222,6 +4523,18 @@
 "rK" = (
 /turf/open/floor/wood/wood_large,
 /area/f13/wasteland)
+"rL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "rN" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 5;
@@ -4274,6 +4587,18 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"sa" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "sb" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4285,6 +4610,12 @@
 	dir = 1
 	},
 /area/f13/building)
+"se" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "sf" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -4318,6 +4649,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/followers)
+"sl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "sm" = (
 /obj/structure/simple_door/room,
 /obj/structure/decoration/rag{
@@ -4377,6 +4717,15 @@
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/wood,
 /area/f13/building)
+"st" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "sw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4435,9 +4784,10 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "sF" = (
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
 	},
 /area/f13/building)
 "sG" = (
@@ -4660,10 +5010,18 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"tx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "ty" = (
 /obj/structure/bed/mattress,
 /obj/item/bedsheet{
 	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
@@ -4771,6 +5129,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"tQ" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "tS" = (
 /obj/structure/railing{
 	dir = 4
@@ -4856,6 +5221,15 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"ud" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "ue" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -4917,6 +5291,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"ur" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "us" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -4924,6 +5304,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"ut" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "uu" = (
 /obj/structure/railing{
 	dir = 1
@@ -4940,6 +5324,26 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
+"uA" = (
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "uB" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -4965,6 +5369,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uL" = (
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "uM" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -5036,6 +5443,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"uV" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "uW" = (
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -5059,6 +5474,12 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"vd" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "ve" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
@@ -5086,9 +5507,11 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/wasteland)
 "vj" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/building)
 "vl" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -5241,6 +5664,20 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"vP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "vQ" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -5356,6 +5793,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"wr" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "ws" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/head/helmet/f13/tribal,
@@ -5514,6 +5957,29 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wV" = (
+/obj/structure/chair/stool/retro/backed,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
+"wW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "wX" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/strong,
@@ -5719,6 +6185,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"xR" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "ruinswindow"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "xS" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -5890,6 +6368,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -6072,11 +6551,15 @@
 /area/f13/building)
 "zA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
 /turf/open/transparent/openspace{
 	name = "air";
@@ -6120,6 +6603,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
+"zL" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "zM" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt{
@@ -6189,6 +6676,15 @@
 	dir = 1
 	},
 /area/f13/building)
+"Ac" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "Ad" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6202,9 +6698,22 @@
 "Af" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
+"Ag" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "Ai" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
+"Aj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ak" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -6243,6 +6752,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"Aq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack{
+	name = "equipment rack"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ar" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall/rust,
@@ -6384,6 +6902,12 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"AP" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "AQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -6497,6 +7021,10 @@
 /obj/item/clothing/under/f13/ncr/ncr_dress,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Bn" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "Bo" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -6513,6 +7041,14 @@
 	dir = 4
 	},
 /area/f13/brotherhood/surface)
+"Bq" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "Br" = (
 /obj/machinery/light{
 	dir = 1
@@ -6540,6 +7076,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
 	dir = 4;
+	tag = "icon-wooden_chair_settler (EAST)"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -6579,6 +7116,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"BL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "BN" = (
 /obj/item/flag/khan{
 	pixel_y = 17
@@ -6850,6 +7396,16 @@
 "CM" = (
 /turf/open/floor/carpet/black,
 /area/f13/caves)
+"CN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "CP" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -6869,6 +7425,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"CR" = (
+/obj/structure/bed/old,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "CS" = (
 /obj/structure/railing{
 	dir = 1
@@ -6904,6 +7464,9 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"CY" = (
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "Da" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/wood,
@@ -6927,6 +7490,7 @@
 "Dd" = (
 /obj/structure/chair/wood{
 	dir = 1;
+	tag = "icon-wooden_chair_settler (NORTH)"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -6973,6 +7537,13 @@
 	name = "skulls"
 	},
 /turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"Dr" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Ds" = (
 /obj/structure/railing{
@@ -7147,6 +7718,15 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"Eg" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ei" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/wood_large,
@@ -7224,6 +7804,14 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"EG" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "EH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7246,6 +7834,13 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"ER" = (
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "ET" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/caves)
@@ -7256,6 +7851,15 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"EW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "EY" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/blood/old{
@@ -7269,28 +7873,29 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Fe" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Ff" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
+"Fh" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+	dir = 8
 	},
 /turf/open/transparent/openspace{
 	name = "air";
 	sunlight_state = 1
 	},
-/area/f13/wasteland)
-"Ff" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/area/f13/building)
 "Fi" = (
 /obj/machinery/light{
 	dir = 4
@@ -8070,6 +8675,13 @@
 	dir = 1
 	},
 /area/f13/building)
+"Ik" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "In" = (
 /obj/machinery/light{
 	dir = 1
@@ -8262,6 +8874,13 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Ja" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
 "Jb" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -8447,6 +9066,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"JI" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "JJ" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -8485,6 +9110,18 @@
 	},
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
+"JQ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "JS" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
@@ -8496,6 +9133,10 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"JW" = (
+/obj/machinery/photocopier,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "JX" = (
 /obj/structure/rack,
@@ -8993,6 +9634,11 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"Ma" = (
+/obj/structure/table/wood,
+/obj/item/binoculars,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Mc" = (
 /obj/machinery/light{
 	dir = 4
@@ -9051,6 +9697,23 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"Mk" = (
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "Ml" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -9128,6 +9791,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"MI" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "MS" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -9136,6 +9803,12 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"MT" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "MU" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowvertical"
@@ -9175,6 +9848,10 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"Nf" = (
+/obj/machinery/workbench,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ng" = (
 /obj/structure/guncase,
 /obj/item/gun/energy/laser/complianceregulator,
@@ -9247,6 +9924,17 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"Ns" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/stack/f13Cash/random/med,
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
+"NA" = (
+/obj/structure/table,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "NB" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
@@ -9294,6 +9982,9 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"NM" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland)
 "NN" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -9448,6 +10139,11 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Ow" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "Ox" = (
 /obj/structure/decoration/vent,
 /obj/structure/curtain,
@@ -9488,6 +10184,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/brotherhood/surface)
+"OG" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "OH" = (
 /obj/machinery/light{
 	dir = 8;
@@ -9559,6 +10267,7 @@
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
@@ -9827,19 +10536,14 @@
 	dir = 4
 	},
 /area/f13/brotherhood/surface)
-"Qm" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+"Qk" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "Qn" = (
 /obj/item/trash/sosjerky{
 	pixel_x = -6
@@ -9925,6 +10629,21 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"QD" = (
+/obj/structure/simple_door/glass,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
+"QE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/megaphone,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "QH" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -10078,6 +10797,7 @@
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
@@ -10147,6 +10867,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
+"RA" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/caves)
 "RB" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -10199,16 +10928,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "RK" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/turf/closed/wall/f13/wood/house,
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "RM" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -10259,6 +10989,13 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"RU" = (
+/obj/structure/simple_door/house,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "RW" = (
 /obj/structure/rack,
 /obj/item/storage/book/bible/booze,
@@ -10400,6 +11137,13 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/f13/ncr)
+"SI" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/caves)
 "SL" = (
 /obj/structure/chair{
 	dir = 4
@@ -10480,6 +11224,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"Tb" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Tc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10507,10 +11258,18 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"Ti" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "Tk" = (
 /obj/structure/chair/stool{
 	dir = 8;
 	icon_state = "bench";
+	tag = "icon-bench (WEST)"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
@@ -10587,6 +11346,7 @@
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -10629,6 +11389,9 @@
 "TL" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
+"TP" = (
+/turf/closed/wall/f13/ruins,
 /area/f13/building)
 "TS" = (
 /obj/structure/simple_door/house,
@@ -10679,6 +11442,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Ud" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ue" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10776,11 +11547,11 @@
 	},
 /area/f13/followers)
 "Uz" = (
-/obj/structure/closet/crate/trashcart,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	pixel_y = 12
 	},
+/obj/machinery/mineral/wasteland_vendor/khanchem,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
 	sunlight_state = 1
@@ -10877,6 +11648,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"UV" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "UX" = (
 /obj/structure/table/wood,
 /obj/machinery/msgterminal/ncr{
@@ -10964,6 +11741,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
@@ -11133,6 +11911,16 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"We" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "Wh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11142,6 +11930,28 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"Wj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
+"Wk" = (
+/obj/structure/dresser,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/caves)
 "Wl" = (
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
@@ -11222,6 +12032,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"WB" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "WC" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11401,6 +12219,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Xi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -11;
+	pixel_y = 15
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "Xk" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -11544,6 +12374,13 @@
 /obj/item/warpaint_bowl,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"Yc" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/f13/caves)
 "Yd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -11625,6 +12462,13 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"YD" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "YH" = (
 /obj/item/clothing/under/f13/tribe,
 /obj/structure/rack,
@@ -11706,6 +12550,13 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"YV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "YY" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -11729,6 +12580,12 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"Zh" = (
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "Zk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -11742,6 +12599,13 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"Zl" = (
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/caves)
 "Zn" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -11931,6 +12795,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"ZY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "ZZ" = (
 /obj/structure/kitchenspike,
 /obj/structure/decoration/rag,
@@ -11941,6 +12809,7 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+
 (1,1,1) = {"
 Al
 Al
@@ -13788,13 +14657,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14045,13 +14914,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14302,13 +15171,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14555,18 +15424,18 @@ Jd
 kC
 kC
 kC
+pg
+pg
+pg
+pg
+pg
+pg
+pg
+pg
+pg
 kC
 kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -14812,18 +15681,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
+pg
+ri
+qy
+pg
+ut
+zL
+Nf
+TG
+NM
+jZ
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -15069,18 +15938,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+pg
+el
+fD
+jP
+jZ
+sl
+jZ
+TG
+xR
+se
+sl
+aJ
 PL
 PL
 PL
@@ -15326,18 +16195,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+pg
+ku
+ng
+pg
+QE
+sl
+sl
+ev
+xR
+sl
+sl
+aJ
 PL
 PL
 PL
@@ -15583,18 +16452,18 @@ Jd
 kC
 kC
 lH
-kC
-kC
-kC
-kC
+pg
+pg
+pg
+pg
+Aq
+sl
+sl
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+NM
+Wj
+sl
+aJ
 PL
 PL
 PL
@@ -15843,15 +16712,15 @@ kC
 kC
 kC
 kC
-kC
+pg
+Aq
+sl
 Wx
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+kK
+sl
+se
+aJ
 PL
 PL
 PL
@@ -16100,15 +16969,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+pg
+jZ
+Tb
+NM
+NM
+NM
+sl
+jZ
+aJ
 PL
 PL
 PL
@@ -16357,15 +17226,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+pg
 Wx
 PL
+NM
+Wx
+Wx
+sl
+jZ
+aJ
 PL
 PL
 PL
@@ -16614,15 +17483,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+pg
+NM
+NM
+NM
+jZ
+rL
+se
+jZ
+aJ
 PL
 PL
 PL
@@ -16872,14 +17741,14 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+TG
+os
+jZ
+wV
+po
+OG
+jZ
+aJ
 PL
 PL
 PL
@@ -17129,14 +17998,14 @@ kC
 kC
 kC
 kC
+TG
+od
+sl
+fX
+WB
+Eg
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17386,14 +18255,14 @@ kC
 kC
 kC
 kC
+TG
+gb
+sl
+sl
+EW
+jZ
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17643,14 +18512,14 @@ kC
 kC
 kC
 kC
+TG
+Ma
+se
+se
 Wx
 Wx
 Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17899,14 +18768,14 @@ kC
 kC
 kC
 kC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
 PL
 PL
 PL
@@ -28188,19 +29057,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+TP
+wr
+eD
+eD
+TP
+eD
+eD
+wr
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28440,24 +29309,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+TP
+TP
+TP
+TP
+TP
+bN
+iN
+nM
+nM
+Qk
+Dr
+MI
+MI
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28697,24 +29566,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+UV
+NA
+HD
+uA
+TP
+Ow
+tx
+tx
+dc
+dc
+nM
+nM
+nM
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28954,24 +29823,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+tQ
+Bq
+HD
+HD
+nT
+tx
+nM
+tx
+JQ
+Fh
+Fh
+Fh
+Fh
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29211,24 +30080,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+HD
+HD
+HD
+JW
+TP
+nM
+dc
+nM
+bh
+Py
+Py
+Py
+Py
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29468,24 +30337,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+Mk
+HD
+HD
+le
+TP
+Py
+Fh
+Fh
+Py
+Py
+Py
+Py
+Py
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29725,24 +30594,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+TP
+TP
+TP
+TP
+TP
+Py
+Py
+Py
+Py
+Py
+Py
+Py
+Py
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29987,19 +30856,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+TP
+TP
+TP
+TP
+TP
+TP
+TP
+TP
+TP
+TP
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30254,9 +31123,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30511,9 +31380,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30768,9 +31637,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -45975,11 +46844,11 @@ PL
 PL
 PL
 CC
-CC
 PL
 PL
-CC
-CC
+PL
+PL
+ZY
 CC
 PL
 PL
@@ -46220,11 +47089,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
@@ -46235,9 +47104,9 @@ CC
 PL
 PL
 PL
-CC
-CC
-CC
+PL
+PL
+ZY
 PL
 PL
 PL
@@ -46477,23 +47346,23 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
 PL
 CC
 CC
+CC
+CC
+CC
+CC
+PL
+PL
 CC
 PL
 PL
@@ -46734,25 +47603,25 @@ PL
 PL
 PL
 PL
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
@@ -46990,15 +47859,14 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
 CC
 CC
-CC
-CC
-CC
-CC
+PL
+PL
 PL
 PL
 CC
@@ -47011,8 +47879,9 @@ CC
 CC
 CC
 CC
-CC
-CC
+PL
+PL
+PL
 PL
 PL
 PL
@@ -47247,15 +48116,14 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
 CC
 CC
-CC
-CC
-CC
-CC
+PL
+PL
 PL
 PL
 CC
@@ -47268,8 +48136,9 @@ CC
 CC
 CC
 CC
-CC
-CC
+PL
+PL
+PL
 PL
 PL
 PL
@@ -47504,15 +48373,14 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
 CC
 CC
-CC
-CC
-CC
-CC
+PL
+PL
 PL
 PL
 CC
@@ -47525,8 +48393,9 @@ CC
 CC
 CC
 CC
-CC
-CC
+PL
+PL
+PL
 PL
 PL
 PL
@@ -47761,15 +48630,15 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
 CC
 CC
-CC
-CC
-CC
-CC
+PL
+PL
+PL
 PL
 CC
 CC
@@ -48018,7 +48887,7 @@ PL
 PL
 PL
 PL
-CC
+PL
 CC
 CC
 CC
@@ -48028,9 +48897,9 @@ CC
 CC
 CC
 PL
-PL
-PL
-PL
+CC
+CC
+CC
 CC
 CC
 CC
@@ -48275,7 +49144,7 @@ PL
 PL
 PL
 PL
-CC
+PL
 CC
 CC
 CC
@@ -48285,9 +49154,9 @@ CC
 CC
 CC
 PL
-PL
-PL
-PL
+CC
+CC
+CC
 CC
 CC
 CC
@@ -48532,7 +49401,7 @@ PL
 PL
 PL
 PL
-CC
+PL
 CC
 CC
 CC
@@ -48542,9 +49411,9 @@ CC
 CC
 CC
 PL
-PL
-PL
-PL
+CC
+CC
+CC
 CC
 CC
 CC
@@ -48789,7 +49658,7 @@ PL
 PL
 PL
 PL
-CC
+PL
 CC
 CC
 CC
@@ -48799,12 +49668,12 @@ CC
 CC
 CC
 PL
-PL
-PL
-PL
-PL
-PL
-PL
+CC
+CC
+CC
+CC
+CC
+CC
 CC
 CC
 CC
@@ -49046,7 +49915,7 @@ PL
 PL
 PL
 PL
-CC
+PL
 CC
 CC
 CC
@@ -49062,13 +49931,13 @@ PL
 PL
 PL
 PL
+PL
+PL
+PL
+PL
+PL
 CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -49304,6 +50173,14 @@ PL
 PL
 PL
 PL
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
@@ -49316,15 +50193,7 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+CC
 PL
 PL
 PL
@@ -49560,9 +50429,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -49576,12 +50443,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
 PL
 PL
 PL
@@ -49817,16 +50686,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -49839,6 +50699,15 @@ PL
 PL
 PL
 PL
+PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
 PL
 PL
 PL
@@ -50074,19 +50943,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -50096,6 +50953,18 @@ CC
 CC
 CC
 PL
+PL
+PL
+PL
+PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
 PL
 PL
 PL
@@ -50331,6 +51200,7 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
@@ -50339,21 +51209,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -50588,6 +51457,7 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
@@ -50596,21 +51466,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -50845,6 +51714,7 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
@@ -50853,21 +51723,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -51102,21 +51971,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -51130,13 +51985,27 @@ PL
 PL
 PL
 PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
 PL
 PL
+PL
+PL
+PL
+PL
+PL
+PL
+Wx
 Wx
 Wx
 Wx
 Wx
-Wx
 PL
 PL
 PL
@@ -51157,7 +52026,7 @@ al
 al
 al
 al
-PL
+Wx
 PL
 PL
 PL
@@ -51359,21 +52228,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -51387,6 +52242,20 @@ PL
 PL
 PL
 PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 Wx
@@ -51415,9 +52284,9 @@ Wx
 Wx
 Wx
 Wx
-Wx
-Wx
-Wx
+PL
+PL
+PL
 PL
 PL
 PL
@@ -51616,21 +52485,7 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 CC
 CC
 CC
@@ -51644,6 +52499,20 @@ PL
 PL
 PL
 PL
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+CC
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 Wx
@@ -51666,15 +52535,15 @@ Wx
 Wx
 Wx
 PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
+PL
 PL
 PL
 PL
@@ -51873,6 +52742,7 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
@@ -51881,21 +52751,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -51922,14 +52791,11 @@ Wx
 Wx
 Wx
 Wx
+Wx
+Wx
+Wx
+Wx
 PL
-PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
 Wx
 Wx
 PL
@@ -51938,8 +52804,11 @@ PL
 PL
 PL
 PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -52130,6 +52999,7 @@ PL
 PL
 PL
 PL
+PL
 CC
 CC
 CC
@@ -52138,21 +53008,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 CC
 CC
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
 PL
 PL
 PL
@@ -52179,15 +53048,12 @@ Wx
 Wx
 Wx
 Wx
+Wx
+Wx
+Wx
 PL
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
 Wx
 PL
 PL
@@ -52195,8 +53061,11 @@ PL
 PL
 PL
 PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -52387,6 +53256,8 @@ PL
 PL
 PL
 PL
+PL
+PL
 CC
 CC
 CC
@@ -52394,22 +53265,20 @@ CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -52436,15 +53305,12 @@ Wx
 Wx
 Wx
 Wx
+Wx
+Wx
+Wx
 PL
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
 Wx
 PL
 PL
@@ -52452,8 +53318,11 @@ PL
 PL
 PL
 PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -52644,29 +53513,29 @@ PL
 PL
 PL
 PL
+PL
+PL
+PL
 CC
 CC
 CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -52693,14 +53562,12 @@ Wx
 Wx
 Wx
 Wx
+Wx
+Wx
+Wx
 PL
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
 Wx
 PL
 PL
@@ -52708,9 +53575,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -52901,29 +53770,29 @@ PL
 PL
 PL
 PL
+PL
+PL
+PL
+PL
 CC
 CC
 CC
 CC
 CC
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -52950,15 +53819,12 @@ Wx
 Wx
 Wx
 Wx
+Wx
+Wx
+Wx
 PL
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
 Wx
 PL
 PL
@@ -52966,8 +53832,11 @@ PL
 PL
 PL
 PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -53158,22 +54027,10 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+PL
+PL
+PL
+PL
 CC
 CC
 CC
@@ -53193,6 +54050,21 @@ PL
 PL
 PL
 PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+Wx
+Wx
+Wx
 Wx
 Wx
 Wx
@@ -53211,12 +54083,9 @@ PL
 PL
 Wx
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
+PL
+PL
 PL
 PL
 PL
@@ -53415,24 +54284,6 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
 PL
 PL
 PL
@@ -53450,6 +54301,31 @@ PL
 PL
 PL
 PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 Wx
 Wx
 Wx
@@ -53466,14 +54342,7 @@ Wx
 Wx
 PL
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
 PL
 PL
 PL
@@ -53722,15 +54591,15 @@ Wx
 Wx
 Wx
 PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
+PL
 PL
 PL
 PL
@@ -53979,15 +54848,15 @@ Wx
 Wx
 Wx
 PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
+PL
 PL
 PL
 PL
@@ -54236,14 +55105,14 @@ Wx
 Wx
 Wx
 PL
+Wx
+Wx
+Wx
+Wx
 PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+PL
+PL
+PL
 PL
 PL
 PL
@@ -54493,15 +55362,15 @@ Wx
 Wx
 Wx
 PL
-PL
-Wx
-Wx
-Wx
-Wx
 Wx
 Wx
 Wx
 PL
+PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -54750,15 +55619,15 @@ Wx
 Wx
 Wx
 PL
-PL
-Wx
-Wx
-Wx
 Wx
 Wx
 Wx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -55008,14 +55877,14 @@ PL
 PL
 PL
 PL
-Wx
-Wx
-Wx
 PL
 PL
-Wx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -55269,10 +56138,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -55526,10 +56395,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -56822,11 +57691,11 @@ bg
 Ez
 sr
 PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -57079,17 +57948,17 @@ bg
 En
 zB
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -57336,23 +58205,23 @@ bg
 tU
 zB
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -57452,13 +58321,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+cY
+zB
+oU
+Xv
+bs
+vj
+aL
 PL
 PL
 PL
@@ -57593,23 +58462,23 @@ zB
 zB
 ze
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -57710,12 +58579,12 @@ PL
 PL
 PL
 RK
-zB
-oU
-Xv
-bs
+pN
+yM
+yM
+yM
 sF
-aL
+Xv
 PL
 PL
 PL
@@ -57850,23 +58719,23 @@ yj
 Oo
 sr
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -57971,7 +58840,7 @@ XS
 Nr
 yM
 yM
-pN
+yM
 Xv
 eA
 PL
@@ -58107,23 +58976,23 @@ yj
 QQ
 UG
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
+rx
+rx
+rx
+rx
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -58364,6 +59233,11 @@ nr
 zB
 zB
 PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -58372,15 +59246,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -58621,11 +59490,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+rx
+rx
+rx
+rx
+rx
 PL
 PL
 PL
@@ -60570,17 +61439,17 @@ vX
 AM
 AM
 AM
-kC
-kC
-fu
-kR
-kC
-xj
 AM
 AM
 AM
 AM
-nd
+AM
+AM
+AM
+AM
+AM
+Hj
+aJ
 PL
 PL
 PL
@@ -60834,10 +61703,10 @@ AM
 AM
 AM
 AM
-AM
-AM
-Hj
-aJ
+wX
+zA
+nE
+PL
 PL
 PL
 PL
@@ -61081,19 +61950,19 @@ PL
 PL
 nE
 nE
-jS
-pU
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-wX
-Fe
 nE
+nE
+nE
+nE
+pU
+nE
+nE
+pU
+nE
+nE
+nE
+PL
+PL
 PL
 PL
 PL
@@ -61339,16 +62208,16 @@ PL
 PL
 PL
 PL
-nE
-nE
-nE
-Qm
-nE
-nE
-Qm
-nE
-nE
-nE
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -61853,18 +62722,18 @@ AM
 AM
 AM
 nL
-tY
-tY
-zA
-tY
-tY
-tY
-tY
-tY
-tY
-tY
-zA
-tY
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -62110,19 +62979,19 @@ Xt
 AM
 AM
 AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-pU
-aJ
+Ds
+tY
+kR
+tY
+tY
+tY
+tY
+tY
+tY
+tY
+kR
+tY
+PL
 PL
 PL
 PL
@@ -62364,8 +63233,6 @@ LA
 yZ
 oC
 Al
-Al
-Al
 AM
 AM
 AM
@@ -62373,13 +63240,15 @@ AM
 AM
 AM
 AM
-xo
-xo
-xo
 AM
 AM
 AM
-Ds
+AM
+AM
+AM
+AM
+Fe
+aJ
 PL
 PL
 PL
@@ -62624,8 +63493,8 @@ kC
 kC
 BC
 Vo
-Al
-Al
+AM
+AM
 AM
 Xt
 AM
@@ -63129,7 +63998,7 @@ PL
 Mj
 Gl
 Gl
-kC
+Jk
 kC
 kC
 kC
@@ -63386,7 +64255,7 @@ PL
 Mj
 Gl
 mz
-kC
+fu
 kC
 kC
 kC
@@ -63496,8 +64365,8 @@ Jk
 oR
 AM
 AM
-kC
-kC
+AM
+AM
 kC
 kC
 kC
@@ -63646,12 +64515,12 @@ Gl
 Cb
 PL
 PL
-PL
-PL
-PL
-PL
 Jk
-Jk
+kC
+kC
+kC
+kC
+kC
 kC
 kC
 kC
@@ -63753,18 +64622,18 @@ Jk
 kC
 wo
 AM
+AM
+AM
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -63907,9 +64776,9 @@ PL
 PL
 PL
 PL
-PL
-PL
-lx
+kC
+kC
+kC
 kC
 kC
 kC
@@ -64010,18 +64879,18 @@ kC
 kC
 AM
 AM
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+AM
+AM
+AM
+Jj
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -64164,10 +65033,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-Jk
+kC
+Al
+Al
+Al
 kC
 kC
 kC
@@ -64244,17 +65113,17 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+uL
+uL
+uL
+uL
+uL
+uL
+uL
+Bn
+uL
+uL
+uL
 kC
 Ht
 Jk
@@ -64268,17 +65137,17 @@ kC
 xj
 AM
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+AM
+md
+md
+pR
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -64421,12 +65290,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-SA
+kC
+kC
+kC
+Al
+Al
+Al
+Al
 kC
 kC
 kC
@@ -64435,53 +65305,6 @@ kC
 kC
 kC
 kC
-kC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
 PL
 PL
 PL
@@ -64491,10 +65314,73 @@ PL
 PL
 PL
 PL
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
+CC
 PL
 PL
 PL
 PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+kC
+kC
+kC
+kC
+kC
+kC
+uL
+RA
+RA
+CY
+WY
+WY
+WY
+RU
+WY
+xo
+AP
 kC
 kC
 kC
@@ -64512,30 +65398,13 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -64678,14 +65547,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
+Ht
 Jk
+fu
 kC
+kC
+kC
+kC
+Al
 kC
 kC
 kC
@@ -64758,6 +65627,17 @@ lH
 kC
 kC
 kC
+uL
+lQ
+st
+JI
+Ti
+lv
+Zh
+uL
+Wk
+WY
+AP
 kC
 kC
 kC
@@ -64775,26 +65655,15 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -64934,14 +65803,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-gg
+Mj
+kT
+CN
+ad
+pg
+Jk
+SI
+uV
 kC
 kC
 kC
@@ -65015,18 +65884,17 @@ kC
 kC
 kC
 lH
-lH
-kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-kC
-kC
-kC
+Bn
+Ns
+st
+lk
+QU
+aV
+Af
+Af
+oq
+CR
+AP
 kC
 kC
 kC
@@ -65045,13 +65913,14 @@ kC
 kC
 kC
 Wx
-kC
-kC
-kC
-kC
-kC
-kC
-PL
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 PL
@@ -65191,14 +66060,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Mj
+Zl
+wW
+EG
+WY
+dd
+dd
+Ht
 kC
 kC
 kC
@@ -65272,17 +66141,17 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-kC
+Bn
+ur
+st
+cA
+QU
+Ik
+Af
+Af
+Af
+Af
+uL
 kC
 kC
 PL
@@ -65308,7 +66177,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -65448,13 +66317,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Mj
+YD
+wW
+cP
+WY
+vP
+id
 Jk
 kC
 kC
@@ -65529,18 +66398,18 @@ kC
 kC
 kC
 kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+Bn
+ud
+qe
+Ja
+QU
+Gj
+bv
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -65565,7 +66434,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -65705,14 +66574,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-BC
-kC
+Mj
+BL
+wW
+nX
+WY
+We
+Xi
+Jk
 kC
 kC
 kC
@@ -65786,18 +66655,18 @@ kC
 kC
 kC
 kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+Bn
+TG
+Ud
+sa
+jZ
+Ka
+Af
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -65953,7 +66822,7 @@ Qp
 AM
 AM
 AM
-pg
+zI
 eA
 PL
 PL
@@ -65962,10 +66831,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
+mJ
+YV
+cP
+WY
+Yc
+dd
 Jk
 kC
 kC
@@ -65974,9 +66846,6 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
 PL
 PL
 PL
@@ -66043,18 +66912,18 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+Af
+Af
+fw
+vd
+fM
+Af
+Af
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -66073,7 +66942,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -66210,7 +67079,7 @@ bk
 Lf
 AM
 vX
-yZ
+ad
 PL
 PL
 PL
@@ -66219,10 +67088,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-cY
+Mj
+Zl
+aS
+Ht
+WY
+Ag
+Jk
+Jk
 kC
 kC
 kC
@@ -66230,10 +67103,6 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
 PL
 PL
 PL
@@ -66301,6 +67170,21 @@ PL
 PL
 PL
 PL
+Ac
+PL
+PL
+PL
+Aj
+Wx
+Wx
+Wx
+Wx
+Wx
+Wx
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -66311,26 +67195,11 @@ Wx
 Wx
 Wx
 Wx
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
 Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -66476,10 +67345,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
+ER
+MT
+QD
+xo
+Zh
+Ht
 kC
 kC
 kC
@@ -66488,9 +67360,6 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
 PL
 PL
 PL
@@ -66587,7 +67456,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -66730,24 +67599,24 @@ kC
 kC
 kC
 kC
-kC
-BC
 PL
 PL
 PL
 PL
-PL
-kC
-kC
-kC
-kC
-kC
+aE
+fu
+jt
+Jk
+Jk
+Ht
 kC
 kC
 kC
 kC
 kC
 kC
+kC
+kC
 PL
 PL
 PL
@@ -66844,7 +67713,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -66988,12 +67857,9 @@ kC
 kC
 kC
 kC
-kC
-gg
+BC
 PL
 PL
-PL
-vj
 kC
 kC
 kC
@@ -67004,6 +67870,9 @@ kC
 kC
 kC
 kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -67047,16 +67916,6 @@ CC
 CC
 CC
 CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
 PL
 PL
 PL
@@ -67077,6 +67936,16 @@ PL
 PL
 PL
 Wx
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+Wx
 Wx
 Wx
 Wx
@@ -67101,7 +67970,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -67246,10 +68115,8 @@ kC
 kC
 kC
 kC
-kC
-pg
-Jk
-kC
+PL
+PL
 kC
 kC
 kC
@@ -67261,6 +68128,8 @@ kC
 kC
 kC
 kC
+kC
+kC
 PL
 PL
 PL
@@ -67358,7 +68227,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -67504,6 +68373,7 @@ kC
 kC
 kC
 kC
+Jk
 kC
 kC
 kC
@@ -67517,7 +68387,6 @@ kC
 kC
 kC
 kC
-kC
 PL
 PL
 PL
@@ -67580,7 +68449,7 @@ PL
 PL
 PL
 PL
-PL
+Gl
 PL
 PL
 PL
@@ -67615,7 +68484,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -67759,6 +68628,8 @@ kC
 kC
 kC
 kC
+Al
+Al
 kC
 kC
 kC
@@ -67773,8 +68644,6 @@ kC
 kC
 kC
 kC
-kC
-kC
 PL
 PL
 PL
@@ -67837,7 +68706,7 @@ PL
 PL
 PL
 PL
-PL
+Gl
 PL
 PL
 PL
@@ -67872,7 +68741,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -68129,7 +68998,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -68264,7 +69133,7 @@ AM
 xo
 xE
 AM
-Ht
+mm
 Gt
 kC
 kC
@@ -68351,7 +69220,7 @@ PL
 PL
 PL
 PL
-PL
+Wx
 PL
 PL
 PL
@@ -68386,7 +69255,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -68643,7 +69512,7 @@ Wx
 PL
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -68900,7 +69769,7 @@ Wx
 Wx
 PL
 PL
-Wx
+PL
 Wx
 Wx
 Wx
@@ -69167,7 +70036,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -69424,7 +70293,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -69938,7 +70807,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -70195,7 +71064,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+Wx
 PL
 PL
 PL
@@ -70414,8 +71283,8 @@ PL
 PL
 Wx
 Wx
-PL
-PL
+Gl
+Gl
 Wx
 Wx
 Wx
@@ -70671,8 +71540,8 @@ PL
 PL
 Wx
 Wx
-PL
-PL
+Gl
+Gl
 Wx
 Wx
 Wx

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -285,11 +285,16 @@
 	},
 /area/f13/wasteland)
 "agA" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 4
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
 	},
-/obj/structure/fluff/beach_umbrella/cap,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "agF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -513,6 +518,7 @@
 "akk" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -521,6 +527,21 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"akl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/wicker{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/reagent_containers/pill/patch/bitterdrink,
+/obj/item/reagent_containers/pill/patch/bitterdrink,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "ako" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/road{
@@ -750,6 +771,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
+"apf" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "apk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
@@ -866,6 +891,11 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"arR" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "arT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/f13{
@@ -932,10 +962,10 @@
 	},
 /area/f13/wasteland)
 "atk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "atI" = (
 /obj/structure/cargocrate,
@@ -1023,6 +1053,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"auV" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "auX" = (
 /obj/structure/simple_door/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1086,28 +1126,35 @@
 	},
 /area/f13/building)
 "awO" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/window/fulltile/wood,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "axo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/wasteland)
 "axr" = (
 /obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "axw" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "axA" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -1121,7 +1168,6 @@
 /area/f13/caves)
 "axG" = (
 /obj/item/storage/trash_stack,
-/obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
@@ -1267,6 +1313,30 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"aBi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"aBj" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "aBx" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -1405,10 +1475,8 @@
 /area/f13/wasteland)
 "aFG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "aFK" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -1424,20 +1492,13 @@
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aFV" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
 "aFY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "aGc" = (
 /obj/structure/table,
@@ -1494,12 +1555,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "aHN" = (
-/obj/structure/fluff/beach_umbrella/security,
-/obj/structure/chair/comfy/plywood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
 /area/f13/village)
 "aIe" = (
 /obj/structure/fence/handrail_corner{
@@ -1624,6 +1683,14 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"aKh" = (
+/obj/structure/wreck/trash/machinepile{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "aKs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -1845,6 +1912,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
+"aPK" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "aPN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -2018,7 +2091,18 @@
 	},
 /area/f13/village)
 "aUa" = (
-/turf/open/indestructible/ground/outside/water,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
 /area/f13/village)
 "aUl" = (
 /obj/structure/fence,
@@ -2073,9 +2157,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "aVn" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aVq" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2184,6 +2271,7 @@
 "aXM" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
@@ -2270,6 +2358,14 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"aZH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/f13/cram,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "aZJ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
@@ -2405,12 +2501,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "bbW" = (
-/obj/structure/simple_door/room,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/village)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/wood/broken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "bca" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -2453,15 +2553,12 @@
 /turf/open/water,
 /area/f13/caves)
 "bcF" = (
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty. You hear some weird noises behind these vents...";
-	pixel_x = -7;
-	pixel_y = -3
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/enclave)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "bcK" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -2601,6 +2698,7 @@
 "beF" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -2637,6 +2735,12 @@
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bfW" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/caves)
 "bgd" = (
 /obj/structure/barricade/wooden,
 /turf/open/water,
@@ -2653,13 +2757,15 @@
 	},
 /area/f13/wasteland)
 "bgq" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "bgs" = (
 /obj/item/clothing/suit/f13/sexymaid,
 /obj/structure/closet/cabinet/anchored{
@@ -2710,10 +2816,23 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/village)
+"bgY" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "bhc" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bhA" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "bhC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -2798,6 +2917,16 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"bjf" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "bjg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -2872,10 +3001,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "bkc" = (
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "housewastelandsouth"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
 "bkk" = (
 /obj/structure/target_stake,
@@ -2892,6 +3021,10 @@
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"bkC" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "bkF" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -2937,11 +3070,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"blt" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "blu" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/wood/f13/oak,
@@ -2973,6 +3101,16 @@
 	},
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"bmf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "bmh" = (
 /turf/open/floor/wood/f13/stage_br,
@@ -3110,6 +3248,7 @@
 	layer = 2.07;
 	max_mobs = 2
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
 	},
@@ -3137,6 +3276,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "boN" = (
@@ -3598,6 +3738,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/tunnel)
+"bxG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "bxK" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	pixel_y = 21
@@ -3608,10 +3755,12 @@
 /obj/structure/chair/stool{
 	dir = 4;
 	icon_state = "bench";
+	tag = "icon-bench (EAST)"
 	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "bzb" = (
@@ -3685,10 +3834,12 @@
 /obj/structure/chair/stool{
 	dir = 8;
 	icon_state = "bench";
+	tag = "icon-bench (WEST)"
 	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "bAh" = (
@@ -3901,12 +4052,12 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bEu" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood/house,
-/area/f13/village)
+/area/f13/wasteland)
 "bEw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -3946,6 +4097,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bFR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "Vault1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "bFV" = (
 /obj/item/trash/f13/cram,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3956,6 +4115,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"bGk" = (
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/farm)
 "bGu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -3968,8 +4132,8 @@
 /area/f13/village)
 "bGG" = (
 /obj/structure/table,
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/turf/open/floor/wood/f13/old/ruinedcornerbl,
+/area/f13/wasteland)
 "bGM" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4019,6 +4183,13 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"bIe" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "bIh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4283,6 +4454,15 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"bNp" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/building)
 "bNA" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -4427,6 +4607,7 @@
 "bQr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
+	tag = "icon-tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -4507,19 +4688,26 @@
 	},
 /area/f13/building)
 "bRF" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner";
+/obj/effect/overlay/junk/toilet{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/item/clothing/under/f13/legskirt/tac,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "bRG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
+"bRO" = (
+/obj/structure/simple_door/dirtyglass,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "bRP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4534,6 +4722,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "bSR" = (
@@ -4542,6 +4731,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "bSS" = (
@@ -4587,10 +4777,9 @@
 	},
 /area/f13/tunnel)
 "bTk" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/closed/wall/f13/store,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bTl" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
@@ -4608,11 +4797,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "bUd" = (
-/obj/structure/table/wood/poker,
-/obj/item/storage/box/dice,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "bUj" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -4676,6 +4863,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "bVT" = (
@@ -4778,6 +4966,23 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"bZj" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "bZk" = (
 /obj/structure/rack,
 /obj/item/crowbar/basic,
@@ -4944,6 +5149,15 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"cbK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
+/area/f13/village)
 "cbM" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -5004,11 +5218,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/brotherhood/surface)
 "ccN" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/enclave)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "ccZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5072,8 +5287,9 @@
 /turf/open/floor/wood/f13/stage_b/outdoors,
 /area/f13/building)
 "ces" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/obj/item/trash/f13/dog,
+/turf/open/floor/wood/f13/old/ruinedcornerendtl,
+/area/f13/wasteland)
 "cey" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -5146,6 +5362,16 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cfX" = (
+/obj/machinery/autolathe/constructionlathe,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "cgc" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert{
@@ -5164,6 +5390,7 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/caves)
 "chb" = (
@@ -5176,6 +5403,18 @@
 /obj/machinery/smartfridge/bottlerack/gardentool,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"chH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/item/paper/crumpled,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "chT" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt,
@@ -5359,6 +5598,7 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "cmU" = (
@@ -5420,6 +5660,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "cnz" = (
@@ -5495,6 +5736,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "cov" = (
@@ -5594,6 +5836,7 @@
 /obj/item/clothing/head/radiation,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
 "cqt" = (
@@ -5692,6 +5935,22 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"crP" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "crR" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5755,10 +6014,11 @@
 	},
 /area/f13/building)
 "ctm" = (
-/obj/item/bedsheet,
-/obj/structure/bed/old,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
 /area/f13/village)
 "cts" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5788,6 +6048,17 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/building)
+"cuk" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "cuv" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -5817,6 +6088,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"cuQ" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "cvu" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -5886,6 +6164,13 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"cym" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowdestroyed"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "cyp" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/ruins{
@@ -5906,6 +6191,16 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"czm" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "czr" = (
@@ -6018,6 +6313,14 @@
 	id = "exteriorgate2"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"cAG" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building)
 "cAQ" = (
 /obj/structure/table/wood/settler,
@@ -6358,16 +6661,14 @@
 	},
 /area/f13/wasteland)
 "cIR" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "cJj" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -6503,6 +6804,7 @@
 "cLX" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
 "cMb" = (
@@ -6562,6 +6864,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "cNv" = (
+/obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
@@ -6614,6 +6917,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"cPd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
+/area/f13/village)
 "cPg" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -6653,6 +6962,15 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cPL" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/building)
 "cPR" = (
 /obj/structure/chair/wood/fancy,
 /obj/machinery/light/small/broken{
@@ -6685,13 +7003,12 @@
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "cRc" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "cRd" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6739,6 +7056,13 @@
 /obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
+/area/f13/building)
+"cTd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cTg" = (
 /obj/structure/window/fulltile/store,
@@ -6814,6 +7138,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "cVx" = (
@@ -6842,6 +7167,7 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "cWq" = (
@@ -6871,6 +7197,7 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "cWG" = (
@@ -7050,6 +7377,14 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/f13/store/constructed,
 /area/f13/ncr)
+"cZw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "cZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7082,8 +7417,19 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
+"daK" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "daU" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -7201,9 +7547,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dcS" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/flora/grass/jungle,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "ddb" = (
 /obj/item/ammo_casing/caseless,
 /turf/open/floor/f13/wood,
@@ -7393,6 +7745,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/building)
 "dgU" = (
@@ -7543,6 +7896,16 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"djP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "djV" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowdestroyed"
@@ -7694,11 +8057,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dmg" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/enclave)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "dmC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -7803,10 +8168,12 @@
 	},
 /area/f13/village)
 "doh" = (
-/obj/structure/simple_door/metal/dirtystore,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "dol" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -7820,6 +8187,17 @@
 	icon_state = "verticalinnermainbottom"
 	},
 /area/f13/wasteland)
+"dos" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/processor/chopping_block,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "doB" = (
 /obj/item/trash/semki,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7847,6 +8225,14 @@
 /obj/structure/car/rubbish3,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"dph" = (
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "dpl" = (
 /obj/effect/landmark/start/f13/venator,
 /turf/open/floor/carpet/black,
@@ -8134,6 +8520,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "dvo" = (
@@ -8163,6 +8550,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "dwV" = (
@@ -8208,6 +8596,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"dxr" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "dxx" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/supermart,
@@ -8218,11 +8612,20 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"dxC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 6;
+	icon_state = "outerpavement";
+	tag = "icon-outerpavement (SOUTHEAST)"
+	},
+/area/f13/wasteland)
 "dxJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "dxM" = (
@@ -8508,6 +8911,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "dCP" = (
@@ -8530,6 +8934,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "dDg" = (
@@ -8670,6 +9075,7 @@
 /obj/structure/chair/wood{
 	dir = 1;
 	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8783,12 +9189,10 @@
 	},
 /area/f13/building)
 "dJn" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/car/rubbish3,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dJv" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/combat/swat,
@@ -8827,6 +9231,7 @@
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "dJX" = (
@@ -8866,6 +9271,12 @@
 "dKW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom1"
+	},
+/area/f13/wasteland)
+"dLM" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "dLO" = (
@@ -8969,9 +9380,11 @@
 "dOg" = (
 /obj/structure/chair/office{
 	dir = 1;
+	tag = "icon-chair (NORTH)"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "dOn" = (
@@ -9204,6 +9617,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"dTV" = (
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "dUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9353,6 +9770,12 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/building)
+"dWG" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "dWH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -9362,6 +9785,14 @@
 	name = "concrete wall"
 	},
 /area/f13/ncr)
+"dWW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "dWZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench,
@@ -9457,6 +9888,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"dYM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "dYT" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -9603,12 +10038,10 @@
 	},
 /area/f13/building)
 "ebC" = (
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "ebI" = (
 /obj/structure/window{
 	dir = 8
@@ -9853,6 +10286,7 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/caves)
 "efO" = (
@@ -9866,14 +10300,14 @@
 	},
 /area/f13/building)
 "ega" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/door/poddoor{
-	id = "vaultelevator"
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "egt" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -9946,6 +10380,7 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "ehG" = (
@@ -9996,6 +10431,33 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"eiC" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"eiJ" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bedsheetbin{
+	pixel_y = 10
+	},
+/obj/structure/table/wood{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "eiS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10014,12 +10476,16 @@
 	},
 /area/f13/wasteland)
 "ejp" = (
-/obj/structure/window/reinforced/tinted{
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "ejD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -10093,15 +10559,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "elL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/obj/structure/junk/micro,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "elN" = (
 /obj/structure/flora/grass/jungle/b,
@@ -10127,6 +10586,15 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"emg" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "emh" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13,
@@ -10190,11 +10658,9 @@
 	},
 /area/f13/city)
 "enp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ent" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10211,6 +10677,7 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "enx" = (
@@ -10398,6 +10865,10 @@
 	icon_state = "housebase"
 	},
 /area/f13/village)
+"eqY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "ero" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -10412,8 +10883,10 @@
 	},
 /area/f13/building)
 "erB" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -10439,6 +10912,17 @@
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"ess" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/reagentgrinder,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "esz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -10667,6 +11151,12 @@
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"ewh" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "ewi" = (
 /obj/structure/chair/wood/worn,
 /obj/effect/decal/cleanable/dirt{
@@ -10707,6 +11197,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"ewV" = (
+/obj/item/trash/f13/dog,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "exd" = (
 /obj/structure/table,
 /obj/item/melee/onehanded/slavewhip,
@@ -10804,6 +11299,7 @@
 "ezo" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/building)
 "ezp" = (
@@ -11092,6 +11588,7 @@
 /obj/machinery/shower{
 	dir = 8;
 	icon_state = "shower";
+	tag = "icon-shower (WEST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11100,6 +11597,7 @@
 "eEL" = (
 /obj/machinery/shower{
 	dir = 4;
+	tag = "icon-shower (EAST)"
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -11268,6 +11766,7 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 10;
+	tag = "icon-sink (EAST)"
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -11329,6 +11828,7 @@
 "eKM" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2";
+	tag = "icon-platingdmg2"
 	},
 /area/f13/caves)
 "eKN" = (
@@ -11524,6 +12024,13 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/building)
+"eOm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "eOr" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -11633,14 +12140,11 @@
 	},
 /area/f13/ncr)
 "eQq" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "eQA" = (
 /obj/structure/dresser{
 	pixel_y = 10
@@ -11794,6 +12298,7 @@
 "eUD" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
+	tag = "icon-tall_grass_4"
 	},
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/savannah/bottomleftcorner,
@@ -11855,6 +12360,7 @@
 /obj/structure/fence{
 	dir = 4;
 	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -11946,12 +12452,8 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "eYa" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "eYj" = (
 /obj/structure/bed/mattress{
@@ -12010,6 +12512,7 @@
 /obj/machinery/shower{
 	dir = 8;
 	icon_state = "shower";
+	tag = "icon-shower (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12038,6 +12541,7 @@
 /obj/structure/fence{
 	dir = 4;
 	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12060,6 +12564,7 @@
 /obj/item/clothing/head/radiation,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
 	},
 /area/f13/caves)
 "faq" = (
@@ -12082,14 +12587,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fas" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/pill/patch/jet{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "faC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -12276,11 +12781,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
 "fdO" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/structure/reagent_dispensers/watertank{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "fdV" = (
 /obj/structure/flora/grass/wasteland{
@@ -12314,6 +12822,20 @@
 	icon_state = "plating"
 	},
 /area/f13/ncr)
+"fej" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "fek" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -12601,8 +13123,13 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "fjR" = (
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
 /area/f13/village)
 "fkl" = (
 /obj/machinery/light/small{
@@ -12680,6 +13207,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerpavement";
+	tag = "icon-outerpavement (EAST)"
 	},
 /area/f13/wasteland)
 "fmW" = (
@@ -12714,10 +13242,9 @@
 	},
 /area/f13/village)
 "fnB" = (
-/obj/item/toy/poolnoodle/blue,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fnE" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -12738,12 +13265,14 @@
 "fnP" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
 	},
 /area/f13/wasteland)
 "fnT" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg2";
+	tag = "icon-platingdmg2"
 	},
 /area/f13/caves)
 "fnW" = (
@@ -12761,6 +13290,14 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/building)
+"fok" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building)
 "fow" = (
 /obj/structure/sign/poster/contraband/punch_shit{
@@ -12788,6 +13325,7 @@
 /obj/structure/rack,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "fpl" = (
@@ -13024,10 +13562,7 @@
 /area/f13/building)
 "fug" = (
 /obj/structure/bonfire,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
+/turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "fum" = (
 /obj/structure/table/snooker{
@@ -13160,6 +13695,11 @@
 "fyf" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fyl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "fym" = (
 /obj/structure/table/wood/settler,
 /obj/item/lipstick/purple,
@@ -13605,6 +14145,10 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/village)
+"fGp" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fGr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -13700,6 +14244,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/tunnel)
+"fIE" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "fIT" = (
 /obj/machinery/chem_heater,
 /obj/structure/table,
@@ -13873,11 +14424,12 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "fLx" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerouter"
+/obj/structure/flora/grass/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "fLB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13898,6 +14450,9 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"fLF" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/tunnel)
 "fLN" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt,
@@ -13987,11 +14542,14 @@
 "fNq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "fNs" = (
-/turf/closed/mineral/random/high_chance,
-/area/f13/tunnel)
+/obj/structure/flora/grass/jungle,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "fNt" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -14019,8 +14577,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "fOs" = (
-/obj/effect/overlay/junk/sink{
-	pixel_y = 15
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/stairs/north{
+	color = "#A47449"
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -14043,10 +14604,10 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/village)
 "fPb" = (
-/obj/structure/table,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "fPv" = (
 /obj/structure/fence{
@@ -14186,6 +14747,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/building)
 "fRZ" = (
@@ -14228,6 +14790,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"fSC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "Raider"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "fSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/ore_redemption,
@@ -14264,6 +14836,18 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"fTt" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "fTu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14385,12 +14969,9 @@
 	},
 /area/f13/building)
 "fUs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "fUA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -14597,6 +15178,7 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "fZb" = (
@@ -14683,6 +15265,16 @@
 /obj/machinery/mineral/wasteland_trader,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"gaz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "gaI" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbroken"
@@ -14712,6 +15304,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"gbh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
 "gbz" = (
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
@@ -14941,6 +15540,7 @@
 "ggs" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -14996,9 +15596,6 @@
 	color = "#363636"
 	},
 /obj/machinery/smartfridge/bottlerack/drug_storage,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -15126,17 +15723,39 @@
 	},
 /area/f13/wasteland)
 "giU" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "giZ" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "gjs" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/fence{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
+	},
+/area/f13/wasteland)
+"gjB" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/village)
 "gjC" = (
 /obj/effect/landmark/latejoin,
@@ -15337,25 +15956,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "gnk" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -11;
-	pixel_y = 2;
-	},
+/obj/structure/sign/poster/contraband/pinup_funk,
 /obj/structure/barricade/bars{
 	max_integrity = 800;
 	name = "strong metal bars";
 	obj_integrity = 800
 	},
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "gnv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -15371,19 +15979,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
 "goj" = (
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty, someone attempted to weld this vent.. but he was too late. You hear some weird noises behind these vents...";
-	pixel_x = -7;
-	pixel_y = -3
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/enclave)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "goq" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross3"
@@ -15530,17 +16133,14 @@
 	},
 /area/f13/building)
 "grc" = (
-/obj/structure/window/fulltile/wood,
+/obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	},
 /obj/structure/barricade/bars{
 	max_integrity = 800;
 	name = "strong metal bars";
 	obj_integrity = 800
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "grf" = (
 /obj/effect/turf_decal/stripes/line,
@@ -15661,12 +16261,14 @@
 	},
 /area/f13/building)
 "gsB" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sign/poster/contraband/pinup_bed,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "gsM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15697,6 +16299,7 @@
 "gtn" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/building)
 "gts" = (
@@ -15744,13 +16347,17 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "gtU" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/tunnel)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "guh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -15771,6 +16378,7 @@
 "gun" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase";
+	tag = "icon-housebase"
 	},
 /area/f13/building)
 "gus" = (
@@ -15798,9 +16406,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "guU" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "guY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15847,6 +16465,20 @@
 	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland)
+"gvp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
+/area/f13/village)
 "gvr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/wood/normal{
@@ -15932,6 +16564,13 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gwC" = (
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "gwG" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Uniform Storage"
@@ -15983,9 +16622,17 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"gxb" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/village)
 "gxh" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
+	tag = "icon-tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -16005,9 +16652,11 @@
 	},
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "gxo" = (
@@ -16016,6 +16665,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"gxK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/flour,
+/mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "gxP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/nukacolavend,
@@ -16035,6 +16693,15 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
+"gye" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gyf" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -16093,6 +16760,12 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"gzt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
 "gzQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16128,6 +16801,7 @@
 "gAt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
+	tag = "icon-tall_grass_2"
 	},
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -16208,10 +16882,7 @@
 /area/f13/ncr)
 "gBu" = (
 /obj/structure/tires/two,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
+/turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "gBx" = (
 /obj/structure/car/rubbish3,
@@ -16252,6 +16923,7 @@
 "gBW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -16377,9 +17049,20 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "gDL" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gDW" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -16400,10 +17083,7 @@
 /area/f13/building)
 "gEA" = (
 /obj/structure/tires/half,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
+/turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "gEK" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16475,6 +17155,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"gGC" = (
+/obj/structure/simple_door/dirtyglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "gGJ" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/unum,
@@ -16524,6 +17209,10 @@
 /obj/effect/landmark/start/f13/ncrconscript,
 /turf/open/floor/carpet/blackred,
 /area/f13/ncr)
+"gHJ" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gHM" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/dirt,
@@ -16638,6 +17327,17 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gLj" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
+"gLu" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "gLG" = (
 /obj/machinery/autolathe/ammo,
 /obj/machinery/light/small{
@@ -16753,6 +17453,7 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
 	},
 /area/f13/caves)
 "gNG" = (
@@ -16876,6 +17577,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"gPK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
+"gPN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
+/area/f13/village)
 "gPV" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood{
@@ -16904,14 +17626,15 @@
 	},
 /area/f13/wasteland)
 "gQy" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "gQL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood/f13/old,
@@ -16965,11 +17688,19 @@
 	},
 /area/f13/wasteland)
 "gSx" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/obj/effect/decal/cleanable/dirt{
+/obj/structure/sign/poster/contraband/pinup_pink,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/curtain{
 	color = "#363636"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gSB" = (
 /obj/structure/flora/tree/tall,
@@ -16999,6 +17730,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/building)
 "gTv" = (
@@ -17107,6 +17839,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/building)
+"gXc" = (
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/closet/fridge/standard,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gXt" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
@@ -17222,6 +17960,12 @@
 "gZG" = (
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/building)
+"gZJ" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "gZW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -17247,7 +17991,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "hau" = (
-/obj/machinery/microwave/stove,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -17263,6 +18010,7 @@
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 23;
+	tag = "icon-sink (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17467,6 +18215,11 @@
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"hea" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/junk/small/table,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "heh" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -17572,11 +18325,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
 "hfw" = (
-/obj/item/defibrillator/primitive,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/fence/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/savannah/bottomcenter,
+/area/f13/building)
 "hfz" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall/f13/store/constructed,
@@ -17610,14 +18364,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "hfV" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "S1"
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
+/obj/item/flag/khan,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "hga" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -17835,6 +18590,7 @@
 "hiT" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -17909,10 +18665,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "hko" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hkr" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/oil,
@@ -18062,6 +18821,7 @@
 "hmP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18120,22 +18880,34 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "hnU" = (
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/wood/broken,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/structure/table,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hoe" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/wasteland)
+"hol" = (
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hom" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -18144,6 +18916,15 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/tunnel)
+"hov" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "hoy" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18152,10 +18933,12 @@
 	},
 /area/f13/wasteland)
 "hoz" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/wood/f13/old/ruinedcornerendbl,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "hoD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18166,9 +18949,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "hoH" = (
-/obj/item/storage/toolbox/mechanical/old,
-/obj/structure/table,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "hoR" = (
 /obj/machinery/vending/dinnerware,
@@ -18303,6 +19088,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "hrh" = (
@@ -18385,6 +19171,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "hsH" = (
@@ -18437,6 +19224,7 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
 	},
 /area/f13/caves)
 "hum" = (
@@ -18497,6 +19285,13 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"hvi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "hvp" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet,
@@ -18624,6 +19419,7 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
 /area/f13/building)
 "hxx" = (
@@ -18849,12 +19645,11 @@
 	},
 /area/f13/wasteland)
 "hCp" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2"
+/obj/structure/chair/sofa/corner{
+	dir = 4
 	},
-/obj/item/shovel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hCs" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -18866,6 +19661,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -18945,11 +19741,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "hEh" = (
-/obj/structure/chair/f13chair2{
+/obj/structure/fence/pole_t,
+/obj/structure/chair/sofa,
+/obj/machinery/light/fo13colored/Red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hEj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -18992,6 +19790,7 @@
 "hEX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "hFM" = (
@@ -19038,18 +19837,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "hGm" = (
-/obj/machinery/button/door{
-	id = "vaultelevator";
-	name = "Blast Door Exit";
-	pixel_y = -27
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/structure/chair/sofa/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hGr" = (
 /obj/structure/car/rubbish3,
 /obj/structure/car/rubbish2,
@@ -19203,9 +19995,9 @@
 	},
 /area/f13/building)
 "hIi" = (
-/obj/structure/fluff/fokoff_sign,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/punch_shit,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "hIA" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/boxing/green,
@@ -19225,6 +20017,10 @@
 	icon_state = "floordirty"
 	},
 /area/f13/ncr)
+"hJb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "hJf" = (
 /obj/item/kirbyplants,
 /obj/structure/sign/poster/official/cleanliness{
@@ -19430,6 +20226,10 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/building)
+"hMW" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hMX" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -19458,10 +20258,11 @@
 	},
 /area/f13/village)
 "hNC" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hNE" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/supermart,
@@ -19782,6 +20583,17 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/village)
+"hVm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "hVp" = (
 /obj/machinery/light{
 	dir = 8
@@ -19809,6 +20621,15 @@
 	name = "stone floor"
 	},
 /area/f13/legion)
+"hVD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/syndi_cakes,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "hVN" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -19822,14 +20643,13 @@
 	},
 /area/f13/ncr)
 "hVW" = (
-/obj/structure/chair/comfy{
-	dir = 8
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hWd" = (
 /obj/structure/closet/fridge/standard{
 	pixel_x = 8
@@ -20244,12 +21064,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/village)
-"icB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "icE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -20337,6 +21151,14 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
+	},
+/area/f13/wasteland)
+"ieF" = (
+/obj/structure/wreck/trash/two_barrels,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "ieK" = (
@@ -20372,6 +21194,15 @@
 /obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
+"ifp" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ifq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -20491,6 +21322,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/caves)
 "ijC" = (
@@ -20645,10 +21477,9 @@
 	},
 /area/f13/building)
 "imR" = (
-/obj/item/mine/shrapnel,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/the_griffin,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "imT" = (
 /obj/structure/tires/five,
 /obj/structure/tires,
@@ -20681,6 +21512,7 @@
 "inl" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -20778,10 +21610,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ipE" = (
-/obj/structure/rack,
-/obj/item/storage/backpack,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/table/booth,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ipF" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -20822,8 +21659,8 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/turf/open/floor/wood/f13/old/ruinedstraightwest,
+/area/f13/wasteland)
 "iqH" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
@@ -20866,14 +21703,13 @@
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
 "ira" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	name = "towel boy pod";
-	pixel_y = 20
+/obj/machinery/door/unpowered/securedoor{
+	max_integrity = 800;
+	obj_integrity = 800;
+	req_access_txt = "125"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "irr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/greyscale{
@@ -20924,6 +21760,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ist" = (
+/obj/structure/table/snooker{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "isv" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20945,6 +21790,7 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3"
 	},
 /area/f13/caves)
 "itn" = (
@@ -21092,6 +21938,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"iwz" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "iwG" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -21147,6 +21999,7 @@
 	dir = 8;
 	icon_state = "sink";
 	pixel_x = -12;
+	tag = "icon-sink (WEST)"
 	},
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
@@ -21216,6 +22069,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"izf" = (
+/obj/machinery/vending/tool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "izg" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/subway,
@@ -21234,6 +22095,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"izt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/random,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "izB" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21288,11 +22157,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iAU" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iBo" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21367,6 +22237,16 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
+"iCf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "iCG" = (
 /obj/structure/closet,
 /obj/item/card/id/dogtag/legprime,
@@ -21376,6 +22256,7 @@
 "iCH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21429,6 +22310,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
 	},
 /area/f13/wasteland)
 "iDS" = (
@@ -21445,6 +22327,10 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"iEe" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "iEg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -21459,6 +22345,16 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"iEJ" = (
+/obj/machinery/vending/nukacolavend,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building)
 "iEO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21518,6 +22414,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building)
+"iFV" = (
+/obj/machinery/power/smes,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "iGm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/curtain{
@@ -21576,6 +22478,7 @@
 "iHk" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "iHu" = (
@@ -21617,6 +22520,7 @@
 "iHR" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
+	tag = "icon-tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -21695,6 +22599,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"iJw" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "iJy" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -21747,6 +22665,7 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
+	tag = "icon-housewood2"
 	},
 /area/f13/building)
 "iKc" = (
@@ -21889,6 +22808,13 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/f13,
 /area/f13/wasteland)
+"iML" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "iMQ" = (
 /obj/structure/table/wood,
 /obj/item/paper/pamphlet{
@@ -22030,10 +22956,25 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"iOx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "iOB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/store,
 /area/f13/village)
+"iOD" = (
+/obj/effect/decal/remains/human,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "iOI" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
@@ -22045,6 +22986,7 @@
 	icon_state = "skulls";
 	pixel_x = -4;
 	pixel_y = 2;
+	tag = "icon-skulls"
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22092,6 +23034,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"iPs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "iPB" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
@@ -22117,6 +23069,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"iPY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "iPZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -22150,10 +23107,12 @@
 "iQR" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore";
+	tag = "icon-brokenstore"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/caves)
 "iQT" = (
@@ -22210,6 +23169,13 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"iRw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
 /area/f13/building)
 "iRx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -22321,6 +23287,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"iSz" = (
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty. You hear some weird noises behind these vents...";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "iSC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -22345,6 +23321,22 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"iSP" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/backpack,
+/obj/item/storage/backpack,
+/obj/item/storage/backpack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "iTx" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -22367,13 +23359,12 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "iTC" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/fence/pole_b,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iTF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/settler,
@@ -22382,6 +23373,7 @@
 "iTI" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
@@ -22423,6 +23415,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"iUw" = (
+/obj/structure/fence/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iUS" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -22566,13 +23565,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iXC" = (
-/obj/structure/wreck/trash/machinepile{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/obj/structure/sign/poster/contraband/pinup_vixen,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "iXE" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22607,6 +23602,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/building)
+"iYw" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/head/welding/weldingfire,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "iYx" = (
 /obj/structure/chair/office/dark,
@@ -22724,14 +23733,14 @@
 	},
 /area/f13/bunker)
 "jay" = (
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jaI" = (
 /obj/structure/railing/handrail/blue{
 	dir = 4
@@ -22750,6 +23759,18 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"jbc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "jbg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
@@ -22772,6 +23793,20 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/f13/village)
+"jbR" = (
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty, someone attempted to weld this vent.. but he was too late. You hear some weird noises behind these vents...";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "jbV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -22903,10 +23938,14 @@
 	},
 /area/f13/building)
 "jel" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jem" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -22922,12 +23961,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "jeI" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "jeO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23110,10 +24148,9 @@
 	},
 /area/f13/building)
 "jiv" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/pinup_shower,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "jix" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/cigarette,
@@ -23297,6 +24334,17 @@
 	dir = 10
 	},
 /area/f13/village)
+"jlV" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "jmb" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -23346,6 +24394,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"jmQ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "jmZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -23453,6 +24510,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
 	},
 /area/f13/building)
 "joY" = (
@@ -23485,11 +24543,15 @@
 	},
 /area/f13/ncr)
 "jpB" = (
-/obj/effect/overlay/junk/shower{
-	dir = 4
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jpO" = (
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/wood/f13,
@@ -23590,6 +24652,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
+"jsb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "jsq" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
@@ -23606,6 +24678,20 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/mask/fakemoustache/italian,
 /turf/open/floor/carpet,
+/area/f13/building)
+"jsH" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "jsY" = (
 /obj/structure/closet/crate/freezer{
@@ -23654,6 +24740,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -23815,6 +24902,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
+"jwe" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/toolbox/drone,
+/obj/item/pickaxe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jwl" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/tentflap_cloth,
@@ -23916,14 +25014,16 @@
 	},
 /area/f13/village)
 "jxD" = (
-/obj/item/trash/coal,
-/obj/item/trash/coal,
-/obj/item/trash/coal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/area/f13/village)
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
+	},
+/area/f13/building)
 "jxH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
@@ -23986,7 +25086,7 @@
 /area/f13/building)
 "jzC" = (
 /obj/machinery/seed_extractor,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jzN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24030,6 +25130,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"jBp" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "jBs" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -24096,7 +25205,10 @@
 	},
 /area/f13/wasteland)
 "jCH" = (
-/turf/open/floor/wood/f13/old,
+/obj/structure/sign/poster/prewar/poster71{
+	pixel_x = 32
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jCV" = (
 /obj/structure/curtain{
@@ -24129,6 +25241,7 @@
 "jDk" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
+	tag = "icon-tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -24240,6 +25353,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"jGP" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleslab"
+	},
+/area/f13/village)
 "jGU" = (
 /obj/item/clothing/under/f13/petrochico,
 /obj/effect/decal/cleanable/dirt{
@@ -24502,8 +25621,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jMN" = (
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "jMP" = (
@@ -24586,6 +25706,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jOm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "jOq" = (
 /obj/structure/closet/crate,
 /turf/open/indestructible/ground/outside/wood,
@@ -24689,6 +25817,7 @@
 /obj/structure/chair/wood{
 	dir = 4;
 	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -24701,6 +25830,14 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"jRz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "jRJ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -24860,6 +25997,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jVa" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jVi" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -24911,7 +26060,7 @@
 "jVE" = (
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "jVM" = (
 /obj/effect/decal/riverbank,
 /obj/effect/decal/waste{
@@ -24959,6 +26108,15 @@
 /obj/item/roller,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"jWy" = (
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jWz" = (
 /obj/effect/overlay/junk/sink{
 	pixel_y = 15
@@ -25020,6 +26178,7 @@
 "jXh" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
 	},
 /area/f13/caves)
 "jXj" = (
@@ -25093,6 +26252,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
+"jYY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "jZk" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = 11
@@ -25110,6 +26283,14 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"jZD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "jZI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/ghoul{
@@ -25180,9 +26361,19 @@
 "kaP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"kaT" = (
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
@@ -25198,6 +26389,7 @@
 "kbw" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25456,11 +26648,13 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/village)
 "kgn" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "kgy" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/desert,
@@ -25517,6 +26711,7 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/caves)
 "kho" = (
@@ -25597,6 +26792,7 @@
 "kin" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
 	},
 /area/f13/wasteland)
 "kiC" = (
@@ -25618,6 +26814,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"kiQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "kiW" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -25695,6 +26900,15 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland)
+"kkO" = (
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
 "kkQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -25717,6 +26931,11 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building)
+"kkY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper,
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "kld" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded";
@@ -25859,6 +27078,11 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"knV" = (
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "knY" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -25899,8 +27123,14 @@
 	},
 /area/f13/wasteland)
 "koZ" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "kpe" = (
 /obj/structure/rack,
@@ -26066,6 +27296,20 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"krQ" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "krS" = (
 /obj/structure/fence/post,
 /obj/structure/sign/warning{
@@ -26090,6 +27334,13 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"ksP" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ksX" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -26114,6 +27365,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"kum" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kuo" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -26227,11 +27482,23 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"kwy" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "kwA" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor{
+	max_integrity = 800;
+	obj_integrity = 800;
+	req_access_txt = "125"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "kwK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26240,13 +27507,13 @@
 	},
 /area/f13/wasteland)
 "kwL" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/cram,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/village)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "kwN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26322,6 +27589,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"kyZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "kzt" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/desert,
@@ -26349,6 +27621,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kAE" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "kAJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -26372,13 +27651,9 @@
 	},
 /area/f13/building)
 "kBd" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "kBg" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -26406,6 +27681,7 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "kBV" = (
@@ -26765,6 +28041,19 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kKj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "kKk" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -26835,6 +28124,16 @@
 /obj/machinery/trading_machine/medical,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"kMk" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/closet/crate/solarpanel_small,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "kMl" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -26918,8 +28217,13 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
 "kNT" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/building)
 "kOz" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26951,6 +28255,11 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"kOX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "kPm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/structure/table/wood,
@@ -27020,6 +28329,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"kRr" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"kRD" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/head/helmet/f13/raider/eyebot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "kRT" = (
@@ -27111,9 +28441,13 @@
 /area/f13/building)
 "kTP" = (
 /obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/building)
 "kTZ" = (
@@ -27293,7 +28627,7 @@
 "kWW" = (
 /obj/item/seeds/feracactus,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "kXa" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -27393,6 +28727,7 @@
 "kYI" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "kYQ" = (
@@ -27455,11 +28790,7 @@
 	},
 /area/f13/wasteland)
 "lag" = (
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "lak" = (
 /obj/item/radio,
@@ -27524,7 +28855,7 @@
 "lbJ" = (
 /mob/living/simple_animal/hostile/wolf/playable,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "lbO" = (
 /obj/structure/table/wood,
 /obj/item/wirecutters/crude,
@@ -27619,6 +28950,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"lds" = (
+/turf/closed/wall/f13/ruins{
+	color = "#d9cdb9"
+	},
+/area/f13/building)
 "ldw" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -27669,10 +29005,10 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "leq" = (
-/obj/structure/simple_door/interior,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/sign/barsign,
+/obj/structure/sign/barsign,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "les" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -27826,6 +29162,14 @@
 	dir = 4
 	},
 /area/f13/building)
+"lgE" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "lgH" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -27839,6 +29183,7 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "lgN" = (
@@ -27909,6 +29254,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
+/area/f13/building)
+"lhO" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "lhW" = (
 /obj/structure/noticeboard{
@@ -28093,6 +29445,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"lme" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "lmk" = (
 /obj/structure/simple_door/tent,
 /turf/open/floor/f13/wood{
@@ -28217,6 +29577,7 @@
 "log" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/savannah,
@@ -28285,6 +29646,7 @@
 "lpL" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
+	tag = "icon-tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
@@ -28302,14 +29664,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
-"lqh" = (
-/obj/structure/fluff/beach_umbrella/science,
-/obj/structure/chair/comfy/plywood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
-/area/f13/village)
 "lqp" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13{
@@ -28519,6 +29873,7 @@
 "lvH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -28617,6 +29972,7 @@
 "lxW" = (
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "lyg" = (
@@ -28655,6 +30011,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"lzv" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/ruins,
+/area/f13/village)
 "lzE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
@@ -28770,9 +30130,11 @@
 	},
 /area/f13/village)
 "lBS" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -28784,6 +30146,12 @@
 /obj/item/ammo_box/magazine/m556/rifle/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"lBX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/village)
 "lBY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -28828,15 +30196,15 @@
 	},
 /area/f13/wasteland)
 "lDx" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lDz" = (
 /obj/structure/fence/wooden{
 	pixel_x = -14
@@ -28895,6 +30263,18 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
+"lER" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/village)
 "lEY" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -28943,6 +30323,7 @@
 "lFD" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3";
+	tag = "icon-platingdmg3"
 	},
 /area/f13/caves)
 "lFL" = (
@@ -29114,6 +30495,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "lLh" = (
@@ -29147,6 +30529,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lLL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "lLX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/corner,
@@ -29189,6 +30588,18 @@
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"lMu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/village)
 "lMA" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -29338,6 +30749,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/brotherhood/surface)
+"lPw" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "lPN" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -29543,6 +30959,7 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "lTG" = (
@@ -29689,6 +31106,7 @@
 "lVS" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
@@ -29723,13 +31141,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"lWj" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 9;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "lWo" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -29741,6 +31152,15 @@
 "lWp" = (
 /obj/item/trash/sosjerky,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/village)
+"lWu" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "lWx" = (
 /obj/structure/table/wood,
@@ -29772,13 +31192,12 @@
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "lXu" = (
-/obj/machinery/light/broken{
-	dir = 8
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lXy" = (
 /obj/structure/junk/small/tv{
 	desc = "A wall mounted television, sadly it's broken.";
@@ -29892,6 +31311,16 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
+"lYZ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
+	},
+/area/f13/building)
 "lZw" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -29984,6 +31413,15 @@
 /obj/item/reagent_containers/pill/patch/turbo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"maX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "mbd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
@@ -30047,8 +31485,9 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mcp" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -30086,9 +31525,9 @@
 	},
 /area/f13/building)
 "mdv" = (
-/mob/living/simple_animal/hostile/stalker,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/pinup_topless,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "mdA" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -30216,11 +31655,11 @@
 	},
 /area/f13/wasteland)
 "mfR" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "mfV" = (
 /obj/machinery/light/small/broken,
 /turf/open/indestructible/ground/outside/road{
@@ -30295,6 +31734,7 @@
 "mhJ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
+	tag = "icon-tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -30337,6 +31777,25 @@
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"miC" = (
+/obj/item/stock_parts/cell,
+/obj/item/stock_parts/cell{
+	icon_state = "hpcell"
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "miE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30410,6 +31869,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mkf" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mkh" = (
 /obj/structure/sink/greyscale{
 	dir = 8;
@@ -30493,11 +31956,10 @@
 	},
 /area/f13/building)
 "mlf" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/structure/flora/grass/wasteland,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mlm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30572,10 +32034,22 @@
 /area/f13/building)
 "mmT" = (
 /obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "mna" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -30625,6 +32099,23 @@
 	icon_state = "bar"
 	},
 /area/f13/caves)
+"mnR" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
+"mnT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "moc" = (
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
@@ -30730,6 +32221,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "mpH" = (
@@ -30771,6 +32263,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -30823,7 +32316,6 @@
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
 "mrQ" = (
-/obj/item/clothing/head/cone,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -31340,6 +32832,17 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"mCa" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "mCd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -31407,12 +32910,14 @@
 "mDM" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/caves)
 "mEh" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "mEy" = (
@@ -31732,11 +33237,12 @@
 	},
 /area/f13/wasteland)
 "mKr" = (
-/obj/structure/table/wood/settler,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "mKu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31866,6 +33372,10 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mNR" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mNS" = (
 /obj/structure/chair{
 	dir = 8
@@ -31925,11 +33435,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mOP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "mOS" = (
 /obj/machinery/light/small{
@@ -31979,11 +33492,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mPT" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mQj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowleft"
@@ -32161,10 +33673,9 @@
 	},
 /area/f13/tunnel)
 "mTy" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mTF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -32523,7 +34034,10 @@
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "mZn" = (
 /obj/structure/fence/wooden{
@@ -32577,12 +34091,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mZW" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/building)
 "mZX" = (
 /obj/structure/punching_bag,
 /turf/open/floor/carpet/black,
@@ -32638,6 +34151,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"naZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/village)
 "nbs" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -32683,6 +34200,17 @@
 /obj/machinery/light,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"ncl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "ncy" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -32749,10 +34277,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland)
 "nes" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
 	},
-/area/f13/enclave)
+/area/f13/building)
 "nev" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32841,19 +34370,20 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "ngr" = (
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/table/snooker{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "ngs" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
 "ngw" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ngC" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -33020,6 +34550,16 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
+"nky" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
+	},
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "nkz" = (
@@ -33241,6 +34781,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
 "npH" = (
@@ -33458,12 +34999,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ntz" = (
-/obj/structure/simple_door/interior,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
-/area/f13/village)
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ntI" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -33512,6 +35050,19 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"nuY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "nvg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -33581,6 +35132,7 @@
 "nwZ" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /obj/item/flag/khan,
 /turf/closed/wall/f13/wood,
@@ -33648,6 +35200,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"nyn" = (
+/obj/structure/sink/greyscale{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "nyA" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -33711,10 +35275,10 @@
 	},
 /area/f13/village)
 "nzN" = (
-/obj/structure/junk/micro,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "nAh" = (
 /obj/structure/barricade/wooden,
@@ -33790,7 +35354,9 @@
 "nBF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/old,
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
 /area/f13/village)
 "nBQ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -33861,6 +35427,7 @@
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "nDx" = (
@@ -33951,6 +35518,7 @@
 /obj/structure/fence{
 	dir = 4;
 	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -34065,15 +35633,11 @@
 	light_color = "#d8b1b1";
 	pixel_y = 11
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
-"nIz" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
 "nID" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sunset{
@@ -34099,9 +35663,13 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "nJr" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "nJz" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/wasteland)
@@ -34331,6 +35899,7 @@
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1";
+	tag = "icon-verticalinnermain1"
 	},
 /area/f13/wasteland)
 "nON" = (
@@ -34464,10 +36033,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"nQY" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "nRb" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
@@ -34615,8 +36180,11 @@
 	},
 /area/f13/followers)
 "nTP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "nTV" = (
 /obj/structure/fence/corner,
@@ -34671,8 +36239,12 @@
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/building)
 "nVi" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "nVn" = (
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -34814,6 +36386,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"nYR" = (
+/mob/living/simple_animal/hostile/rat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "nYW" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -34906,6 +36488,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"oaQ" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "oaZ" = (
 /obj/structure/tires/two,
 /obj/structure/tires/five{
@@ -35020,6 +36613,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"ody" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "odA" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road,
@@ -35083,6 +36683,16 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"oeK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "oeL" = (
@@ -35153,13 +36763,15 @@
 /obj/item/seeds/potato,
 /obj/item/seeds/soya,
 /obj/item/seeds/soya,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ogR" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
 "ogZ" = (
@@ -35270,6 +36882,14 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"oiY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "ojl" = (
 /obj/effect/decal/remains/robot,
 /turf/open/indestructible/ground/outside/road{
@@ -35337,6 +36957,16 @@
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"okC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "okG" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -35384,6 +37014,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/building)
+"ola" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "oli" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -35488,11 +37123,17 @@
 	},
 /area/f13/followers)
 "onh" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 8
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "onk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -35591,6 +37232,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"opA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "opC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10;
@@ -35624,6 +37270,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"opZ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oqa" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35653,6 +37305,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"oqo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "oqp" = (
 /obj/structure/car/rubbish1,
 /turf/closed/mineral/random/low_chance,
@@ -35662,11 +37325,13 @@
 	icon_state = "skulls";
 	pixel_x = -12;
 	pixel_y = 2;
+	tag = "icon-skulls"
 	},
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
 	pixel_x = 12;
 	pixel_y = 2;
+	tag = "icon-skulls"
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
@@ -35705,6 +37370,7 @@
 	icon_state = "skulls";
 	pixel_x = 4;
 	pixel_y = 2;
+	tag = "icon-skulls"
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
@@ -35750,6 +37416,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"orJ" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "orV" = (
 /obj/effect/decal/remains/human{
 	pixel_x = -13;
@@ -35788,14 +37458,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "osF" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/obj/structure/stairs/north{
+	color = "#A47449"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "otm" = (
 /obj/structure/sign/poster/contraband/atmosia_independence,
 /turf/closed/wall/f13/store/constructed,
@@ -35838,6 +37505,14 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/village)
+"otO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "otQ" = (
 /obj/machinery/light{
@@ -35888,13 +37563,25 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"ouJ" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+"ouH" = (
+/obj/item/kitchen/knife,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 7
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
+"ouJ" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/item/flag/khan,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "ouO" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants,
@@ -35913,15 +37600,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ovt" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/destructible/tribal_torch/wall/lit{
+/obj/structure/fence/wooden{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "ovF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -35942,6 +37625,14 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ovV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "owh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -36077,6 +37768,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"oza" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
+	},
+/area/f13/building)
 "ozc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -36111,6 +37809,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"ozB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "ozI" = (
 /obj/item/clothing/shoes/combat,
 /obj/structure/closet,
@@ -36129,12 +37836,44 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"oAe" = (
-/obj/machinery/power/smes,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+"ozN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
+"oAb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
+"oAe" = (
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "oAo" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -36145,12 +37884,19 @@
 	},
 /area/f13/building)
 "oAB" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oAQ" = (
 /obj/structure/displaycase,
@@ -36160,6 +37906,8 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mus3"
 	},
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -36198,6 +37946,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"oBA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "oCg" = (
 /obj/structure/guncase{
 	anchored = 1
@@ -36251,24 +38004,45 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"oDe" = (
+/obj/structure/table,
+/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/area/f13/wasteland)
 "oDf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/caves)
 "oDo" = (
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -4;
+	pixel_y = 2;
+	tag = "icon-skulls"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
+/obj/machinery/door/unpowered/securedoor{
+	req_access_txt = "125"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oDG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"oDQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "oEd" = (
@@ -36285,6 +38059,7 @@
 "oES" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
@@ -36312,13 +38087,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "oFK" = (
-/obj/structure/wreck/trash/engine{
-	desc = "Oh, you love the lake? Then name five brands of car batteries you’ve thrown into it.";
-	name = "Car battery";
-	pixel_x = 9
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oFX" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Bar";
@@ -36365,6 +38138,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
 "oGU" = (
@@ -36378,14 +38152,33 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
-"oGX" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+"oGW" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/village)
+"oGX" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -11;
+	pixel_y = 2;
+	tag = "icon-skulls"
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oGZ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
@@ -36427,10 +38220,7 @@
 /area/f13/building)
 "oHK" = (
 /obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 6;
-	icon_state = "outerpavement"
-	},
+/turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "oHT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36467,6 +38257,16 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building)
+"oIz" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "oIF" = (
 /obj/structure/window/fulltile/house{
@@ -36592,10 +38392,12 @@
 	},
 /area/f13/building)
 "oMn" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oMp" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/road{
@@ -36603,15 +38405,12 @@
 	},
 /area/f13/wasteland)
 "oMC" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oMP" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -36628,25 +38427,36 @@
 	},
 /area/f13/building)
 "oNf" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "oNs" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
-"oNC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"oNu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/village)
+"oNz" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "oNE" = (
 /obj/structure/rack,
 /obj/item/clothing/head/nun_hood,
@@ -36661,11 +38471,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "oNR" = (
-/obj/structure/sign/poster/prewar/poster71{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oOa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36760,6 +38573,7 @@
 "oPO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right";
+	tag = "icon-horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
 "oPQ" = (
@@ -36853,14 +38667,17 @@
 	},
 /area/f13/legion)
 "oSz" = (
-/obj/item/toy/beach_ball,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/sign/poster/prewar/poster80,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "oSA" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/armor/f13/slavelabor,
 /obj/item/clothing/shoes/f13/rag,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "oSC" = (
 /obj/structure/fence/wooden{
@@ -37026,6 +38843,21 @@
 	footstep = "wood"
 	},
 /area/f13/building)
+"oWN" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"oWS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "oWU" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_north"
@@ -37145,12 +38977,15 @@
 	},
 /area/f13/village)
 "paa" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pad" = (
 /obj/structure/table/wood,
 /obj/item/documents{
@@ -37181,6 +39016,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"pap" = (
+/obj/structure/barricade/tentclothcorner,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "pas" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -37204,6 +39046,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"paZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "pbc" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -37241,7 +39092,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pbx" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
 /area/f13/village)
 "pbM" = (
 /obj/structure/chair/wood/modern{
@@ -37252,26 +39113,39 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
+"pbR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/bench{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "pbX" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pcb" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -4;
-	pixel_y = 2;
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
 	},
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "125"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pck" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"pcm" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "pcw" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -37316,15 +39190,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pcV" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
 	},
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "pdl" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
@@ -37345,13 +39215,14 @@
 	},
 /area/f13/village)
 "pei" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pek" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -37420,6 +39291,7 @@
 "pfd" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
+	tag = "icon-tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -37540,6 +39412,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
+	tag = "icon-skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
@@ -37553,6 +39426,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"pgQ" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
+"phd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "phy" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -37587,6 +39476,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (WEST)"
 	},
 /area/f13/caves)
 "pia" = (
@@ -37720,6 +39610,7 @@
 /obj/structure/fence{
 	dir = 4;
 	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -37745,6 +39636,14 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/followers)
+"plB" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
+	},
+/area/f13/building)
 "plF" = (
 /obj/effect/landmark/start/f13/legionary,
 /obj/item/bedsheet/brown,
@@ -37956,10 +39855,7 @@
 	},
 /area/f13/followers)
 "pqw" = (
-/obj/structure/chair/stool/retro/backed,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "pqB" = (
 /obj/structure/bed/mattress{
@@ -37992,6 +39888,7 @@
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
+/area/f13/followers,
 /area/f13/followers)
 "prp" = (
 /obj/structure/barricade/tentclothedge,
@@ -38000,6 +39897,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"pry" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "prG" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -38037,14 +39942,20 @@
 /obj/item/stack/f13Cash/random/high,
 /turf/open/floor/wood,
 /area/f13/building)
+"psk" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "psu" = (
 /obj/item/flag/khan,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"psD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
+"psw" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "psK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -38057,6 +39968,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 6;
 	icon_state = "outerpavement";
+	tag = "icon-outerpavement (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "ptb" = (
@@ -38095,10 +40007,14 @@
 	},
 /area/f13/building)
 "ptI" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/effect/decal/remains/human,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -38146,6 +40062,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
 	icon_state = "outerpavement";
+	tag = "icon-outerpavement (SOUTHWEST)"
 	},
 /area/f13/wasteland)
 "pvf" = (
@@ -38160,10 +40077,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pvD" = (
-/obj/structure/chair/stool/retro/tan,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "pvL" = (
 /obj/structure/showcase/cyborg/old,
@@ -38234,6 +40149,7 @@
 "pxw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "pxy" = (
@@ -38260,6 +40176,7 @@
 "pye" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6";
+	tag = "icon-tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -38273,6 +40190,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "pyr" = (
@@ -38320,9 +40238,11 @@
 "pyU" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
+	tag = "icon-remains"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "pyZ" = (
@@ -38360,6 +40280,7 @@
 "pzN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left";
+	tag = "icon-horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
 "pAm" = (
@@ -38432,6 +40353,7 @@
 "pBX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2";
+	tag = "icon-horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
 "pCi" = (
@@ -38492,6 +40414,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
+"pDy" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "pDA" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/structure/table/reinforced,
@@ -38516,6 +40442,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pDQ" = (
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "pDR" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood{
@@ -38597,6 +40531,7 @@
 "pFM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3";
+	tag = "icon-horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
 "pFN" = (
@@ -38605,6 +40540,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pFP" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "pFX" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -38628,6 +40570,7 @@
 "pGg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn";
+	tag = "icon-outerturn"
 	},
 /area/f13/wasteland)
 "pGq" = (
@@ -38776,6 +40719,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "pIT" = (
@@ -38816,6 +40760,7 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "pJT" = (
@@ -38839,6 +40784,7 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left (WEST)"
 	},
 /area/f13/wasteland)
 "pKj" = (
@@ -38855,8 +40801,13 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right (WEST)"
 	},
 /area/f13/wasteland)
+"pKr" = (
+/obj/structure/stalkeregg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "pKt" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38929,6 +40880,7 @@
 "pLJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
 "pLK" = (
@@ -39028,6 +40980,7 @@
 "pOC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2";
+	tag = "icon-horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
 "pOK" = (
@@ -39108,6 +41061,7 @@
 "pQX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
 "pRd" = (
@@ -39123,6 +41077,7 @@
 "pRo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
 	},
 /area/f13/wasteland)
 "pRq" = (
@@ -39144,6 +41099,7 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right (WEST)"
 	},
 /area/f13/wasteland)
 "pRQ" = (
@@ -39253,6 +41209,14 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
+"pUu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pUA" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -39263,6 +41227,7 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
 	},
 /area/f13/wasteland)
 "pUQ" = (
@@ -39298,6 +41263,7 @@
 "pVb" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3";
+	tag = "icon-horizontalinnermain3"
 	},
 /area/f13/wasteland)
 "pVQ" = (
@@ -39324,6 +41290,7 @@
 "pWt" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right"
 	},
 /area/f13/wasteland)
 "pWC" = (
@@ -39424,6 +41391,7 @@
 "pYj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left"
 	},
 /area/f13/wasteland)
 "pYn" = (
@@ -39510,20 +41478,19 @@
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
 	},
 /area/f13/wasteland)
 "qax" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
-	pixel_x = -11;
-	pixel_y = 11
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "qbe" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -39793,6 +41760,14 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
+"qfB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "qfI" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -39836,6 +41811,11 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"qgO" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/enclave)
 "qgP" = (
 /obj/structure/closet,
 /obj/item/restraints/handcuffs,
@@ -39913,12 +41893,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qin" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/farm)
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qip" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -40222,9 +42199,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qoN" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "qoP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/decan,
@@ -40444,6 +42424,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
+"qvc" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "qvp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -40511,6 +42499,33 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"qwR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
+"qwV" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "qwW" = (
 /obj/structure/debris/v3,
 /turf/open/water,
@@ -40791,6 +42806,15 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/ncr)
+"qCB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
+/area/f13/village)
 "qCE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -40946,8 +42970,16 @@
 	},
 /area/f13/wasteland)
 "qER" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"qEV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/village)
 "qEZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -40991,6 +43023,14 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/building)
+"qGE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/flour,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "qGF" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -41126,11 +43166,17 @@
 	},
 /area/f13/building)
 "qIS" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qJa" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner"
 	},
-/area/f13/enclave)
+/area/f13/wasteland)
 "qJx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -41289,10 +43335,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "qMt" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/enclave)
+/obj/structure/chair/stool/retro/backed,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qMA" = (
 /obj/structure/table,
 /obj/machinery/light/small/broken{
@@ -41577,17 +43622,21 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"qRy" = (
+"qRo" = (
 /obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/item/screwdriver/nuke{
+	anchored = 1;
+	pixel_x = 12;
+	pixel_y = 10
 	},
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "qRB" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
+/obj/structure/reagent_dispensers/barrel/three,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/village)
 "qSe" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41708,6 +43757,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
+"qUt" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "qUy" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -41818,8 +43872,9 @@
 	},
 /area/f13/building)
 "qXO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "qYa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41933,11 +43988,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "ram" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -42584,6 +44634,15 @@
 "rqs" = (
 /turf/open/floor/carpet,
 /area/f13/village)
+"rqC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/village)
 "rqG" = (
 /obj/structure/fence{
 	dir = 8
@@ -42648,6 +44707,13 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rsl" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "rss" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -42664,6 +44730,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rsO" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "rtk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken,
@@ -42870,6 +44940,11 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
+"ryN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/campfire/barrel,
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "ryS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43003,6 +45078,10 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"rCd" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "rCx" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
@@ -43041,10 +45120,8 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/village)
 "rDi" = (
-/obj/structure/flora/tree/cactus,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
+/obj/item/candle/tribal_torch,
+/turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "rDr" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43124,12 +45201,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rFc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "rFk" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/plating,
@@ -43707,6 +45781,15 @@
 	icon_state = "plating"
 	},
 /area/f13/building)
+"rSc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rSy" = (
 /obj/machinery/door/poddoor{
 	id = 42
@@ -43760,12 +45843,10 @@
 	},
 /area/f13/caves)
 "rTf" = (
-/obj/structure/closet,
-/obj/item/toy/poolnoodle/yellow,
-/obj/item/toy/poolnoodle,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/barricade/wooden,
+/obj/structure/urinal,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "rTi" = (
 /obj/structure/sign/poster/contraband/pinup_couch,
 /turf/closed/wall/f13/wood,
@@ -43816,6 +45897,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"rUN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
+"rUX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/tires/five,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rVe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt{
@@ -43845,18 +45942,20 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "rVM" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/overlay/junk/sink{
+	pixel_y = 15
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "rVN" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "rVQ" = (
 /obj/item/bodypart/l_arm,
 /obj/item/melee/onehanded/knife/throwing,
@@ -43885,6 +45984,18 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/building)
+"rWg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/village)
 "rWr" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -44250,6 +46361,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"sdg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "sdo" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44264,10 +46384,6 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/village)
-"sdI" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
 "sdK" = (
 /obj/structure/rack,
@@ -44439,6 +46555,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"shh" = (
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "shp" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -44549,16 +46674,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "siS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/vermouth,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/village)
+/area/f13/building)
 "siV" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -44596,6 +46721,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
+"sjC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/interior,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/area/f13/village)
 "sjX" = (
 /obj/structure/wreck/trash/brokenvendor,
 /obj/effect/decal/cleanable/dirt,
@@ -44790,12 +46920,11 @@
 	},
 /area/f13/wasteland)
 "snR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/door/unpowered/securedoor{
+	req_access_txt = "125"
 	},
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "soh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44896,11 +47025,6 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
-"spG" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "spL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -45010,6 +47134,21 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"srZ" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
+/area/f13/village)
 "sse" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45129,6 +47268,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/clothing/under/f13/legskirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "svh" = (
@@ -45137,11 +47277,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
-"svp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "svA" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/road{
@@ -45249,6 +47384,30 @@
 	name = "tile"
 	},
 /area/f13/building)
+"swV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/wood,
+/area/f13/village)
+"sxf" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/box/bowls{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "sxl" = (
 /obj/machinery/light/small/broken,
 /mob/living/simple_animal/hostile/raider/tribal,
@@ -45270,6 +47429,10 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"sxJ" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/village)
 "sxT" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -45371,12 +47534,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
 "sAe" = (
-/obj/structure/closet,
-/obj/item/toy/beach_ball,
-/obj/item/toy/poolnoodle/red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "sAk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -45384,6 +47544,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"sAA" = (
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "sAL" = (
 /obj/structure/filingcabinet{
 	pixel_x = 10
@@ -45711,15 +47874,8 @@
 	},
 /area/f13/village)
 "sIc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "sIf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45797,6 +47953,21 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland)
+"sJz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "sJH" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/torch,
@@ -45820,6 +47991,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"sJY" = (
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "sKe" = (
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt{
@@ -45943,8 +48119,11 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/wasteland)
 "sMp" = (
 /obj/structure/sign/poster/contraband/tools{
 	pixel_x = -32
@@ -45978,13 +48157,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
 "sNC" = (
-/obj/structure/chair/stool/retro/backed{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/stairs/west,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/village)
+/area/f13/building)
 "sND" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -46129,20 +48310,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"sQp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "sQu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/wood,
 /area/f13/village)
 "sQL" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "enclavebase";
-	name = "maintenance ladder"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/enclave)
+/obj/structure/sign/poster/contraband/pinup_ride,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "sQM" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -46150,10 +48331,12 @@
 	},
 /area/f13/wasteland)
 "sQW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "sQX" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -46230,11 +48413,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sTn" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/area/f13/village)
+/obj/structure/fence/pole_t,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "sTv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -46426,6 +48611,7 @@
 "sWn" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore";
+	tag = "icon-brokenstore"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood,
@@ -46441,6 +48627,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
+"sWs" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/building)
 "sWv" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -46677,9 +48872,9 @@
 	},
 /area/f13/wasteland)
 "tbX" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/kudzu,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "tcg" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -46701,12 +48896,24 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"tcJ" = (
-/obj/machinery/door/window{
-	dir = 4
+"tcr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/item/stack/sheet/metal/ten,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"tcJ" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tcU" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -46741,9 +48948,19 @@
 	},
 /area/f13/village)
 "tdM" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/greyscale{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "tdO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46763,15 +48980,36 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ten" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/flora/tree/cactus,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "teu" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"tfd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "tfy" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_y = 10
@@ -46815,6 +49053,19 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/legion)
+"tgx" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tgC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -46831,8 +49082,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
 "tgR" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "tgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -46884,6 +49141,16 @@
 /obj/item/clothing/under/f13/brahmin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"thR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "thW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -47162,15 +49429,23 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"tmw" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+"tmo" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"tmw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "tmA" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47212,20 +49487,15 @@
 	},
 /area/f13/building)
 "tnu" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "tnK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -47473,16 +49743,29 @@
 /area/f13/building)
 "tsO" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/item/reagent_containers/food/drinks/bottle/vermouth,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "tsS" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tsU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tsZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -47508,6 +49791,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"ttp" = (
+/obj/machinery/button/door{
+	id = "vaultelevator";
+	name = "Blast Door Exit";
+	pixel_y = -27
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "ttq" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47724,9 +50020,16 @@
 	},
 /area/f13/wasteland)
 "txC" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 23;
+	tag = "icon-sink (NORTH)"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "txN" = (
 /obj/structure/closet/fridge/meat,
 /obj/effect/decal/cleanable/dirt,
@@ -47754,6 +50057,20 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
+"tyi" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tyw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/debris/v3{
@@ -47763,12 +50080,9 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/village)
 "tyA" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "innermaincornerinner"
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/prewar/poster79,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "tzb" = (
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
@@ -47853,8 +50167,8 @@
 /area/f13/village)
 "tAD" = (
 /obj/structure/chair/office/dark,
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/turf/open/floor/wood/f13/old/ruinedstraightwest,
+/area/f13/wasteland)
 "tAX" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -47876,6 +50190,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tBe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tBm" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -48022,9 +50345,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "tFP" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/red/white/side,
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tFR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -48087,16 +50415,19 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"tHk" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "tHN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/bedsheetbin/towel,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/village)
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tIv" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -48123,10 +50454,14 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "tJl" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
-/area/f13/village)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tJm" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48190,6 +50525,10 @@
 "tKZ" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
+"tLa" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/farm)
 "tLq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48212,12 +50551,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "tLE" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 4
+/obj/item/trash/f13/steak,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/area/f13/wasteland)
 "tLI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -48270,6 +50608,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tMN" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "tMU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -48341,6 +50685,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"tOi" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "tOp" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48348,9 +50700,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "tOt" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white/side,
-/area/f13/village)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "tOD" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -48414,7 +50768,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "tPD" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tPY" = (
@@ -48537,12 +50891,15 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "tSf" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tSQ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48572,16 +50929,15 @@
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "tTV" = (
-/obj/effect/overlay/junk/toilet{
-	pixel_y = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tUb" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
@@ -48600,8 +50956,13 @@
 	},
 /area/f13/building)
 "tUk" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "tUo" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48633,15 +50994,8 @@
 	},
 /area/f13/village)
 "tUO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "tUQ" = (
 /obj/structure/reagent_dispensers/barrel/three,
@@ -48651,12 +51005,8 @@
 	},
 /area/f13/caves)
 "tUU" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood/house,
 /area/f13/village)
 "tVc" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -48843,18 +51193,9 @@
 	},
 /area/f13/building)
 "tZh" = (
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tZr" = (
 /obj/structure/chair/wood/modern{
 	dir = 4
@@ -49045,8 +51386,32 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
+"uch" = (
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"uck" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "uco" = (
-/obj/item/clothing/head/cone,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "ucr" = (
@@ -49295,6 +51660,12 @@
 	icon_state = "bar"
 	},
 /area/f13/caves)
+"uge" = (
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "ugj" = (
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/floor/f13{
@@ -49338,6 +51709,21 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/village)
+"ugx" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
 	},
 /area/f13/village)
 "ugD" = (
@@ -49626,6 +52012,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
 	},
 /area/f13/wasteland)
 "ulN" = (
@@ -49790,6 +52177,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/village)
+"upn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/old/ruinedcornerbl,
+/area/f13/wasteland)
 "upu" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -49938,6 +52329,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"urS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "urW" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -50053,6 +52450,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"uuK" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "uvb" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -50087,6 +52488,11 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"uvw" = (
+/obj/item/mine/shrapnel,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "uvC" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -50177,6 +52583,12 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"uyo" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/farm)
 "uyp" = (
 /obj/structure/lamp_post/doubles/bent{
 	dir = 8
@@ -50237,8 +52649,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "uzN" = (
-/obj/structure/nest/mirelurk,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/table/snooker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
+	},
 /area/f13/village)
 "uzO" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -50249,6 +52664,12 @@
 /obj/structure/sign/poster/prewar/protectron,
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"uzW" = (
+/obj/structure/table,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/old,
+/area/f13/village)
 "uAk" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -50257,11 +52678,9 @@
 	},
 /area/f13/wasteland)
 "uAp" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "uAv" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/wasteland)
@@ -50723,6 +53142,12 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"uHF" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "uHG" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
@@ -50760,9 +53185,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "uIT" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "uJa" = (
 /obj/machinery/hydroponics/soil,
@@ -50891,6 +53315,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"uNH" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "uNK" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -50936,9 +53364,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "uNW" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "uOg" = (
 /obj/machinery/light/small{
@@ -51071,11 +53500,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uPJ" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "uPK" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "uPP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -51295,10 +53742,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
 "uTA" = (
-/obj/machinery/icecream_vat,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "uTE" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
@@ -51382,6 +53828,16 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
+"uVw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
 "uVy" = (
 /obj/effect/decal/riverbank{
 	dir = 9
@@ -51412,6 +53868,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/caves)
+"uVU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "uVW" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -51436,6 +53899,18 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
+/area/f13/village)
+"uWx" = (
+/obj/structure/table/snooker{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
 /area/f13/village)
 "uWA" = (
 /obj/structure/table/wood,
@@ -51557,12 +54032,11 @@
 /turf/open/floor/wood,
 /area/f13/village)
 "uZg" = (
-/obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "uZl" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -51612,12 +54086,10 @@
 	},
 /area/f13/building)
 "uZS" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/area/f13/village)
+/area/f13/building)
 "vad" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -51801,10 +54273,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "veZ" = (
-/obj/effect/decal/remains/human,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "vfc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -51863,8 +54342,12 @@
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
 "vfY" = (
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/item/trash/f13/dandyapples,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vga" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -51976,9 +54459,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "viv" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/freezer,
+/obj/item/kirbyplants,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vix" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -52018,12 +54500,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
-"vjj" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
 "vjn" = (
 /obj/structure/sign/poster/ncr/democracy,
 /turf/closed/wall/r_wall/rust,
@@ -52130,9 +54606,27 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vlI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/flour,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "vmB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
+	},
+/area/f13/building)
+"vmE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "vmQ" = (
@@ -52153,8 +54647,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "vns" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/store,
@@ -52193,6 +54687,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/caves)
 "voc" = (
@@ -52283,14 +54778,13 @@
 	},
 /area/f13/ncr)
 "vpp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vpw" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/f13/wood/house,
@@ -52453,6 +54947,14 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"vud" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "vug" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -52490,12 +54992,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vvh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vvl" = (
 /obj/structure/simple_door/house{
 	icon_state = "interioropening"
@@ -52673,6 +55175,11 @@
 /obj/item/defibrillator/primitive,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"vyX" = (
+/turf/closed/wall/f13/ruins{
+	color = "#d9cdb9"
+	},
+/area/f13/caves)
 "vzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -52760,14 +55267,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vAu" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "vAJ" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"vAL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "vAQ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52962,12 +55478,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vEw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vEG" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -52995,6 +55515,11 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"vFv" = (
+/obj/structure/decoration/vent/rusty,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "vFz" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53252,6 +55777,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"vKn" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/door/poddoor{
+	id = "vaultelevator"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "vKt" = (
 /obj/structure/sign/poster/prewar/poster82{
 	pixel_x = 32
@@ -53462,6 +55996,15 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"vPn" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "enclavebase";
+	name = "maintenance ladder"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/enclave)
 "vPz" = (
 /obj/structure/nest/scorpion,
 /turf/open/floor/plasteel/barber{
@@ -53484,6 +56027,13 @@
 /obj/item/soap,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/area/f13/building)
+"vPJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building)
 "vPV" = (
 /obj/structure/simple_door/house{
@@ -53536,12 +56086,12 @@
 	},
 /area/f13/legion)
 "vQE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/village)
+/area/f13/building)
 "vQS" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -53559,6 +56109,17 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"vRp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "vRC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/cola/space_up,
@@ -53571,6 +56132,13 @@
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"vRQ" = (
+/obj/structure/table/snooker{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "vRR" = (
 /turf/closed/indestructible/rock,
 /area/f13/legion)
@@ -53712,6 +56280,12 @@
 /obj/structure/sign/poster/prewar/poster81,
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
+"vVM" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "vVU" = (
 /obj/structure/table/wood/settler,
 /obj/item/shovel,
@@ -53993,23 +56567,25 @@
 	},
 /area/f13/building)
 "wcB" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
 	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wcO" = (
-/obj/effect/decal/remains/human,
-/obj/item/screwdriver/nuke{
-	anchored = 1;
-	pixel_x = 12;
-	pixel_y = 10
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wcS" = (
 /obj/structure/rack,
 /obj/machinery/light/small/broken{
@@ -54017,6 +56593,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"wdk" = (
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wdo" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/corner{
 	dir = 1
@@ -54124,6 +56713,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
+"wgd" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wgg" = (
 /obj/structure/table,
 /obj/item/reagent_containers/rag/towel,
@@ -54163,6 +56756,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"whK" = (
+/obj/structure/safe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "whO" = (
@@ -54212,6 +56816,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wiM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "wiU" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -54232,6 +56849,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"wjf" = (
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "wjh" = (
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/r_wall/rust,
@@ -54255,8 +56878,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wju" = (
-/obj/structure/closet,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "wjI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -54617,12 +57240,28 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
+"wrO" = (
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "wrQ" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"wrU" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/tunnel)
 "wrV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -54638,6 +57277,13 @@
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
+"wsn" = (
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "wsq" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/wasteland)
@@ -54694,6 +57340,16 @@
 "wtq" = (
 /obj/structure/junk/cabinet,
 /turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"wtF" = (
+/obj/machinery/door/window{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
@@ -54824,9 +57480,16 @@
 	},
 /area/f13/legion)
 "wxi" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wxr" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
@@ -55116,14 +57779,10 @@
 	},
 /area/f13/wasteland)
 "wDW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wDX" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -55173,6 +57832,20 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
+"wFi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
+"wFm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "wFo" = (
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
@@ -55444,6 +58117,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/wood_large,
 /area/f13/building)
+"wLm" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "S1"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland)
 "wLu" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -55472,11 +58154,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wLF" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/eat,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "wLO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -55493,11 +58173,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
@@ -55555,9 +58232,12 @@
 	},
 /area/f13/wasteland)
 "wMU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "wMX" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
@@ -55673,6 +58353,16 @@
 /mob/living/simple_animal/hostile/raider/legendary,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wPe" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "wPl" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/village)
@@ -55688,6 +58378,28 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wPC" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/obj/item/storage/box/cups{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wPG" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -55742,6 +58454,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"wQd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper,
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
+	},
+/area/f13/village)
 "wQk" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -55829,12 +58548,12 @@
 	},
 /area/f13/building)
 "wRI" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "wSa" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/luchador/rudos,
@@ -55946,6 +58665,16 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"wTT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "wUc" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -56035,6 +58764,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/ncr)
+"wWa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "wWb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/room,
@@ -56252,11 +58988,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xab" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "xae" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -56309,6 +59043,17 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/building)
+"xbt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "xbA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -56412,9 +59157,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xdG" = (
-/obj/structure/stalkeregg,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "xdP" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
@@ -56442,11 +59190,9 @@
 	},
 /area/f13/wasteland)
 "xei" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
 /area/f13/village)
 "xeo" = (
 /obj/machinery/light{
@@ -56464,10 +59210,9 @@
 	},
 /area/f13/legion)
 "xeG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/pinup_couch,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "xeK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -56478,10 +59223,16 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "xeO" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/village)
 "xeQ" = (
 /obj/item/kirbyplants/random,
@@ -56631,6 +59382,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xhw" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/pill/patch/healpoultice,
+/obj/item/reagent_containers/pill/patch/healpoultice,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
+/area/f13/village)
 "xhB" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/effect/decal/cleanable/dirt,
@@ -56873,9 +59637,9 @@
 /turf/open/indestructible/ground/outside/savannah/bottomright,
 /area/f13/building)
 "xny" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/sign/poster/contraband/free_tonto,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "xnC" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 4;
@@ -57051,9 +59815,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xql" = (
-/obj/structure/decoration/clock/old/active,
-/turf/closed/wall/f13/wood/house,
-/area/f13/village)
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "xqp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/shreds,
@@ -57087,6 +59853,14 @@
 	},
 /turf/open/floor/wood,
 /area/f13/village)
+"xqJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "xqQ" = (
 /obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
@@ -57113,6 +59887,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xrk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/tray,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "xrA" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/inside/mountain,
@@ -57529,6 +60312,12 @@
 /obj/item/flag/legion,
 /turf/open/floor/carpet/red,
 /area/f13/legion)
+"xzV" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "xAd" = (
 /obj/structure/toilet{
 	dir = 8
@@ -57552,13 +60341,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xAB" = (
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "xAX" = (
 /obj/machinery/smartfridge/bottlerack,
 /obj/effect/decal/cleanable/dirt{
@@ -57600,6 +60387,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/legion)
+"xBK" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "xBM" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -57617,6 +60411,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"xCc" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "xCI" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -57678,16 +60478,16 @@
 /area/f13/building)
 "xDL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
-/area/f13/village)
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xDP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xEh" = (
 /obj/structure/table,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -57929,11 +60729,17 @@
 	},
 /area/f13/building)
 "xIh" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "xIm" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -58191,6 +60997,25 @@
 /obj/item/storage/box/dice,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"xOk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
+	},
+/area/f13/village)
 "xOq" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah,
@@ -58200,11 +61025,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xOt" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/area/f13/village)
+/area/f13/building)
 "xOD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -58326,8 +61160,11 @@
 	},
 /area/f13/caves)
 "xSc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "xSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58350,18 +61187,19 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "xSs" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/enclave)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xSC" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xSS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -58433,6 +61271,15 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"xUM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
+	},
+/area/f13/building)
 "xUO" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -58447,8 +61294,16 @@
 	},
 /area/f13/bunker)
 "xVu" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/farm)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/village)
 "xVG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -58456,12 +61311,23 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"xVI" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+"xVH" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"xVI" = (
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xVN" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall/f13/store,
@@ -58472,6 +61338,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"xVU" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "xWg" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt{
@@ -58605,6 +61477,20 @@
 /obj/item/reagent_containers/food/snacks/meatsalted,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xZE" = (
+/obj/structure/kitchenspike,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "xZO" = (
 /obj/item/bedsheet/black,
 /obj/machinery/light/small{
@@ -58635,6 +61521,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"yaS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
+/area/f13/village)
 "yaZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/greyscale{
@@ -58766,10 +61659,10 @@
 	},
 /area/f13/village)
 "ydq" = (
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/closet/fridge/standard,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ydE" = (
 /obj/structure/chair{
 	dir = 4
@@ -58925,6 +61818,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/store,
 /area/f13/village)
+"yha" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/junk/cabinet{
+	pixel_y = 10
+	},
+/turf/open/floor/wood{
+	icon_state = "housewastelandnorth"
+	},
+/area/f13/village)
 "yhc" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -58974,12 +61876,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "yhL" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "yig" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -59063,13 +61962,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "yjE" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
+/obj/structure/car/rubbish2,
+/obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter"
+	dir = 1;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "yjF" = (
@@ -59169,9 +62066,9 @@
 	},
 /area/f13/village)
 "ylQ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "ylR" = (
 /obj/structure/fence{
 	dir = 4
@@ -59195,6 +62092,7 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+
 (1,1,1) = {"
 ktB
 ktB
@@ -60099,6 +62997,9 @@ gcK
 gcK
 gcK
 gcK
+dYM
+oBA
+gXc
 gcK
 gcK
 gcK
@@ -60110,9 +63011,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -60354,23 +63252,23 @@ gcK
 gcK
 gcK
 gcK
+gLj
+mkf
+mwp
+mwp
+mwp
+rCd
+fLF
+gcK
+rCd
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gbL
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -60612,20 +63510,20 @@ gcK
 gcK
 gcK
 gcK
+tHk
+mwp
+mwp
+mwp
+mwp
+mwp
+bkC
+mwp
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -60780,7 +63678,7 @@ rUp
 wDX
 wvV
 ayH
-lDx
+gcK
 gcK
 gcK
 gcK
@@ -60870,26 +63768,26 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+pKr
+mwp
+mwp
+iOD
+mwp
+mwp
+mwp
+mwp
+pKr
 gbL
-ktB
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 mwp
-mwp
+wEs
 mwp
 mwp
 mwp
@@ -61037,18 +63935,18 @@ rUp
 xGv
 wvV
 ayH
-lDx
 gcK
 gcK
 gcK
 gcK
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 kGc
 unI
@@ -61125,24 +64023,24 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
+gbL
+gbL
+hMW
+mwp
+dTV
+mwp
+mwp
+mwp
+hMW
+dTV
+mwp
+mwp
+mwp
+mwp
+mwp
 gcK
-gcK
-gcK
-gcK
+oKE
 gcK
 mwp
 mwp
@@ -61294,18 +64192,18 @@ rUp
 xGv
 wvV
 ayH
-lDx
 gcK
 gcK
 gcK
 gcK
-gjP
-aUV
-pJd
-siS
-gjs
-pJd
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 kGc
 unI
@@ -61383,28 +64281,28 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
-gcK
-gcK
-gcK
+gbL
+pKr
+bkC
+mwp
+mwp
+mwp
 gcK
 gcK
 mwp
 mwp
 mwp
-wEs
+hMW
+mwp
+mwp
+mwp
+orJ
+orJ
+mwp
+mwp
+mwp
+mwp
 mwp
 mwp
 mwp
@@ -61551,18 +64449,18 @@ rUp
 jQd
 wvV
 ayH
-lDx
 gcK
 gcK
 gcK
 gcK
-gjP
-fOs
-pJd
-vQE
-pvD
-pJd
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 sdo
 pBv
@@ -61642,6 +64540,7 @@ gcK
 gcK
 gcK
 gcK
+rCd
 gcK
 gcK
 gcK
@@ -61650,20 +64549,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
-gcK
+mwp
+mwp
+gHJ
+mwp
+mwp
+orJ
+orJ
 mwp
 mwp
 mwp
 mwp
 mwp
-mwp
+wEs
 mwp
 mwp
 mwp
@@ -61808,17 +64706,17 @@ xGv
 sWz
 wvV
 ayH
-lDx
+gcK
 gcK
 gcK
 gcK
 gcK
 gjP
-hau
-fUs
-fPb
-gjs
-xIh
+gjP
+gjP
+gjP
+gjP
+gjP
 gjP
 fyf
 kGc
@@ -61902,17 +64800,17 @@ gcK
 gcK
 gcK
 gcK
+sJY
+sJY
+sJY
+sJY
 gcK
 gcK
+rCd
+mwp
+dTV
+pKr
 gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 mwp
@@ -62065,18 +64963,18 @@ wvV
 wvV
 wvV
 ayH
-lDx
+gcK
 gcK
 gcK
 gcK
 gcK
 gjP
 nzN
-pJd
+pqw
 tsO
 pvD
 pJd
-bEu
+gjP
 fyf
 kGc
 ofX
@@ -62158,18 +65056,18 @@ gcK
 gcK
 gcK
 gcK
+sJY
+vPn
+qgO
+vVM
+cuk
+sJY
 gcK
 gcK
+ola
+bhA
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -62322,18 +65220,18 @@ cqA
 oUo
 wvV
 ayH
-lDx
+gcK
 gcK
 gcK
 gcK
 gcK
 gjP
 rVM
+pqw
+fUs
+sIc
 pJd
-pJd
-pJd
-pJd
-tmw
+gjP
 fyf
 kGc
 unI
@@ -62415,18 +65313,18 @@ gcK
 gcK
 gcK
 gcK
+sJY
+sJY
+sJY
+sJY
+ttp
+sJY
+gcK
+wrU
+bhA
+aPK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -62579,18 +65477,18 @@ qwe
 kBw
 wvV
 ayH
-lDx
+gcK
 gcK
 gcK
 gcK
 gcK
 gjP
 eYa
-pJd
+fPb
 tUO
-pJd
+pvD
 jMN
-trG
+gjP
 fyf
 kGc
 unI
@@ -62672,17 +65570,17 @@ gcK
 gcK
 gcK
 gcK
+sJY
+xCc
+lPw
+kwy
+vud
+vKn
+kum
+bhA
+uvw
+mwp
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
@@ -62842,12 +65740,12 @@ gcK
 gcK
 gcK
 gjP
-pJd
+elL
 pqw
 bUd
 sIc
-xIh
-gjP
+pJd
+gxb
 fyf
 kGc
 unI
@@ -62925,22 +65823,22 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+sJY
+wjf
+ewh
+lPw
+dWG
+sJY
+kaT
+bhA
+mwp
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63099,12 +65997,12 @@ gcK
 gcK
 gcK
 gjP
-pJd
-pqw
 erB
-sNC
 pJd
-gjP
+pJd
+pJd
+pJd
+hau
 igz
 hgX
 unI
@@ -63184,20 +66082,20 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
 gbL
 gcK
-gbL
+sJY
+aKh
+qRo
+ewh
+iFV
+sJY
+mNR
+mwp
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63358,7 +66256,7 @@ gcK
 gjP
 pJd
 pJd
-elL
+pJd
 pJd
 pJd
 lyG
@@ -63439,22 +66337,22 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
 gbL
 gcK
-ktB
+gcK
+gcK
+gcK
+sJY
+jbR
+iSz
+sJY
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63613,7 +66511,7 @@ gcK
 gcK
 gcK
 gjP
-gwJ
+fOs
 pJd
 wjl
 pJd
@@ -63710,8 +66608,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
-gbL
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -65154,12 +68052,12 @@ gcK
 ace
 ace
 fyf
-thG
-tdM
-tUk
+xHN
+mvv
+mvv
 nIm
-tUk
-thG
+pIn
+gjs
 fyf
 fyf
 kGc
@@ -65411,12 +68309,12 @@ gcK
 gcK
 fyf
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+ttW
+mvv
+mvv
+mvv
+gjs
 fyf
 fyf
 sPC
@@ -65668,12 +68566,12 @@ ayH
 gcK
 fyf
 fyf
-thG
+xHN
 jzC
-tUk
-tUk
-tUk
-thG
+mvv
+mvv
+mvv
+gjs
 fyf
 fyf
 kGc
@@ -65925,12 +68823,12 @@ ayH
 gcK
 fyf
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+mvv
+mvv
+mvv
+mvv
+gjs
 fyf
 fyf
 kGc
@@ -66182,12 +69080,12 @@ ayH
 gcK
 gcK
 fyf
-thG
+xHN
 ogw
-tUk
-tUk
-tUk
-thG
+mvv
+mvv
+mvv
+gjs
 fyf
 fyf
 kGc
@@ -66439,12 +69337,12 @@ ayH
 ayH
 gcK
 fyf
-thG
-pbX
-tUk
-tUk
-pbX
-thG
+xHN
+xwW
+mvv
+mvv
+xwW
+gjs
 fyf
 fyf
 kGc
@@ -66696,12 +69594,12 @@ wvV
 ayH
 gcK
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+mvv
+mvv
+mvv
+mvv
+gjs
 fyf
 fyf
 kGc
@@ -66953,12 +69851,12 @@ wvV
 ayH
 gcK
 fyf
-vxC
-uxC
-uxC
-uxC
-uxC
-vxC
+bEu
+igc
+igc
+igc
+igc
+pLD
 fyf
 pis
 kGc
@@ -75433,7 +78331,7 @@ gcK
 gcK
 gcK
 gcK
-ggK
+bfW
 ptf
 gcK
 gcK
@@ -75442,19 +78340,19 @@ gcK
 gcK
 ptf
 ptf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
 cpK
 unI
 qvQ
@@ -75690,8 +78588,6 @@ gcK
 gcK
 gcK
 gcK
-ggK
-ggK
 gcK
 gcK
 gcK
@@ -75701,17 +78597,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+mZW
+vQE
+lgE
+oAo
+wrO
+okC
+cfX
+aBi
+rUX
+oqo
+kMk
+sqy
 lKG
 emn
 rMB
@@ -75946,10 +78844,6 @@ gcK
 gcK
 gcK
 gcK
-oKE
-ggK
-ggK
-mZW
 gcK
 gcK
 gcK
@@ -75960,15 +78854,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+pbX
+xIh
+vmE
+oaQ
+rSc
+kKj
+vmE
+vRZ
+vRZ
+iOx
+czm
+tgx
 cpK
 unI
 qvQ
@@ -76203,12 +79101,6 @@ gcK
 gcK
 gcK
 gcK
-oKE
-ggK
-ggK
-ggK
-oKE
-oKE
 gcK
 gcK
 gcK
@@ -76219,15 +79111,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+siS
+siS
+pUu
+djP
+bZj
+iSP
+kRD
+bjf
+pDQ
+gaz
+oNz
+auV
 cpK
-unI
+jnK
 qvQ
 ehN
 ehN
@@ -76460,12 +79358,6 @@ gcK
 gcK
 gcK
 gcK
-oKE
-mZW
-ggK
-ggK
-ggK
-oKE
 gcK
 gcK
 gcK
@@ -76476,15 +79368,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+oWS
+kyZ
+oeK
+qwV
+mCa
+cZw
+chH
+oWN
+gaz
+giZ
+giZ
 cpK
-jnK
+unI
 qvQ
 ehN
 ehN
@@ -76719,10 +79617,6 @@ gcK
 gcK
 gcK
 gcK
-oKE
-ggK
-ggK
-oKE
 gcK
 gcK
 gcK
@@ -76731,15 +79625,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+sNC
+tBe
+gdN
+wiM
+wtF
+wdk
+cZw
+eiC
+crP
+vmE
+wsn
+eOf
 cpK
 ofX
 qvQ
@@ -76977,9 +79875,6 @@ gcK
 gcK
 gcK
 gcK
-mZW
-ggK
-oKE
 gcK
 gcK
 gcK
@@ -76987,16 +79882,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+gHP
+eOf
+gdN
+rSc
+jsH
+whK
+cZw
+fej
+wPC
+tsU
+iRw
+giZ
 cpK
 unI
 qvQ
@@ -77235,25 +80133,25 @@ gcK
 gcK
 gcK
 gcK
-oKE
-oKE
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+oWS
+nuY
+krQ
+bjf
+iYw
+aBj
+izf
+djP
+jwe
+ody
 cpK
 axG
 qvQ
@@ -77498,19 +80396,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+tdM
+fok
+uVU
+vmE
+iOx
+gaz
+gaz
+vmE
+vPJ
+uch
+tyi
+sqy
 cpK
 unI
 qvQ
@@ -77755,19 +80653,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+tmw
+fok
+sQp
+jVa
+shh
+miC
+tcr
+xVH
+iEJ
+oDQ
+cAG
+ody
 cpK
 unI
 qvQ
@@ -77820,7 +80718,7 @@ nlO
 mfD
 mkw
 thG
-fyf
+vvK
 fyf
 fyf
 pEv
@@ -78012,19 +80910,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+tUk
+wFm
+dVy
+giZ
+giZ
+giZ
+oWS
+uVU
+oWS
+oWS
+giZ
+giZ
 cFe
 unI
 qvQ
@@ -78269,10 +81167,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+giZ
 gcK
 gcK
 gcK
@@ -85250,7 +88148,7 @@ uRJ
 xaF
 xaF
 luK
-fbq
+bGk
 fbq
 fbq
 fbq
@@ -85507,7 +88405,7 @@ uRJ
 tVV
 ssm
 qyx
-fbq
+tLa
 fbq
 vHb
 fbq
@@ -91180,8 +94078,8 @@ eQR
 giM
 mXv
 oIX
-mLv
-mLv
+lBX
+kkY
 pcG
 uaf
 pBv
@@ -91432,13 +94330,13 @@ jMC
 pcG
 eIU
 mLv
+ewV
 mLv
 mLv
-mLv
-nBF
-nBF
-mLv
-mLv
+gZJ
+uzW
+lBX
+wQd
 mgX
 uaf
 ajD
@@ -91689,13 +94587,13 @@ fyf
 pcG
 eQR
 mLv
+eQR
+eQR
+lBX
 mLv
+ryN
 mLv
-mLv
-mLv
-mLv
-mLv
-mLv
+wQd
 gMT
 uaf
 jIB
@@ -91947,12 +94845,12 @@ pcG
 dpK
 mLv
 mLv
-mLv
-mLv
+lBX
+lBX
 mLv
 pFL
 jEa
-mLv
+kkY
 mgX
 cam
 nAi
@@ -92203,13 +95101,13 @@ uey
 pcG
 arh
 mLv
-mLv
-mLv
-mLv
+eQR
+lBX
+ewV
 mLv
 oqV
 ePP
-mLv
+eOm
 pcG
 bFJ
 unI
@@ -92717,9 +95615,9 @@ qOV
 pcG
 eQR
 rDa
+lBX
 mLv
-mLv
-mLv
+kkY
 pcG
 jPD
 bFJ
@@ -92973,10 +95871,10 @@ bNg
 daU
 pcG
 eQR
-mLv
+lBX
 sMn
 nBF
-mLv
+eOm
 acK
 xKx
 dkg
@@ -93106,7 +96004,7 @@ qai
 mrQ
 wFW
 aFG
-kRe
+bFR
 sGp
 bpD
 fyf
@@ -93225,12 +96123,12 @@ gjP
 wLu
 wLu
 ydT
-wxr
+uyo
 nTV
 mvv
 pcG
 hXJ
-ces
+gmz
 tAD
 bGG
 mLv
@@ -93362,7 +96260,7 @@ sGp
 uco
 kBV
 oDG
-kRe
+lei
 axr
 sGp
 hCg
@@ -93473,13 +96371,13 @@ qvQ
 ehN
 ehN
 koD
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+dMW
+wPl
+wPl
+wPl
+wPl
+wPl
+fFu
 fyf
 tBN
 ofL
@@ -93488,9 +96386,9 @@ amc
 pcG
 iqy
 ces
-jCH
-bGG
-mLv
+fyf
+oDe
+lBX
 acK
 trd
 xKx
@@ -93619,8 +96517,8 @@ sGp
 vxz
 oDG
 oDG
-kRe
-umX
+lei
+bWM
 sGp
 fyf
 fyf
@@ -93730,33 +96628,33 @@ qvQ
 ehN
 ins
 koD
-thG
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-bTk
-nGq
-nGq
-nGq
-hoz
+dMW
+wPl
+xRk
+xRk
+iEe
+xRk
+qOV
+cWG
+daU
+wgd
 pcG
 pcG
-yjE
-trd
-gCo
-uaf
+pcG
+pcG
+pcG
+pcG
+auk
+eQN
+pcG
+wIK
+jZD
+jmQ
+bFJ
 uaf
 jIB
 qvQ
-ehN
+hEX
 pfl
 fyf
 bKh
@@ -93987,29 +96885,29 @@ qvQ
 ehN
 ehN
 koD
-thG
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-bni
-hCg
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-kdJ
-xKx
-uaf
+dMW
+wPl
+ylQ
+mnR
+pcm
+oGW
+daU
+mvv
+mvv
+mvv
+ygZ
+mnT
+jbc
+jRz
+otO
+pcG
+pcG
+pcG
+uuK
+vFv
+bFJ
+oiY
+bFJ
 uaf
 nZJ
 qvQ
@@ -94244,29 +97142,29 @@ qvQ
 rbi
 ehN
 koD
-gjP
-gjP
-cPn
-cPn
-gjP
-gjP
-gjP
-gjP
-gjP
-fyf
-fyf
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-ijg
-ijg
-gjP
+dMW
+wPl
+dxr
+fSC
+pcm
+psk
+mvv
+mvv
+mvv
+mvv
+thR
+hVD
+lWu
+qGE
+phd
+pcG
+maX
+iPs
+ess
+uuK
+bFJ
+uck
+bFJ
 cam
 unI
 qvQ
@@ -94501,29 +97399,29 @@ qvQ
 ehN
 ehN
 koD
-gjP
-jel
-bMg
+dMW
+wPl
+oGW
 qRB
-lqO
-cbk
-uRJ
-mPT
-gjP
-fyf
-fyf
-srw
-bMg
-lly
-gvh
-pIV
-dvp
-aUV
-cbk
-isy
-lly
-uRJ
-gjP
+pcm
+pDy
+xGH
+mvv
+mvv
+mvv
+ygZ
+jlV
+lme
+vAL
+kOX
+pcG
+xbt
+gxK
+dos
+iwz
+bFJ
+bFJ
+bFJ
 bFJ
 unI
 qvQ
@@ -94758,33 +97656,33 @@ qvQ
 ehN
 ehN
 bfu
-gjP
-uRJ
-uRJ
-mvJ
-uRJ
-jnX
-wyI
-lqO
-gjP
-fyf
-qOV
-srw
-bMg
-lly
-uRJ
-uRJ
-uRJ
-uRJ
-cbk
+dMW
+wPl
+oGW
+pDy
+xRk
+xRk
+nky
+hko
+mvv
+mvv
+gLu
+xVu
+xVu
+xqJ
+gPK
+qEV
+ovV
+eqY
+ouH
 ctm
-wyI
-uRJ
-gjP
+dLM
+bFJ
+bFJ
 bKv
 fsl
 voF
-wGJ
+ehN
 wGJ
 pfl
 fyf
@@ -95015,29 +97913,29 @@ voF
 ehN
 ehN
 wwM
-gjP
-uRJ
-uRJ
-uRJ
-uRJ
-cbk
-cbk
-cbk
-gjP
-qOV
-gjP
-gjP
-gjP
-gjP
-cbk
-cbk
-cbk
-jnX
-cbk
-cbk
-cbk
-jnX
-gjP
+dMW
+wPl
+wPl
+wPl
+wPl
+wPl
+ieF
+mvv
+mvv
+mvv
+wFi
+bmf
+wWa
+aZH
+jYY
+qEV
+ovV
+sAA
+sdg
+pcG
+uuK
+pcG
+uuK
 bFJ
 unI
 voF
@@ -95272,33 +98170,33 @@ qvQ
 ehN
 ehN
 koD
+dMW
+ijg
 gjP
-wyI
-jdE
-uRJ
-uRJ
-jnX
-uRJ
-uRJ
-srw
-daU
-soY
+xei
+ijg
+ijg
+naZ
+sjC
+sxJ
+mvv
+ygZ
 rVN
-rVN
+rWg
 xVu
-tlr
-cCf
-cbk
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-srw
+gPK
+qEV
+qEV
+nYR
+nyn
+pcG
+jsb
+gjB
+uuK
 bFJ
 bwE
 qvQ
-mHW
+wGJ
 mHW
 pfl
 uey
@@ -95529,29 +98427,29 @@ qvQ
 ehN
 hOl
 koD
+dMW
 gjP
-cbk
-dJg
-cbk
-cbk
-cbk
-uRJ
-uRJ
-oiu
+ugx
+qfB
+yaS
+qXO
+uIT
+uIT
+gjP
 mvv
-soY
-fbq
-fbq
+thR
+xrk
+iCf
 xVu
-tTV
-oGX
-jnX
-uRJ
-aqv
-uRJ
-uRJ
-uRJ
-oiu
+ygZ
+sxf
+uPJ
+tfd
+paZ
+gwC
+wTT
+xZE
+uuK
 bFJ
 unI
 dXy
@@ -95786,33 +98684,33 @@ qvQ
 ehN
 sgz
 koD
-gjP
-nQY
-ppn
+dMW
+xei
+qwR
 fjR
-uRJ
-cbk
-uRJ
-uRJ
-srw
-amc
-soY
-fbq
-fbq
-xVu
+xOk
+qOz
+pbR
+nTP
 gjP
-gjP
-gjP
-uRJ
-jTq
-bMg
-uRJ
-hVN
-gjP
+mvv
+ygZ
+vlI
+hVm
+lMu
+ima
+pcG
+ncl
+oNu
+jOm
+pcG
+sJz
+iJw
+pcG
 wfe
 eSX
 grp
-wNe
+mHW
 mmH
 fyf
 bKy
@@ -96043,33 +98941,33 @@ grp
 wKo
 sgz
 koD
+dMW
 gjP
-mfR
-uRJ
-uRJ
-kwA
-cbk
-adN
+qOz
+qOz
+qOz
+qOz
+pbR
 uIT
-gjP
-xGH
-soY
-fbq
-boN
-fbq
-hCp
-fbq
-jnX
-uRJ
-uRJ
-mTy
-wyI
-ipE
-gjP
+gbh
+mvv
+pcG
+pcG
+pcG
+pcG
+pcG
+pcG
+ygZ
+dph
+pcG
+pcG
+pcG
+pcG
+pcG
 fyf
 fyf
 fyf
-fyf
+wNe
 fyf
 fyf
 fyf
@@ -96300,32 +99198,32 @@ fyf
 ukl
 gWo
 hzb
+obr
 gjP
+xhw
+bxG
+fyl
+qXO
+rUN
+nTP
 gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-nlO
-qin
-wxr
-wxr
-wxr
-wxr
-wxr
-gjP
-gjP
-xql
-ijg
-ijg
-gjP
-gjP
+mvv
+mvv
+urS
+mvv
+mvv
+mvv
+mvv
+hko
+mvv
+bpD
+fyf
+thG
+lzv
 tFR
 tFR
-tFR
+fyf
+fyf
 fyf
 fyf
 fyf
@@ -96557,28 +99455,28 @@ fyf
 ukl
 pfl
 fyf
+ydq
+xei
+daK
+qCB
+lLL
+qOz
+hvi
+nTP
+gjP
+hxO
+mvv
+hxO
+opZ
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
+lzv
 fyf
 fyf
 fyf
@@ -96813,34 +99711,34 @@ fyf
 fyf
 ukl
 pfl
-fyf
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hLi
+hLi
+gjP
+qOz
+qOz
+qOz
+qOz
+eiJ
+kiQ
+swV
+hxO
+hJg
+hxO
+tcJ
+mvv
+gjP
+rsl
+gjP
+gGC
+gjP
+cuQ
+ijg
+wPl
 fyf
 dDr
 fyf
 tuy
-fyf
+hAC
 fyf
 fyf
 fyf
@@ -97070,30 +99968,30 @@ noK
 nJT
 rkr
 pfl
-fyf
-pcG
-qXO
+hLi
+dDC
+gjP
 agA
 atk
 aHN
 qXO
-lqh
-vEw
-qXO
-rTf
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-tFR
-tFR
-tFR
-yeJ
-fLx
+uIT
+sbX
+ijg
+hxO
+mvv
+hxO
+mvv
+hko
+yhL
+wju
+akl
+nTP
+rqC
+wju
+cym
+wPl
+fyf
 fyf
 fyf
 fyf
@@ -97328,29 +100226,29 @@ qvQ
 sgz
 pfl
 hAC
-pcG
-psD
+fyf
+xei
 pbx
-pbx
-psD
-fnB
-psD
-psD
-qXO
-sAe
-pcG
-uNW
+cbK
+oAb
+qOz
+wPe
+iPY
+bRO
+mvv
+mvv
+mvv
 ptI
-awO
+mvv
 uNW
 wju
-nIz
-pcG
-pcG
-pcG
-pcG
-cam
-uaf
+nTP
+nTP
+kiQ
+wju
+kAE
+wPl
+tVV
 ssm
 fyf
 fyf
@@ -97585,33 +100483,33 @@ qvQ
 sgz
 pfl
 fyf
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
+trW
+gjP
+qOz
+qOz
+qOz
+qOz
+izt
 lag
-qXO
-ihA
-tFP
+tUU
+mfD
+mfD
 vfY
-vfY
+mvv
+mvv
 xSc
-xSc
-xSc
-vfY
+wju
+uIT
 nVi
-nTP
-rak
-pcG
-pcG
-pcG
+sbX
+wju
+uge
+wPl
+kGc
 eqo
 noK
 nJT
-uPP
+fyf
 fyf
 fyf
 fyf
@@ -97842,33 +100740,33 @@ qvQ
 sgz
 pWN
 oCi
-pcG
-vjj
+ssm
+gjP
 aUa
-aUa
-aUa
-aUa
-aUa
-lag
+cPd
+aHN
 qXO
-kNf
-pcG
-vpp
-ebC
-tUU
+nTP
+uIT
+gjP
+pEv
+upX
+tBN
+mvv
+mvv
 tUU
 fdO
-aFV
-pcG
-pzL
 nTP
-icB
-hEh
-pcG
+bIe
+lag
+tmo
+tUU
+wPl
+kGc
 bFJ
 unI
 iiC
-tyA
+uPP
 rgZ
 oCi
 yeJ
@@ -98099,33 +100997,33 @@ qvQ
 hOl
 sgz
 koD
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
-lag
-qXO
-sQW
-pcG
+yjE
+xei
+gvp
+gPN
+oAb
+qOz
+pbR
+nTP
+gjP
+fyf
+trW
 wcB
-tSf
-xSC
+mvv
+mvv
 yhL
-yhL
+wju
 xeO
-pcG
+xBK
 mOP
-svp
-pzL
-rFc
-blt
+wju
+qvc
+wPl
+kGc
 gdY
 pBv
 dXy
-sgz
+qJa
 ehN
 koD
 bFJ
@@ -98354,35 +101252,35 @@ pcG
 ajD
 qvQ
 ehN
-uit
-iYF
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
-lag
-qXO
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
+hOl
+koD
+dMW
+gjP
+qOz
+qOz
+qOz
+qOz
+pbR
 nTP
-spG
+gbh
+uey
+fyf
+tBN
+mvv
+mvv
+uNW
+wju
+rqC
+rqC
 nTP
-hEh
-blt
+wju
+knV
+wPl
+doh
 uaf
 ajD
 lSD
-ehN
+sgz
 ehN
 koD
 gdY
@@ -98613,29 +101511,29 @@ qvQ
 ehN
 hOl
 wwM
-pcG
-xei
-aUa
-aUa
-aUa
-aUa
-aUa
-pbx
-qER
-pcG
-tHN
-kBd
-pcG
-uAp
-qRy
-oNC
+dMW
+gjP
+srZ
+rYE
+bxG
+qXO
+dyS
+dyS
+gjP
+fyf
+qTY
+tBN
+mvv
+mvv
+xSc
+wju
 mKr
-pcG
-nTP
-sdI
-nTP
-qoN
-pcG
+arR
+pry
+wju
+uge
+wPl
+doh
 uaf
 jIB
 qvQ
@@ -98870,28 +101768,28 @@ qvQ
 ehN
 hOl
 koD
-pcG
+dMW
 xei
-aUa
-aUa
-aUa
-aUa
-aUa
+vRp
+uVw
+xOk
+qOz
+yha
 bkc
-ihA
-sTn
-xDL
-tJl
-ntz
-pJd
-aku
-pei
-aku
-leq
-txC
-spG
-pzL
-pzL
+gjP
+trW
+iGM
+tBN
+pye
+mvv
+ijg
+gjP
+ijg
+gjP
+gjP
+ijg
+ijg
+wPl
 doh
 cam
 ofX
@@ -99127,29 +102025,29 @@ qvQ
 ehN
 ehN
 koD
-pcG
-xei
-aUa
-aUa
-aUa
-aUa
-aUa
-bkc
-ihA
-pcG
-xDL
-xOt
-pcG
-iTC
-kwL
-hVW
-xVI
-pcG
-bgq
+dMW
+gjP
+qOz
+qOz
+qFk
+qOz
+lER
+rqC
+gzt
+uey
+aIr
+tBN
+mvv
+mvv
+mvv
+mvv
+koD
+cam
+dkg
 jeI
-nTP
-qoN
-pcG
+ttq
+wPl
+dxC
 bFJ
 unI
 qvQ
@@ -99167,7 +102065,7 @@ dcM
 uRJ
 uRJ
 eXA
-eXA
+jGP
 cpH
 uRJ
 uRJ
@@ -99189,8 +102087,8 @@ mvv
 doX
 wDc
 qLa
-ouu
-jNJ
+erp
+cVe
 jNJ
 jNJ
 hGf
@@ -99384,29 +102282,29 @@ qvQ
 ehN
 ehN
 koD
-pcG
-psD
-psD
+dMW
+ijg
+hea
 axw
-pbx
-psD
-psD
-psD
-ihA
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-sdI
-spG
 nTP
-hEh
-blt
+uIT
+dWW
+ozN
+gjP
+hAC
+tMN
+tBN
+mvv
+mvv
+kbF
+mvv
+koD
+wPl
+wPl
+lzv
+wPl
+wPl
+bFJ
 bFJ
 unI
 qvQ
@@ -99422,7 +102320,7 @@ uaf
 srw
 dyt
 uRJ
-eXA
+jGP
 eXA
 gvh
 uRJ
@@ -99436,17 +102334,17 @@ srw
 aSd
 cbr
 cbr
-cbr
-wOp
-cbr
-cbr
-lBS
+mvv
+rjH
+mvv
+psw
+mvv
 mvv
 mvv
 npG
 hCg
 nsK
-uVG
+nYa
 qrB
 tXb
 tPD
@@ -99641,29 +102539,29 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-pcG
-pcG
-pcG
-pcG
-qXO
-qXO
-qXO
-ihA
-tbX
-pcG
+dMW
+vjR
+opA
+aFY
+nTP
+vRQ
+uWx
+nTP
+gjP
+fyf
+fyf
 tLE
 dJn
-tLE
-dJn
-dJn
-jpB
-pcG
-xDP
-pzL
-svp
-rFc
-blt
+uTE
+mvv
+mvv
+koD
+wPl
+dkg
+dkg
+qGZ
+trd
+dkg
 bFJ
 unI
 qvQ
@@ -99693,8 +102591,8 @@ gjP
 tXS
 kUA
 cbr
-wOp
-cbr
+rjH
+mvv
 kWW
 kVv
 mvv
@@ -99898,29 +102796,29 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-uZS
-aku
+dMW
+auk
+upn
 aFY
-pcG
+dyS
 uzN
 ngr
-qXO
-ihA
+iPY
+pgQ
 ten
-pcG
-eQq
+fyf
+tBN
 tcJ
-enp
-enp
-enp
-ejp
-pcG
-pzL
-pzL
+mvv
+mvv
+mvv
+koD
+wPl
+uaf
+qGZ
 hoe
-hEh
-pcG
+kdJ
+dkg
 gdY
 neP
 qvQ
@@ -99950,9 +102848,9 @@ srw
 tXS
 hRN
 cbr
-cbr
-koZ
-cbr
+mvv
+bGM
+mvv
 gDn
 mvv
 mvv
@@ -100155,29 +103053,29 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-uZS
-snR
-aku
-bbW
-ihA
-ihA
-qXO
-qXO
-ihA
-tOt
-tgR
-wMU
-wMU
-wMU
-tgR
-tgR
-nVi
-nTP
-qoN
-pcG
-pcG
-pcG
+dMW
+fyf
+auk
+upn
+sbX
+ist
+kkO
+dyS
+gjP
+jBp
+trW
+tBN
+mvv
+mvv
+mvv
+mvv
+koD
+wPl
+dkg
+nPX
+tVV
+lae
+dkg
 uaf
 pBv
 box
@@ -100207,11 +103105,11 @@ srw
 tXS
 kiH
 cbr
-cbr
-cbr
+mvv
+mvv
 lbJ
 gDs
-mvv
+aLd
 mvv
 pIn
 bpD
@@ -100412,29 +103310,29 @@ qvQ
 ehN
 ehN
 koD
-pcG
-uZS
-wDW
-jxD
-pcG
-ihA
-onh
-gsB
-onh
-ihA
-pcG
-ira
+dMW
+fyf
+fyf
+auk
+ijg
+gjP
+gjP
+ijg
+gjP
+doX
+cWG
+daU
 hko
-fas
-hko
-jiv
-guU
-pcG
-pcG
-pcG
-pcG
-mmT
-kgn
+mvv
+mvv
+mvv
+koD
+uaf
+uaf
+eme
+lae
+bFJ
+dkg
 rVv
 sbt
 lSD
@@ -100464,11 +103362,11 @@ gjP
 bkF
 cDL
 cbr
-wOp
-wOp
+rjH
+rjH
 cbr
 mZn
-mvv
+jIz
 mvv
 mvv
 lBY
@@ -100669,29 +103567,29 @@ qvQ
 ehN
 ehN
 bfu
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-rVv
-rVv
-rVv
-rVv
-rVv
+jkJ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+daU
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+koD
+uaf
+uaf
+uaf
+bFJ
+bFJ
+cam
 uaf
 jIB
 qvQ
@@ -100724,8 +103622,8 @@ dZS
 dZS
 cbr
 cbr
-cbr
-mvv
+hfw
+jIz
 mvv
 mvv
 bpD
@@ -100739,10 +103637,10 @@ bpD
 fyf
 fyf
 fyf
-ouu
-jNJ
-jNJ
-hGf
+erp
+ubl
+ubl
+rWe
 fyf
 tBN
 qSl
@@ -100942,7 +103840,7 @@ ybI
 ybI
 ybI
 ybI
-dkP
+fLc
 hLv
 sTa
 hkW
@@ -100981,8 +103879,8 @@ btv
 btv
 btv
 mlD
-rpu
-pBM
+iUw
+rDi
 mvv
 mvv
 doX
@@ -100996,10 +103894,10 @@ bpD
 bGO
 hAC
 fyf
-pKt
+tXS
 tvl
 rfr
-iGZ
+fIE
 fyf
 tBN
 vqx
@@ -101253,10 +104151,10 @@ bpD
 uey
 fyf
 fyf
-pKt
+tXS
 kNm
 hRN
-pKt
+asz
 fyf
 tBN
 wQS
@@ -101466,8 +104364,8 @@ ehN
 ehN
 ehN
 ehN
-hfV
 ehN
+wLm
 ehN
 vHw
 ehN
@@ -101510,10 +104408,10 @@ bpD
 fyf
 sqA
 qsu
-pKt
+tXS
 rrj
 wTy
-pKt
+asz
 fyf
 tBN
 xOr
@@ -101767,10 +104665,10 @@ bpD
 fyf
 fyf
 fyf
-deJ
+tOi
 ruw
-ruw
-fAM
+lYZ
+plB
 fyf
 tBN
 iuD
@@ -102069,7 +104967,7 @@ cpK
 sYX
 sYX
 uCO
-viv
+uCO
 uCO
 uCO
 nfp
@@ -102324,7 +105222,7 @@ rtZ
 rtZ
 cpK
 cpK
-vAu
+pAm
 uTA
 vno
 wLR
@@ -102527,7 +105425,7 @@ pKt
 bWe
 vqb
 pKt
-mfD
+aBH
 mfD
 mfD
 mfD
@@ -102581,12 +105479,12 @@ kEh
 kEh
 kEh
 kEh
-vAu
-uZg
-vvh
-wRI
-xeG
-ydq
+pAm
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -102780,11 +105678,11 @@ mGP
 aip
 kMn
 qSl
-deJ
-ruw
-ruw
-fAM
-fyf
+qax
+uxf
+uxf
+iML
+hCg
 fyf
 sqA
 fyf
@@ -102792,8 +105690,8 @@ jcp
 fyf
 tBN
 mvv
-ppv
-mvv
+ulN
+daU
 doX
 daU
 bpD
@@ -102838,24 +105736,24 @@ gts
 gts
 gts
 gts
-vAu
-vAu
-wxi
-mwp
-mwp
-mwp
-xny
-fNs
-gcK
-xny
+pAm
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -103037,7 +105935,7 @@ mvv
 jmn
 tAe
 aBH
-fyf
+hCg
 fyf
 fyf
 fyf
@@ -103097,14 +105995,14 @@ fAr
 gts
 gcK
 gcK
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-ylQ
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -103355,21 +106253,21 @@ gts
 gcK
 gcK
 gcK
-xdG
-mwp
-mwp
-veZ
-mwp
-mwp
-mwp
-mwp
-xdG
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gbL
@@ -103565,8 +106463,8 @@ fyf
 uuj
 tBN
 mvv
-bpD
-rDi
+doX
+hOM
 cWG
 cWG
 daU
@@ -103610,22 +106508,22 @@ rpe
 rob
 gts
 gcK
-gbL
-gbL
-gbL
-aVn
-mwp
-mdv
-mwp
-mwp
-mwp
-aVn
-mdv
-mwp
-mwp
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -103813,11 +106711,11 @@ jvg
 bad
 kPO
 uCO
-cWG
-daU
-mvv
-aBH
-hCg
+wUL
+uHF
+cbr
+xzV
+cQC
 uey
 fyf
 iHk
@@ -103833,10 +106731,10 @@ nlO
 mfD
 xGH
 mvv
-jaa
-jaa
-jaa
-jaa
+mvv
+mvv
+mvv
+mvv
 mvv
 mvv
 fZD
@@ -103868,21 +106766,21 @@ gts
 gts
 gcK
 gcK
-gbL
-gbL
-xdG
-ylQ
-mwp
-mwp
-mwp
 gcK
 gcK
-mwp
-mwp
-mwp
-aVn
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104069,19 +106967,19 @@ sYX
 sYX
 jWd
 dhC
-mvv
-dCL
-mfD
-mfD
-hCg
-fyf
+cbr
+oza
+mnh
+mnh
+xKi
+fsV
 pvp
-ouu
+erp
+cVe
 jNJ
 jNJ
-jNJ
-hGf
-wjS
+bgY
+ksP
 sXB
 mvv
 bpD
@@ -104089,12 +106987,12 @@ fyf
 fyf
 fyf
 tBN
-bpD
-fyf
-fyf
-fyf
-qOV
-qax
+aBH
+mfD
+mfD
+mfD
+xGH
+scP
 jIR
 mvv
 dKW
@@ -104127,7 +107025,6 @@ gcK
 gcK
 gcK
 gcK
-xny
 gcK
 gcK
 gcK
@@ -104136,11 +107033,12 @@ gcK
 gcK
 gcK
 gcK
-mwp
-mwp
-dcS
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gbL
@@ -104222,7 +107120,7 @@ gcK
 ktB
 fyf
 fyf
-fyf
+qTY
 fyf
 tBN
 mvv
@@ -104320,37 +107218,37 @@ thG
 fyf
 sYX
 dhC
-gCU
+bRF
 uCO
 uCO
 uCO
 jWz
-mvv
-mvv
+cbr
+cbr
 mcf
-sih
+qUt
+fsV
+fsV
+uNH
 fyf
-fyf
-qTY
-fyf
-uVG
+qJy
 jFc
 suQ
 cbr
-pKt
+asz
 nlO
 xGH
 ouu
-jNJ
-jNJ
-hGf
+emg
+ubl
+rWe
 fyf
 tBN
 dCX
 cWG
-wDc
-fyf
-hfw
+cWG
+cWG
+daU
 scP
 mvv
 pgM
@@ -104387,16 +107285,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-xSs
-xSs
-xSs
 gcK
 gcK
-xny
-mwp
-mdv
-xdG
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104459,11 +107357,11 @@ uXj
 uXj
 uXj
 uXj
-hwC
-hwC
-hwC
-hwC
-kNT
+gcK
+gcK
+gcK
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -104585,24 +107483,24 @@ uCO
 sDp
 uCO
 sYX
-fyf
-tFR
+fsV
+apf
 sYX
 sYX
 fyf
-kSZ
+qBa
 mjf
 cbr
 uNL
-pKt
+asz
 fyf
-fyf
+tBN
 pKt
 fAn
 oOd
-pKt
+asz
 fyf
-bRF
+wjS
 ouu
 jNJ
 jNJ
@@ -104643,16 +107541,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-sQL
-qMt
-qIS
-cIR
-xSs
 gcK
 gcK
-hNC
-gDL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104706,13 +107604,13 @@ uXj
 uXj
 uXj
 uXj
-mvv
-pye
-mvv
-gQy
-mvv
-mvv
-mvv
+sYX
+uqa
+awO
+gxW
+bbW
+uqa
+gCh
 xYS
 uXj
 uXj
@@ -104720,7 +107618,7 @@ uXj
 uXj
 uXj
 uXj
-hwC
+gcK
 gcK
 gcK
 gcK
@@ -104847,19 +107745,19 @@ rpu
 odb
 kGD
 fyf
-uVG
+qJy
 cbr
 hRN
 pqB
-pKt
+asz
 fyf
-fyf
+tBN
 pKt
 hRN
 lsT
-iGZ
+fIE
 fyf
-fyf
+tBN
 pKt
 sao
 cbr
@@ -104900,16 +107798,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-xSs
-xSs
-xSs
-hGm
-xSs
 gcK
-gtU
-gDL
-iAU
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104963,13 +107861,13 @@ mvv
 pye
 mvv
 pye
-sYX
 uqa
-grc
-gxW
+rpu
+rpu
+aVn
 hnU
+dCU
 uqa
-gCh
 iCH
 mvv
 xYS
@@ -105108,15 +108006,15 @@ tTK
 vqb
 wTy
 oOd
-pKt
+asz
 fyf
-tdv
+sij
 pKt
 tWd
 vej
-pKt
+asz
 fyf
-uey
+tBN
 pKt
 hRN
 lsT
@@ -105157,16 +108055,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-ngw
-nes
-lXu
-cRc
-ega
-giU
-gDL
-imR
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105223,8 +108121,8 @@ fcI
 fsN
 djI
 gtn
-gSx
-hoH
+rpu
+rpu
 hxt
 qdS
 iDN
@@ -105361,19 +108259,19 @@ rpu
 jOH
 jvg
 fyf
-uVG
+qJy
 duF
 iQP
 sXx
-iGZ
+fIE
 fyf
-fyf
-deJ
-ruw
-ruw
-fAM
+nlO
+hov
+uxf
+uxf
+plB
 ayR
-fyf
+tBN
 pKt
 aQq
 vqb
@@ -105410,19 +108308,19 @@ dqf
 sgz
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
-xSs
-mlf
-ccN
-nes
-dmg
-xSs
-jay
-gDL
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105620,21 +108518,21 @@ sYX
 fyf
 mZl
 oSA
-vqb
-fAn
-pKt
+ifp
+oIz
+lhO
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-deJ
-ruw
-ruw
-fAM
+gSt
+hgX
+kRr
+gye
+gye
+pap
 jaa
 jaa
 jaa
@@ -105669,16 +108567,16 @@ gcK
 gcK
 gcK
 gcK
-gbL
 gcK
-xSs
-iXC
-wcO
-ccN
-oAe
-xSs
-hIi
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105875,18 +108773,18 @@ igz
 igz
 igz
 igz
-deJ
-ruw
-ruw
-ruw
-fAM
+sWs
+cPL
+cPL
+bNp
+rsO
 fyf
 fyf
 lob
 fyf
 fyf
-fyf
-rkr
+tVV
+lae
 dkg
 dkg
 uaf
@@ -105924,15 +108822,15 @@ kin
 wNe
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
 gcK
-xSs
-goj
-bcF
-xSs
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -106135,14 +109033,14 @@ ybI
 ybI
 ybI
 ybI
-pfl
+rRR
 fyf
 fyf
 ayR
 fyf
 fyf
 fyf
-fyf
+wIK
 jps
 jps
 sTa
@@ -106658,8 +109556,8 @@ fyf
 qTY
 hCs
 wKo
-snB
-ehN
+hOl
+hOl
 ehN
 ehN
 ehN
@@ -106915,7 +109813,7 @@ fyf
 fyf
 fyf
 ukl
-vMU
+hOl
 vMU
 kaM
 kaM
@@ -107412,7 +110310,7 @@ ptf
 ptf
 ptf
 ptf
-eCM
+ptf
 ptf
 ptf
 ptf
@@ -107420,16 +110318,16 @@ ptf
 ptf
 gNA
 wVn
-pWN
+eme
+plq
 plq
 uPP
-fyf
 fyf
 fyf
 mKI
 rkr
 pRy
-pKq
+koD
 gts
 rlf
 hXC
@@ -107678,14 +110576,14 @@ fyf
 kGc
 uCW
 pFM
+dXy
 gWo
 mmH
-xaE
 cax
 rkr
 cdp
 mHW
-ehN
+pTC
 koD
 gts
 uKY
@@ -107826,10 +110724,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
@@ -107935,14 +110833,14 @@ fyf
 kGc
 uCW
 ajD
+dXy
 pWN
 plq
-plq
 rkr
+hOl
+hOl
+hOl
 pTC
-snB
-ehN
-ehN
 koD
 gts
 uKY
@@ -108082,13 +110980,13 @@ oES
 gcK
 gcK
 gcK
-gcK
-gcK
+oAe
+dfR
 gcK
 gcK
 gcK
 jHQ
-tZh
+gcK
 tii
 pfK
 iHu
@@ -108192,14 +111090,14 @@ igz
 hgX
 cpK
 unI
-qvQ
-ehN
+dXy
+hOl
 tPy
 mHW
-ehN
-rbi
-ehN
-ehN
+hOl
+qfm
+hOl
+pTC
 koD
 gts
 oKi
@@ -108336,16 +111234,16 @@ mvv
 mvv
 odZ
 mvv
-ayd
-gcK
-gcK
-mTd
-mTd
-mvv
 mvv
 mvv
 lFX
-pcV
+paa
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 fzN
 bGM
 mvv
@@ -108449,14 +111347,14 @@ cpK
 cpK
 wVn
 unI
-qvQ
+rQh
+hOl
+mHW
+hOl
+hOl
 ehN
-ehN
-ehN
-ehN
-ehN
-ehN
-ehN
+hOl
+pTC
 koD
 gts
 arT
@@ -108595,14 +111493,14 @@ mvv
 mvv
 mvv
 mvv
-mvv
-fzN
+lFX
+oAB
 mvv
 mvv
 odZ
 mvv
-lFX
-tnu
+mvv
+mvv
 mvv
 mvv
 mvv
@@ -108708,12 +111606,12 @@ cpK
 unI
 qvQ
 ehN
+vMU
 ehN
-ehN
-ehN
-ehN
-ehN
-ehN
+hOl
+hOl
+hOl
+pTC
 koD
 gts
 pod
@@ -108853,13 +111751,13 @@ mvv
 mvv
 mvv
 mvv
-mvv
+oDo
 mvv
 bGM
 mvv
 mvv
 mvv
-pcb
+mvv
 mvv
 mvv
 mvv
@@ -108965,12 +111863,12 @@ uCW
 unI
 qvQ
 iWm
-ehN
-ehN
-iWm
-ehN
+vMU
+hOl
+xVU
+hOl
 rbe
-ehN
+pTC
 koD
 gts
 coz
@@ -109105,18 +112003,18 @@ gcK
 gcK
 mTd
 mTd
-gcK
-bGM
-mvv
-oNR
-odZ
-mvv
-mvv
-mvv
 mvv
 bGM
-lFX
-gnk
+mvv
+mvv
+mlf
+oGX
+mvv
+mvv
+mvv
+bGM
+mvv
+mvv
 mvv
 mvv
 mvv
@@ -109222,12 +112120,12 @@ uCW
 unI
 qvQ
 ehN
+hOl
 ehN
 ehN
 ehN
-ehN
-ehN
-ehN
+hOl
+pTC
 koD
 gts
 vYv
@@ -109360,20 +112258,20 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-ayd
-paa
-gcK
-uPK
+dmg
+dmg
+dmg
+hfV
 mvv
-mvv
+jCH
 lFX
-pcV
+paa
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 iwR
 mvv
 iHu
@@ -109484,7 +112382,7 @@ ehN
 pKj
 ehN
 ehN
-ehN
+gmX
 koD
 gts
 ulf
@@ -109610,27 +112508,27 @@ cfD
 mBg
 xYS
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
+ktB
 gcK
+cQs
+enp
+enp
+dmg
+ira
+kgn
+mmT
+oNs
+qin
+ega
+dmg
+uqa
+xab
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-oKE
-jHQ
 waA
 gcK
 hNo
@@ -109741,7 +112639,7 @@ ehN
 ehN
 ehN
 ehN
-ehN
+gmX
 koD
 gts
 mSD
@@ -109867,26 +112765,26 @@ may
 qvX
 xYS
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+cQs
+eQq
+ydO
+lDx
+wLC
+koZ
+mPT
+hoz
+rTQ
+nan
+rTQ
+viv
+xdG
 gcK
 ktB
 gcK
@@ -109998,7 +112896,7 @@ kaM
 kaM
 kaM
 ehN
-ehN
+gmX
 koD
 gts
 tVJ
@@ -110125,25 +113023,25 @@ mcp
 uXj
 uXj
 uXj
-uXj
+cwO
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+cQs
+fas
+ydO
+xDP
+wLC
+koZ
+mTy
+wLC
+rTQ
+sYX
+txC
+vpp
+xeG
 gcK
 ktB
 gcK
@@ -110255,7 +113153,7 @@ ees
 ees
 muk
 qvQ
-ehN
+gmX
 koD
 gts
 vZm
@@ -110382,26 +113280,26 @@ uXj
 uXj
 uXj
 uXj
-lRJ
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+bTk
 gcK
 gcK
 gcK
 ktB
+gcK
+ebC
+fnB
+ydO
+hoH
+rTQ
+kwA
+ydO
+oNR
+rTQ
+rTf
+fGp
+vvh
+xny
+gcK
 gcK
 gcK
 mTd
@@ -110512,7 +113410,7 @@ cpK
 qnE
 unI
 qvQ
-ehN
+gmX
 koD
 ljG
 dhC
@@ -110639,26 +113537,26 @@ uXj
 uXj
 uXj
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+ega
+dmg
+gnk
+kih
+uCO
+kwL
+uCO
+oSz
+qin
+taV
+tyA
+vAu
+xql
+sYX
 gcK
 gcK
 gcK
@@ -110769,7 +113667,7 @@ qnE
 qnE
 unI
 qvQ
-ehN
+gmX
 koD
 gts
 gts
@@ -110899,23 +113797,23 @@ uXj
 uXj
 tQt
 tQt
-tQt
-osF
-ouJ
-ouJ
-oDo
-mTd
-mTd
+oFp
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+goj
+hCp
+iAU
+kBd
+nes
+pcb
+pcV
+uCO
+tFP
+vEw
+ydO
+taV
 gcK
 gcK
 gcK
@@ -111026,7 +113924,7 @@ pyJ
 qnE
 unI
 qvQ
-ehN
+gmX
 koD
 cpK
 cpK
@@ -111145,9 +114043,9 @@ stD
 stD
 mvv
 mvv
-mvv
-mvv
-mvv
+qTe
+qTe
+qTe
 mvv
 mqp
 mzO
@@ -111157,26 +114055,26 @@ mBh
 mBh
 mBh
 mBh
-uXj
-uXj
-jxS
-uXj
-tQt
-oFp
-ayd
+cIR
+cRc
+cRc
+fLx
+grc
+hEh
+iTC
+kNT
+gGz
+mMu
+gGz
+uCO
+tHN
+wcO
+wLC
+sYX
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-fyf
+tNX
 giS
 kGc
 pxw
@@ -111417,24 +114315,24 @@ okS
 uXj
 uXj
 jxS
-uXj
-uXj
-uXj
+qnz
+gsB
+hGm
 oMn
-mTd
+leq
+ngw
+cTd
+cTd
+snR
+ydO
+wLC
+wLC
+xSs
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
+ptP
 fyf
-tNX
 kGc
 pxw
 pOC
@@ -111659,9 +114557,9 @@ fff
 mvv
 mvv
 stD
-mvv
-mvv
-mvv
+qTe
+qTe
+qTe
 mvv
 dCL
 hCg
@@ -111673,20 +114571,20 @@ oav
 bEr
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-tQt
-cwO
-ayd
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+jxS
+qnz
+gtU
+hIi
+iXC
+uCO
+ntz
+cTd
+mMu
+sAe
+tJl
+wxi
+rTQ
+cQs
 gcK
 gcK
 gcK
@@ -111931,19 +114829,19 @@ nId
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-cwO
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+qnz
+guU
+hNC
+jay
+jWy
+nJr
+mMu
+qoN
+sQL
+tOt
+uCO
+qin
+cQC
 gcK
 gcK
 gcK
@@ -112017,8 +114915,8 @@ eRT
 iQs
 rBs
 eeO
-aRl
-aSc
+pFP
+hAw
 vBw
 daB
 etB
@@ -112188,19 +115086,19 @@ uiy
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-wLF
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+qnz
+guU
+hVW
+oMC
+lBS
+cTd
+mMu
+qER
+sQW
+tSf
+wDW
+ydO
+uqa
 gcK
 gcK
 gcK
@@ -112262,7 +115160,7 @@ ofX
 qvQ
 ehN
 ehN
-koD
+qEb
 pLw
 gcK
 uqa
@@ -112272,10 +115170,10 @@ uqa
 gts
 xVT
 aRl
+gGz
 aRl
+hJb
 aRl
-csQ
-ryT
 aRl
 cYL
 eDy
@@ -112445,19 +115343,19 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-jxS
-xab
-oSz
-gcK
-gcK
-gcK
-gcK
-ktB
+qnz
+gDL
+oFK
+jel
+lXu
+aRl
+gGz
+vZr
+sTn
+tTV
+wDW
+wLC
+ftg
 gcK
 gcK
 gcK
@@ -112521,7 +115419,7 @@ ehN
 ehN
 koD
 pLw
-pLw
+vyX
 uqa
 eBc
 otI
@@ -112529,9 +115427,9 @@ uqa
 gts
 xyX
 daB
-aRl
+gGz
 tKk
-aRl
+gGz
 aRl
 aRl
 qsD
@@ -112702,19 +115600,19 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-jxS
+qnz
+gQy
+imR
+jiv
+mdv
+onh
 xAB
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+vZr
+sQW
+tZh
+wDW
+xDL
+ffL
 gcK
 gcK
 wET
@@ -112777,8 +115675,8 @@ qvQ
 ehN
 ehN
 koD
-fug
-giZ
+nIp
+lds
 uqa
 aRl
 nTa
@@ -112959,19 +115857,19 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-jSN
-oNs
-ayd
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+qnz
+gDL
+hNC
+jpB
+jWy
+cTd
+aRl
+qIS
+tbX
+uAp
+wLF
+qin
+xSC
 gcK
 gcK
 hAC
@@ -113034,8 +115932,8 @@ qvQ
 twq
 ehN
 koD
-dMW
-giZ
+nIp
+lds
 uqa
 itJ
 uqa
@@ -113208,9 +116106,7 @@ gcK
 gcK
 gcK
 gcK
-aip
-uXj
-nJr
+bcF
 uXj
 uXj
 uXj
@@ -113218,17 +116114,19 @@ uXj
 uXj
 uXj
 uXj
-uXj
+qnz
+gSx
+ipE
 oMC
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+hol
+mMu
+aRl
+qMt
+tgR
+uPK
+wMU
+heY
+cQC
 gcK
 gcK
 wPz
@@ -113291,8 +116189,8 @@ qvQ
 ehN
 ehN
 koD
-dMW
-giZ
+nIp
+lds
 aND
 cpK
 cpK
@@ -113465,27 +116363,27 @@ gcK
 gcK
 gcK
 gcK
-ieV
-jSN
+bgq
+ccN
 nLj
 uXj
 uXj
 uXj
 uXj
 uXj
-uXj
-uXj
+qnz
+gDL
 oFK
-lGH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+jxD
+lBS
+aRl
+xUM
+qMt
+tgR
+uZg
+ozB
+uZS
+cQC
 gcK
 gcK
 fyf
@@ -113548,7 +116446,7 @@ voF
 ehN
 ehN
 koD
-dMW
+nIp
 giZ
 nPg
 ybI
@@ -113727,22 +116625,22 @@ gcK
 gcK
 ieV
 qzI
-jSN
-ovt
 uXj
 uXj
 uXj
-uXj
+qnz
+ega
+dmg
 oNf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
+gCh
+osF
+mMu
+qMt
+tnu
+uZS
+heY
+uZg
+xVI
 gcK
 gcK
 hAC
@@ -113964,42 +116862,42 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ayd
-oAB
-jxS
-uXj
-nJr
-oNf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ieV
+dcS
+uXj
+qnz
+gcK
+gcK
+gcK
+mfR
+ouJ
+pei
+qMt
+tgR
+veZ
+wRI
+xOt
+uqa
 gcK
 gcK
 fyf
@@ -114062,7 +116960,7 @@ qvQ
 ehN
 ehN
 wwM
-aeZ
+oHK
 giZ
 emn
 qnS
@@ -114218,45 +117116,45 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-nLj
-jSN
-qzI
-lGH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ayd
+ejp
+fNs
+gcK
+gcK
+gcK
+gcK
+ovt
+cQC
+rFc
+hrU
+cQC
+uqa
+uqa
+uqa
 gcK
 dDC
 fyf
@@ -114319,7 +117217,7 @@ qvQ
 ehN
 ehN
 ldy
-ttq
+oHK
 oHK
 emn
 dXy
@@ -114477,6 +117375,9 @@ gcK
 gcK
 gcK
 gcK
+ktB
+gcK
+ktB
 gcK
 gcK
 gcK
@@ -114497,12 +117398,9 @@ gcK
 gcK
 gcK
 gcK
+ieV
+giU
 gcK
-gcK
-gcK
-gcK
-mTd
-mTd
 gcK
 gcK
 gcK
@@ -114730,6 +117628,7 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -114757,8 +117656,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+mTd
 gcK
 gcK
 gcK
@@ -114989,10 +117887,10 @@ gcK
 gcK
 gcK
 gcK
+ktB
 gcK
 gcK
-gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -115280,8 +118178,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -115503,41 +118401,41 @@ gcK
 gcK
 gcK
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gcK
 gcK
 ktB
 ktB
+ktB
+ktB
+ktB
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -115604,8 +118502,8 @@ qvQ
 ehN
 ehN
 wwM
-lWj
-wwW
+oHK
+oHK
 wDc
 fyf
 tCU
@@ -115755,6 +118653,21 @@ ggK
 gcK
 gcK
 gcK
+gcK
+ktB
+ktB
+ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+ktB
+ktB
+ktB
+ktB
 ktB
 ktB
 ktB
@@ -115766,29 +118679,14 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 ktB
 ktB
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 ktB
 ktB
 ktB
@@ -115800,7 +118698,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+xTK
 fyf
 fyf
 fyf
@@ -115861,7 +118759,7 @@ qvQ
 ehN
 ehN
 koD
-aeZ
+oHK
 giZ
 doX
 wDc
@@ -116044,8 +118942,6 @@ gcK
 ktB
 ktB
 ktB
-ktB
-ktB
 gcK
 gcK
 gcK
@@ -116056,7 +118952,9 @@ gcK
 gcK
 gcK
 gcK
-fyf
+gcK
+gcK
+ftz
 uey
 fyf
 qTY
@@ -116375,7 +119273,7 @@ qvQ
 gnv
 ehN
 kqx
-dMW
+nIp
 giZ
 qda
 mvv
@@ -116632,8 +119530,8 @@ qvQ
 ehN
 ehN
 koD
-dMW
-giZ
+nIp
+lds
 bqy
 rjH
 rjH
@@ -116889,8 +119787,8 @@ oIg
 ehN
 ehN
 koD
-dMW
-giZ
+nIp
+lds
 ttW
 rjH
 rjH
@@ -117147,7 +120045,7 @@ ehN
 ehN
 koD
 fug
-giZ
+lds
 biP
 rjH
 rjH
@@ -117403,12 +120301,12 @@ qvQ
 rbi
 ehN
 rYS
-aeZ
+oHK
 giZ
 giZ
 giZ
-giZ
-giZ
+lds
+lds
 giZ
 pJT
 hOl
@@ -117660,12 +120558,12 @@ qvQ
 ehN
 ehN
 fOu
-jkJ
-igz
-igz
-igz
-igz
-igz
+nIp
+nIp
+nIp
+nIp
+nIp
+nIp
 giZ
 cLG
 wto
@@ -119036,8 +121934,8 @@ hom
 wXo
 hom
 mtK
-jEp
-jEp
+fTt
+fTt
 czT
 vSL
 mvv

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -10730,6 +10730,7 @@
 	},
 /obj/effect/decal/waste{
 	icon_state = "goo8";
+	tag = "icon-goo8"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
@@ -15117,6 +15118,7 @@
 "ilx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8";
+	tag = "icon-goo8"
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -26905,7 +26907,6 @@
 "pOB" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pOI" = (
@@ -34085,6 +34086,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"udk" = (
+/obj/structure/nest/deathclaw{
+	radius = 5
+	},
+/obj/item/clothing/suit/armor/f13/ghostechoe,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uef" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/structure/spider/stickyweb,
@@ -39674,11 +39682,11 @@
 /area/f13/brotherhood/mining)
 "xCI" = (
 /obj/structure/table,
+/obj/effect/decal/cleanable/glass,
 /obj/item/weldingtool/experimental{
 	pixel_x = -27;
 	pixel_y = 2
 	},
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "xDj" = (
@@ -44006,7 +44014,7 @@ rDS
 xVz
 oDr
 xVz
-iAy
+udk
 xVz
 xVz
 aoj


### PR DESCRIPTION
## Screenshots
![grafik](https://user-images.githubusercontent.com/69112131/165850682-e4c2b80e-6d99-4f5f-b58a-3a261642f357.png)
![grafik](https://user-images.githubusercontent.com/69112131/165850895-6636ad51-83b5-404d-a9a9-e8ac1350fd74.png)


## About The Pull Request
Adds a little bar to the Khan Khamp to sell drugs in.Re-adds dungeons that were previously removed and adds three new additional places for the second Z-level. Also fixes the blending and second Z-Level on the map PR that added tents.

## Why It's Good For The Game
Fun little expansion on RP for the Khans and a bit more to do for avid dungeon crawlers.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
add: overgrown vault bunker / raider bunker
add: Khan bar
/:cl:
