### PR TITLE
Khan bar 

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1,4 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aaS" = (
+/obj/structure/sink,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"aaU" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "abc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12,16 +25,48 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"abi" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "abo" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "abq" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"acr" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"acB" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"acL" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "acN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
@@ -34,14 +79,56 @@
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/water,
 /area/f13/bunker)
+"aeb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "aes" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
+"aeB" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"afn" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "afS" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/underground/cave)
+"agR" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"ahc" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"ahl" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "ahC" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -56,6 +143,20 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ahS" = (
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"aic" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/goonplaque{
+	desc = "This is a plaque detailing and honoring the corporate dollars lost creating the vault. All craftsmanship is of the highest quality. The Business men are laughing. The Workers are crying. It menaces with spikes of gold."
+	},
+/area/f13/bunker)
 "aiq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
@@ -71,6 +172,11 @@
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"aiw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "aiS" = (
 /obj/item/candle/tribal_torch,
@@ -93,6 +199,14 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ajM" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/water,
+/area/f13/bunker)
 "akd" = (
 /obj/machinery/light/floor,
 /turf/open/floor/f13/wood{
@@ -107,6 +221,15 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"akr" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "akA" = (
 /obj/machinery/status_display{
 	desc = "A large glass display, used to show various types of information.";
@@ -125,6 +248,20 @@
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"all" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"alR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "aml" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -138,6 +275,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"amH" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "anh" = (
 /obj/item/rack_parts,
 /obj/effect/decal/cleanable/dirt,
@@ -152,19 +297,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "anj" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	},
-/area/f13/wasteland)
-"anu" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt{
+/obj/machinery/biogenerator,
+/obj/machinery/light{
 	dir = 1;
-	icon_state = "dirt"
+	light_color = "#706891"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"anu" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"anv" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "any" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -187,6 +344,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"aoN" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"aoW" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "apb" = (
 /obj/machinery/status_display{
 	desc = "A large glass display, used to show various types of information.";
@@ -205,6 +375,11 @@
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"aqw" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "aqU" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -218,7 +393,7 @@
 /area/f13/underground/cave)
 "arv" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 9;
+	dir = 9
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -230,6 +405,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"asb" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "asW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -244,6 +425,11 @@
 "ato" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
+"ats" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/scorpion,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "atI" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -270,6 +456,10 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
+"auP" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "avu" = (
 /obj/item/candle/tribal_torch,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
@@ -330,6 +520,54 @@
 /obj/item/gun/ballistic/automatic/smg/greasegun,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"ayK" = (
+/obj/structure/barricade/wooden/strong,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"aze" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"azk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "azm" = (
 /obj/structure/sign/poster/prewar/vault_tec,
 /turf/closed/indestructible/vaultdoor,
@@ -338,6 +576,16 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"azB" = (
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "azF" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
@@ -347,9 +595,27 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/dark,
 /area/f13/ncr)
+"aAk" = (
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"aAz" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aAP" = (
 /obj/structure/debris/v3,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"aBf" = (
+/obj/structure/flora/junglebush/b,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "aBE" = (
 /obj/structure/chair/office/dark{
@@ -359,6 +625,12 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"aCI" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "aDh" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/f13/wood{
@@ -369,6 +641,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aDF" = (
+/obj/structure/table/optable,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "aEf" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/desert,
@@ -378,11 +657,30 @@
 /obj/structure/debris/v3,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"aEW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"aGh" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/structure/mirelurkegg,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/bunker)
 "aGr" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "aGL" = (
@@ -391,6 +689,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aGV" = (
+/obj/structure/table/reinforced,
+/obj/item/electropack/shockcollar/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "aHp" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -399,10 +705,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aIq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"aIr" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "aIt" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"aIO" = (
+/obj/structure/window/reinforced/spawner,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "aIQ" = (
 /obj/structure/window/plastitanium{
@@ -469,6 +794,26 @@
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"aLY" = (
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"aLZ" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/human/core,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "aMa" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_t,
@@ -486,6 +831,21 @@
 /obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"aNo" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "aNv" = (
 /obj/structure/debris/v3,
 /turf/closed/wall/f13/tunnel,
@@ -501,6 +861,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"aOu" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "aOx" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -512,6 +877,15 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"aOL" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aOW" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -520,6 +894,11 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"aPt" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "aQB" = (
 /obj/structure/rack,
@@ -530,6 +909,32 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"aQJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/drawer,
+/turf/open/water,
+/area/f13/bunker)
+"aRg" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"aRx" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"aSz" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "aSW" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/office/dark{
@@ -539,11 +944,32 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"aSZ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"aTj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "aTl" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"aTD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "aTJ" = (
 /obj/item/reagent_containers/food/snacks/salad/herbsalad,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -568,7 +994,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "aUG" = (
@@ -600,22 +1026,48 @@
 "aWN" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "aWS" = (
 /obj/item/ammo_casing,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"aXn" = (
+/obj/structure/sign/barsign,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "aXF" = (
 /obj/structure/table,
 /obj/item/dice/d100,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"aXO" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"aXY" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "aYg" = (
 /obj/structure/closet/fridge,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"aYo" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/bunker)
 "aYv" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/f13/followersvolunteer,
@@ -638,7 +1090,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "bac" = (
@@ -667,6 +1119,13 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bbt" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "bbJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -686,6 +1145,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bcG" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "bcL" = (
 /obj/structure/flora/tree/wasteland,
 /obj/structure/barricade/sandbags,
@@ -695,6 +1166,11 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/mineral/random/low_chance,
 /area/f13/underground/cave)
+"bdq" = (
+/obj/machinery/vending/cola/space_up,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "bdx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -709,6 +1185,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bey" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 5;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "beI" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -721,9 +1208,19 @@
 /obj/machinery/reagentgrinder,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
+"beZ" = (
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"bga" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "bgc" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -746,12 +1243,19 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bhG" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bhU" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
 "bhW" = (
@@ -759,11 +1263,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bii" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/wasteland)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "bil" = (
 /obj/machinery/light{
 	dir = 1
@@ -772,6 +1279,12 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"biu" = (
+/obj/structure/rack,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "biC" = (
 /obj/machinery/light,
 /obj/structure/rack,
@@ -795,10 +1308,17 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "bji" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right";
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/wasteland)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "bjA" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/floor/f13/wood{
@@ -810,6 +1330,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bjX" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "bkV" = (
 /turf/closed/indestructible/riveted/boss{
@@ -843,6 +1368,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bmZ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bnn" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
@@ -853,15 +1386,79 @@
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"boc" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
+"bnR" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"boc" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"box" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"bpn" = (
+/obj/item/soap,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "bpv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"bpx" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"bpD" = (
+/obj/structure/kitchenspike,
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"bpK" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"bqa" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/water,
+/area/f13/bunker)
+"bqj" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"bqn" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
 /area/f13/bunker)
 "bqA" = (
 /obj/structure/table,
@@ -887,6 +1484,52 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"brn" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = 10
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = -11
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"bro" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"brF" = (
+/obj/structure/rack,
+/obj/item/grenade/empgrenade,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"bsa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
+"bsc" = (
+/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "bsh" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -921,7 +1564,7 @@
 "bvS" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/legion)
 "bvT" = (
@@ -932,17 +1575,34 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"bvV" = (
+/obj/structure/chair/wood,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"bvY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
 "bwD" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar";
+	icon_state = "rubblepillar"
 	},
 /area/f13/wasteland)
+"bwJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/locker,
+/turf/open/water,
+/area/f13/bunker)
 "bxh" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "bxJ" = (
@@ -962,22 +1622,72 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"bys" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"byu" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"byB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "byC" = (
 /mob/living/simple_animal/cow/brahmin/calf,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"byO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"byT" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"bzn" = (
+/obj/structure/sign/warning/securearea,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "bzW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"bAg" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/seedling{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "bAx" = (
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
 "bAH" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
 "bBj" = (
@@ -1027,12 +1737,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"bEW" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "bFa" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
+	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
 "bFo" = (
@@ -1053,10 +1771,35 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"bHv" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/syndieminibomb/concussion/frag,
+/obj/item/grenade/syndieminibomb/concussion/frag,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"bHA" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "bHC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"bHG" = (
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "bHJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1068,9 +1811,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"bIl" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "bJb" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/legion)
 "bJM" = (
@@ -1084,6 +1832,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"bJX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "bKe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste,
@@ -1091,19 +1847,24 @@
 /area/f13/bunker)
 "bKn" = (
 /obj/structure/toilet{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "bKt" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bKH" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bLt" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -1115,11 +1876,23 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"bLI" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "bMf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "bMG" = (
@@ -1145,6 +1918,11 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"bNk" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bNL" = (
 /obj/machinery/power/deck_relay,
 /turf/open/floor/plating/tunnel{
@@ -1159,6 +1937,16 @@
 /obj/structure/stone_tile/center/burnt,
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"bOL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
 /area/f13/bunker)
 "bPz" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -1175,6 +1963,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"bPT" = (
+/obj/machinery/button/door{
+	id = "suka";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"bQl" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "bRa" = (
 /obj/machinery/light{
 	dir = 1;
@@ -1182,15 +1987,40 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bRG" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "bRI" = (
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
+"bSh" = (
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "bSB" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bSM" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"bSQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "bTe" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/timeddoor/sixtyminute,
@@ -1207,9 +2037,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"bTs" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"bTD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "bTS" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/underground/cave)
+"bUg" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "bUi" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -1223,7 +2071,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "bVI" = (
@@ -1247,12 +2095,25 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "bWg" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"bWK" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"bXd" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "bXr" = (
 /obj/structure/table/glass,
@@ -1272,7 +2133,7 @@
 /area/f13/bunker)
 "bYy" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken";
+	icon_state = "ruinswindowbroken"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -1288,7 +2149,7 @@
 /area/f13/legion)
 "bYS" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_2";
+	icon_state = "tree_2"
 	},
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -1302,10 +2163,27 @@
 	},
 /turf/open/water,
 /area/f13/underground/cave)
+"cal" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"cap" = (
+/obj/machinery/vending/cola/starkist,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "caN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup,
@@ -1323,6 +2201,15 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ccn" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "cct" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/f13/old,
@@ -1338,7 +2225,7 @@
 /obj/structure/closet/fridge,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "cdZ" = (
@@ -1354,6 +2241,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"cfd" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"cfB" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cfE" = (
 /obj/item/flag/ncr,
 /obj/structure/obstacle/barbedwire{
@@ -1379,6 +2281,17 @@
 /obj/item/trash/f13/c_ration_3,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"cgn" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "cgp" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -1388,6 +2301,18 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cgz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"cgR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
 /area/f13/bunker)
 "chf" = (
 /obj/structure/table/wood/poker,
@@ -1435,6 +2360,12 @@
 	icon_state = "2-i"
 	},
 /area/f13/bunker)
+"cip" = (
+/obj/structure/table/booth,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "ciK" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
@@ -1452,6 +2383,19 @@
 /obj/item/trash/f13/rotten,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"cjC" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cjN" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cjV" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
@@ -1465,6 +2409,68 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ckv" = (
+/obj/structure/sign/departments/chemistry,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"ckR" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ckV" = (
+/obj/structure/rack,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"clb" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cli" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cml" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution,
+/area/f13/radiation)
+"cmQ" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
+"cmR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"cmZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cna" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "cno" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -1476,18 +2482,43 @@
 /obj/item/reagent_containers/food/snacks/burger/bigbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"cob" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"coo" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "cor" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/hydroponics/constructable,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "coG" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"coJ" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/megaphone/sec,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "cpr" = (
 /obj/structure/chair/left{
@@ -1535,6 +2566,16 @@
 /obj/machinery/power/deck_relay,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"csG" = (
+/obj/machinery/light/broken,
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"ctn" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ctL" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -1554,12 +2595,37 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"cun" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"cuq" = (
+/obj/structure/chair/e_chair,
+/obj/effect/mob_spawn/human/corpse/vault/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "cuS" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"cuY" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cvn" = (
 /obj/structure/bonfire/dense,
 /turf/open/indestructible/ground/outside/desert,
@@ -1599,6 +2665,17 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"cyi" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cyN" = (
+/obj/structure/chair/comfy/brown,
+/obj/item/toy/plush/lizardplushie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "czm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1616,6 +2693,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"czO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
 "cAp" = (
 /obj/structure/bodycontainer/crematorium,
 /turf/open/floor/f13{
@@ -1647,6 +2731,16 @@
 "cCA" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/wasteland)
+"cCP" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "cDn" = (
 /obj/machinery/biogenerator,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1656,6 +2750,13 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"cEy" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "meat";
+	name = "Meat Storage"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cEG" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -1668,6 +2769,15 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"cFb" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "cFf" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1678,11 +2788,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"cFR" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "cGe" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "cGh" = (
@@ -1702,6 +2820,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"cHN" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "cIc" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1718,7 +2841,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "cJv" = (
@@ -1742,6 +2865,10 @@
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"cJS" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "cJX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1751,6 +2878,26 @@
 "cKf" = (
 /obj/structure/rack,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"cKg" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/item/bodypart/l_arm/monkey,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "cKh" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1776,6 +2923,16 @@
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"cMg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "cNd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1784,7 +2941,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "cOh" = (
@@ -1804,6 +2961,19 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"cPC" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"cPF" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "cPL" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/water,
@@ -1821,6 +2991,13 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"cQf" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cQz" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -1841,6 +3018,14 @@
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"cRc" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/bikehorn/rubberducky,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "cRt" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -1865,6 +3050,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"cSQ" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "cTq" = (
 /obj/structure/campfire/barrel,
 /obj/machinery/light{
@@ -1878,6 +3068,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+"cTw" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "cTQ" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -1897,6 +3095,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"cUq" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "cUD" = (
 /obj/structure/sign/poster/contraband/pinup_vixen,
 /turf/closed/wall/f13/wood/interior,
@@ -1904,9 +3114,23 @@
 "cUF" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland)
+"cUH" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"cVm" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "cVB" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbrokenvertical";
+	icon_state = "ruinswindowbrokenvertical"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
@@ -1929,6 +3153,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"cWI" = (
+/obj/structure/sign/poster/official/do_not_question,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "cXn" = (
 /turf/open/floor/plasteel/dark/corner,
 /area/f13/bunker)
@@ -1949,6 +3180,41 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"cYB" = (
+/obj/structure/sign/poster/official/help_others,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"cZy" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"cZI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
+"cZN" = (
+/obj/structure/grille/broken,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"cZQ" = (
+/obj/structure/table/wood,
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "cZT" = (
 /obj/structure/sink{
@@ -1975,6 +3241,12 @@
 /obj/item/pen,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"daL" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "daT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1986,6 +3258,11 @@
 "daX" = (
 /obj/structure/stone_tile/surrounding,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"dba" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker)
 "dbq" = (
 /turf/open/floor/plasteel/dark/corner{
@@ -2010,12 +3287,23 @@
 "dcJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"dcQ" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ddp" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"ddK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "deq" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2027,6 +3315,39 @@
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"deG" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"dfn" = (
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"dfo" = (
+/obj/structure/table,
+/obj/item/stamp/captain{
+	name = "overseer's rubber stamp";
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen/fountain/captain{
+	desc = "It's an expensive Oak fountain pen, engraved with the numbers 113. The nib is quite sharp.";
+	name = "overseer's fountain pen";
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "dfq" = (
 /obj/machinery/workbench,
 /obj/machinery/light/small{
@@ -2042,6 +3363,25 @@
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"dgA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dgI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dgX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/cards/singlecard,
@@ -2050,20 +3390,31 @@
 "dhi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/ncr)
 "dhq" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
+	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
+"dht" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "dhH" = (
 /obj/structure/displaycase/trophy,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/f13/old,
@@ -2113,12 +3464,32 @@
 "dka" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"dkm" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"dkE" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "dkK" = (
 /obj/effect/decal/riverbank{
 	dir = 4
@@ -2156,6 +3527,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"dlF" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dlL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
@@ -2165,7 +3542,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "dlW" = (
@@ -2180,9 +3557,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dmn" = (
+/obj/machinery/button/door{
+	id = "trap";
+	name = "Old Dusty Button"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dmp" = (
 /obj/effect/decal/remains/human,
 /turf/closed/mineral/random/high_chance,
@@ -2199,7 +3584,7 @@
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "dnm" = (
@@ -2212,11 +3597,31 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"dnz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_hatch,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "dnM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dnO" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dnZ" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -2228,6 +3633,10 @@
 /obj/effect/spawner/lootdrop/crafts,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"doz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "doM" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13/wood,
@@ -2237,7 +3646,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "doS" = (
@@ -2250,7 +3659,7 @@
 /area/f13/bunker)
 "dpa" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermaintop";
+	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
 "dpj" = (
@@ -2271,10 +3680,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"drd" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"drG" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/construction/rcd,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "drH" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"dsp" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "dsr" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2294,6 +3729,10 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
+/area/f13/bunker)
+"dtT" = (
+/obj/structure/weightlifter,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dub" = (
 /obj/machinery/autolathe,
@@ -2343,10 +3782,47 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dvR" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"dwV" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/firefighter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dxg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "dxN" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dxU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"dxY" = (
+/obj/structure/destructible/tribal_torch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"dxZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/bunker)
 "dyP" = (
 /obj/structure/table,
@@ -2355,6 +3831,21 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"dzs" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"dzM" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "dzY" = (
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
@@ -2363,6 +3854,16 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"dAV" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "dBJ" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -2398,10 +3899,28 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dCV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/plasteel/caution{
+	dir = 9
+	},
+/area/f13/radiation)
 "dDr" = (
 /obj/effect/decal/remains/human,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"dDv" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
 /area/f13/bunker)
 "dDE" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
@@ -2439,14 +3958,37 @@
 /area/f13/bunker)
 "dDT" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
+	icon_state = "rubbleplate"
 	},
 /area/f13/ncr)
+"dEx" = (
+/obj/structure/table,
+/obj/item/crafting/board,
+/obj/item/crafting/board,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"dEP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "dFa" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
+	icon_state = "housewood2"
 	},
 /area/f13/legion)
+"dFy" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "dFM" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -2460,6 +4002,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"dFO" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "dGp" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
@@ -2470,6 +4017,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"dGE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "dHs" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -2478,6 +4033,25 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"dHD" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"dHF" = (
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "dHW" = (
 /obj/structure/table/wood/settler,
 /obj/item/lighter,
@@ -2490,6 +4064,16 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"dIP" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "dJb" = (
 /obj/structure/closet,
 /obj/item/instrument/guitar,
@@ -2514,6 +4098,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dJE" = (
+/obj/structure/sign/poster/official/obey,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"dKb" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "dKm" = (
 /obj/structure/table/reinforced,
 /obj/item/pickaxe,
@@ -2527,10 +4122,15 @@
 /obj/item/card/id/prisoner/six,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"dKx" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "dKC" = (
 /obj/structure/sink{
 	dir = 1;
-	pixel_y = 16;
+	pixel_y = 16
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -2560,6 +4160,16 @@
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
+	},
+/area/f13/bunker)
+"dLF" = (
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "dLS" = (
@@ -2617,6 +4227,14 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"dNu" = (
+/obj/item/am_containment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "dNU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -2629,6 +4247,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"dOa" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "dOb" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
@@ -2636,6 +4259,10 @@
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"dOu" = (
+/mob/living/simple_animal/hostile/raider/thief,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "dOG" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2644,6 +4271,16 @@
 /obj/structure/safe,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"dPI" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "dPT" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -2662,6 +4299,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"dQl" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "dQr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2670,7 +4313,7 @@
 /area/f13/legion)
 "dQz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "dQM" = (
@@ -2703,7 +4346,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "dRF" = (
@@ -2711,6 +4354,14 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"dRY" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/machinery/chem_master/condimaster,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
 "dSK" = (
 /obj/item/ammo_casing/c9mm,
@@ -2727,6 +4378,22 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"dTC" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/crafting/electronicparts/three,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/bunker)
 "dTG" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2746,11 +4413,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "dVc" = (
-/obj/structure/fence{
-	dir = 4
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"dVf" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "dVr" = (
 /obj/structure/debris/v1{
 	pixel_x = -16
@@ -2769,6 +4445,26 @@
 /obj/structure/chair/wood/worn,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"dWc" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"dWO" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"dWY" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "dXd" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/f13/old,
@@ -2809,7 +4505,7 @@
 "dYw" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
@@ -2826,7 +4522,7 @@
 "dZU" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetUSA";
+	icon_state = "sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
@@ -2839,6 +4535,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"eai" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eas" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2881,6 +4585,13 @@
 /obj/structure/nest/securitron,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"ebp" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "ebF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2900,15 +4611,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ecq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "ecK" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/combat,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ecS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "edb" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbrokenvertical";
+	icon_state = "ruinswindowbrokenvertical"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ncr)
@@ -2917,6 +4642,11 @@
 /obj/effect/spawner/lootdrop/crafts,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"edO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "edV" = (
 /obj/structure/toilet{
@@ -2935,6 +4665,11 @@
 /obj/effect/decal/riverbank,
 /turf/open/water,
 /area/f13/underground/cave)
+"eev" = (
+/obj/structure/decoration/rag,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eeP" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/green,
@@ -2955,6 +4690,13 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"efc" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
 /area/f13/bunker)
 "efu" = (
 /obj/structure/table,
@@ -2981,12 +4723,36 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"egg" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress3"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "egq" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"egJ" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"egQ" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eil" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -3002,6 +4768,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"ejc" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "ejE" = (
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3016,6 +4788,11 @@
 	icon_state = "bar"
 	},
 /area/f13/followers)
+"ekr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "eky" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -3049,9 +4826,16 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"emT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "enj" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -3080,6 +4864,16 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"eoI" = (
+/obj/effect/decal/cleanable/molten_object,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
+"eoK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eoP" = (
 /obj/machinery/door/airlock/security/glass{
 	max_integrity = 9999;
@@ -3092,16 +4886,41 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"eoU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"epC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
 "epJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"eqo" = (
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "erd" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"erA" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "erC" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3114,6 +4933,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"erU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "erX" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/spawner/lootdrop/trash,
@@ -3138,9 +4970,15 @@
 	pixel_x = 14
 	},
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"esZ" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ete" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -3148,6 +4986,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"etq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"euh" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "eut" = (
 /obj/structure/bed,
 /obj/item/trash/cheesie,
@@ -3157,9 +5009,13 @@
 	},
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"euw" = (
+/obj/structure/stacklifter,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "euH" = (
 /obj/structure/flora/tree/tall,
 /obj/structure/flora/grass/wasteland{
@@ -3171,6 +5027,50 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"euR" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_y = -3
+	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/genericbush{
+	pixel_x = -17
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"evu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"evB" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"evD" = (
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ewf" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/nest/cazador,
@@ -3186,9 +5086,16 @@
 /area/f13/bunker)
 "ewx" = (
 /turf/open/floor/f13{
-	icon_state = "stagestairs";
+	icon_state = "stagestairs"
 	},
 /area/f13/ncr)
+"ewI" = (
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "ewW" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -3203,6 +5110,17 @@
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"exU" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "eyh" = (
 /obj/structure/table,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -3220,6 +5138,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"eyQ" = (
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"ezk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/micro,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "ezw" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/item/ammo_box/c10mm,
@@ -3230,6 +5159,11 @@
 /obj/effect/decal/cleanable/cum,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"ezM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
 "eAa" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3241,12 +5175,23 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"eAB" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "eAJ" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
+/area/f13/bunker)
+"eBc" = (
+/obj/structure/weightlifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "eBg" = (
 /obj/structure/closet/wardrobe,
@@ -3287,6 +5232,27 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"eBY" = (
+/obj/structure/table/reinforced,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"eDb" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eDg" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3301,7 +5267,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
 "eDt" = (
@@ -3311,6 +5277,20 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"eDB" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"eDN" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/crafting/abraxo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/bunker)
 "eEe" = (
 /obj/effect/spawner/lootdrop/ammo,
@@ -3352,6 +5332,14 @@
 /obj/item/trash/f13/mre,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"eFA" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "eFR" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -3368,6 +5356,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"eGp" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "eGJ" = (
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3385,6 +5378,14 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"eHS" = (
+/obj/machinery/camera/autoname{
+	dir = 9;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "eIb" = (
 /obj/structure/closet,
 /turf/open/floor/f13/wood,
@@ -3396,6 +5397,22 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"eIo" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"eIv" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "eJd" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3416,6 +5433,26 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"eLM" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/f13/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/item/clothing/head/helmet/f13/combat/swat,
+/obj/item/clothing/glasses/legiongoggles,
+/obj/structure/window/reinforced,
+/obj/item/grenade/chem_grenade/teargas,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/item/grenade/flashbang,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "eLS" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /turf/open/floor/mineral/plastitanium,
@@ -3427,10 +5464,21 @@
 /obj/item/card/id/prisoner/seven,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"eNe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "eNI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"eNT" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "eOb" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /obj/item/ammo_box/c45,
@@ -3448,6 +5496,11 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
+"eOx" = (
+/obj/structure/stacklifter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "eOY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3466,6 +5519,24 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"ePA" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"ePM" = (
+/obj/machinery/button/door{
+	id = "stalin";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "ePY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -3476,15 +5547,18 @@
 	},
 /area/f13/wasteland)
 "eQe" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = 14
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"eQE" = (
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "eRS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -3496,6 +5570,43 @@
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"eSi" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"eSt" = (
+/obj/structure/sign/departments/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"eSB" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"eSF" = (
+/obj/structure/sign/poster/official/science{
+	pixel_y = 32
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"eST" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "eSU" = (
 /obj/machinery/workbench,
 /obj/item/stack/sheet/metal/fifty,
@@ -3506,6 +5617,31 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"eTp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"eTK" = (
+/obj/item/pen/fountain,
+/obj/item/clothing/accessory/lawyers_badge,
+/obj/item/storage/briefcase/lawyer,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"eTQ" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/timeddoor,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "eUe" = (
 /obj/structure/table/glass,
 /obj/item/fermichem/pHmeter,
@@ -3516,6 +5652,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"eUi" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "eUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -3538,6 +5683,15 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
+"eVv" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc1";
+	name = "Cell 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "eVx" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
@@ -3550,9 +5704,25 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"eWb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"eWc" = (
+/obj/structure/table,
+/obj/item/stamp/hos,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/figure/hos,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "eWx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
 "eXb" = (
@@ -3563,7 +5733,7 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "eXZ" = (
@@ -3590,6 +5760,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"eYk" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "eYE" = (
 /obj/structure/rack,
 /obj/item/toy/cards/deck/cas,
@@ -3597,6 +5774,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"eYJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"eYS" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "eZa" = (
 /obj/machinery/light{
 	dir = 1
@@ -3605,6 +5794,17 @@
 	faction = list("wastebot")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"eZD" = (
+/obj/structure/bed/mattress,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"eZE" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "fap" = (
 /obj/effect/decal/cleanable/blood,
@@ -3625,6 +5825,15 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"fcp" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "fcM" = (
 /obj/effect/landmark/poster_spawner/pinup,
 /turf/closed/wall/f13/wood,
@@ -3647,9 +5856,18 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"fea" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "99";
+	name = "Vault 223 armory shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "fee" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_2";
+	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -3682,6 +5900,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ffU" = (
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fga" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/riverbank{
@@ -3712,6 +5935,14 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"fgL" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "fgW" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -3734,6 +5965,27 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"fia" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"fiy" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"fiS" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fiU" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -3744,6 +5996,12 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"flv" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "fnz" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/f13/tunnel,
@@ -3752,7 +6010,7 @@
 /obj/structure/displaycase/trophy,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -3768,16 +6026,16 @@
 /area/f13/bunker)
 "fpl" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "fpw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
-	icon_state = "outerborder";
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
 "fpy" = (
@@ -3785,6 +6043,17 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
+/area/f13/bunker)
+"fqm" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "fqn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3802,6 +6071,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"fqN" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"frm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/crude/snow,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "frr" = (
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
@@ -3811,11 +6092,34 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"frR" = (
+/obj/effect/decal/cleanable/molten_object/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
+"fsQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor{
+	id = 103;
+	name = "Vault Blastdoor 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "fsR" = (
 /obj/structure/timeddoor,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"fuI" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "fuP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3826,6 +6130,12 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"fvo" = (
+/obj/structure/glowshroom/single,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "fvp" = (
 /obj/machinery/light{
@@ -3849,6 +6159,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"fwr" = (
+/obj/structure/closet,
+/obj/item/storage/box/gloves,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"fwv" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/part_replacer,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "fwW" = (
 /obj/machinery/status_display{
 	desc = "A large glass display, used to show various types of information.";
@@ -3856,6 +6187,25 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"fxn" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"fxw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "fxR" = (
 /obj/structure/ladder/unbreakable{
@@ -3876,6 +6226,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"fyq" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "fyx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -3884,11 +6244,25 @@
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"fyI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/junglebush/b,
+/turf/open/water,
+/area/f13/bunker)
 "fzi" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"fzm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/closed/indestructible/fakedoor{
+	name = "Impassable Airlock"
+	},
+/area/f13/bunker)
 "fzC" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -3914,6 +6288,24 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"fBa" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fBp" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	icon_state = "rightsecure"
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "fCi" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer,
@@ -3921,6 +6313,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"fDq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "fDU" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -3929,6 +6328,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"fEm" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "fEu" = (
 /obj/effect/decal/remains/human,
@@ -3939,10 +6343,16 @@
 "fEF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old";
+	icon_state = "floor5-old"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fFd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "fFh" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3955,6 +6365,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"fGK" = (
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"fGW" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "fHk" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3964,16 +6384,44 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fIe" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"fIy" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "fIF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
 	},
 /area/f13/wasteland)
+"fIO" = (
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "fJe" = (
 /obj/structure/table/wood/settler,
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"fJB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "fJM" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/f13/old,
@@ -3983,6 +6431,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"fLs" = (
+/obj/structure/table/reinforced,
+/obj/item/cautery,
+/obj/item/hemostat,
+/obj/item/retractor,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "fMc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3994,6 +6451,13 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"fMr" = (
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fMt" = (
 /obj/structure/fence{
 	dir = 8
@@ -4026,6 +6490,19 @@
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"fNm" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/sign/warning,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"fNA" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "fNB" = (
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
@@ -4052,6 +6529,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"fOM" = (
+/mob/living/simple_animal/hostile/jungle/leaper{
+	desc = "A massive beast that spits out highly pressurized bubbles containing a unique toxin, knocking down its prey and then crushing it with its girth.";
+	health = 500;
+	maxHealth = 500
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "fOW" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -4068,12 +6554,27 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"fPK" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"fPL" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "fQq" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
 	icon_state = "rubble"
 	},
 /area/f13/legion)
+"fQz" = (
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fQC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen,
@@ -4111,6 +6612,32 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"fRX" = (
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
+"fRY" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"fSb" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "fSw" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -4127,6 +6654,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"fSP" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "fTr" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood{
@@ -4141,7 +6673,7 @@
 /area/f13/followers)
 "fTW" = (
 /obj/structure/chair/wood{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -4160,6 +6692,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"fUz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 5
+	},
+/area/f13/bunker)
+"fUH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "fUY" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/dirt,
@@ -4179,15 +6726,33 @@
 	dir = 4
 	},
 /area/f13/bunker)
+"fVY" = (
+/obj/machinery/light/broken,
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "fWe" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "fWH" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
+	},
+/area/f13/bunker)
+"fXb" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"fYf" = (
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "rubblepillar"
 	},
 /area/f13/bunker)
 "fYq" = (
@@ -4212,12 +6777,25 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"fZh" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "fZj" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"fZv" = (
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "fZG" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -4231,6 +6809,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"gas" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gaB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/vault_door/old{
@@ -4242,14 +6825,18 @@
 "gaF" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/legion)
 "gaT" = (
 /turf/open/floor/f13{
-	icon_state = "stagestairs";
+	icon_state = "stagestairs"
 	},
 /area/f13/legion)
+"gaY" = (
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "gaZ" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -4257,6 +6844,14 @@
 	},
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"gbd" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gbN" = (
 /obj/structure/barricade/wooden,
@@ -4274,6 +6869,25 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gcg" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gdc" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -4287,6 +6901,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"gdB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
+"gei" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "ger" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/ruins,
@@ -4304,11 +6933,25 @@
 	},
 /area/f13/followers)
 "gfw" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 4;
-	icon_state = "rubble"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
 	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"gfy" = (
+/obj/structure/sign/poster/official/build{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
 "gfI" = (
 /obj/structure/nest/raider{
 	max_mobs = 3;
@@ -4321,6 +6964,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ggw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ggB" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4328,7 +6978,7 @@
 "ggP" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "ggY" = (
@@ -4336,6 +6986,32 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/tentwall,
+/area/f13/bunker)
+"gha" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"ghj" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"ghv" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ghw" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/construction/rcd,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "ghW" = (
 /turf/open/floor/plasteel/f13{
@@ -4353,7 +7029,7 @@
 "giG" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
 "giN" = (
@@ -4362,6 +7038,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"giT" = (
+/obj/structure/table,
+/obj/item/clothing/head/soft/black,
+/obj/item/clothing/under/color/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"gjB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "gjI" = (
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4372,6 +7067,23 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"gkx" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"glc" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "glz" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/desert,
@@ -4386,6 +7098,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"gmK" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "gmU" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/tier5,
@@ -4404,6 +7120,13 @@
 /obj/item/trash/f13/tin,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"goC" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "goK" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/f13{
@@ -4413,7 +7136,7 @@
 "goT" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "goV" = (
@@ -4423,6 +7146,12 @@
 "gpe" = (
 /obj/machinery/computer/card,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"gpD" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "gpY" = (
 /obj/structure/chair/right{
@@ -4452,9 +7181,14 @@
 	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
+"gqT" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "gsb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -4468,6 +7202,12 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"gsq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "gsV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/pill/radx,
@@ -4480,6 +7220,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gtA" = (
+/obj/structure/table,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "gtL" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -4514,6 +7263,22 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gvi" = (
+/obj/machinery/door/airlock/command{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"gvv" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "gvJ" = (
 /obj/structure/closet/fridge/meat,
 /turf/open/floor/wood/f13/old,
@@ -4523,16 +7288,30 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/underground/cave)
+"gww" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "gwL" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "gxP" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"gyG" = (
+/obj/structure/sign/departments/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "gyJ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -4543,6 +7322,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"gze" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gzH" = (
 /obj/structure/simple_door,
@@ -4555,6 +7340,16 @@
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"gAJ" = (
+/obj/structure/table,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "gAT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4572,7 +7367,7 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "gBm" = (
@@ -4589,17 +7384,71 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"gCc" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "gCm" = (
 /obj/structure/nest/assaultron{
 	max_mobs = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"gCB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gCN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left";
+	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"gDg" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"gDI" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gDO" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"gEd" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "gED" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -4629,6 +7478,16 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gFH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/turf/open/water,
+/area/f13/bunker)
+"gGH" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "gGK" = (
 /obj/structure/bookcase/manuals,
 /obj/item/book/granter/trait/midsurgery,
@@ -4648,16 +7507,39 @@
 /area/f13/bunker)
 "gHO" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
 "gIc" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"gIr" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"gIO" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"gIS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"gIU" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/bunker)
 "gJi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -4669,6 +7551,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"gKj" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "gKr" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/bunker)
@@ -4690,10 +7579,24 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/underground/cave)
+"gLw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "gLz" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gLH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "gMo" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
@@ -4701,6 +7604,21 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"gMy" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gME" = (
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/bunker)
 "gMX" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -4712,14 +7630,37 @@
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"gNj" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/medspray{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/medspray{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/chem_grenade/large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "gNQ" = (
 /obj/machinery/deepfryer,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "gOB" = (
@@ -4751,6 +7692,16 @@
 /obj/item/candle/tribal_torch,
 /turf/open/water,
 /area/f13/wasteland)
+"gPD" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "gQb" = (
 /obj/item/clothing/under/rank/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -4758,7 +7709,7 @@
 /area/f13/bunker)
 "gQn" = (
 /obj/structure/chair/comfy/brown{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
@@ -4768,7 +7719,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "gQB" = (
@@ -4784,6 +7735,17 @@
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gRC" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"gSH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "gTa" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -4796,9 +7758,44 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"gTl" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/caves)
+"gTB" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"gTP" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/closet/crate/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"gUn" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "gUA" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"gUL" = (
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"gUS" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "gUT" = (
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
@@ -4851,6 +7848,14 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"gXJ" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "gYy" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4876,6 +7881,11 @@
 "gYQ" = (
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"gZb" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "gZj" = (
 /obj/item/trash/can,
 /turf/open/floor/carpet/black,
@@ -4897,6 +7907,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gZE" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"gZV" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "haa" = (
 /obj/structure/stone_tile/slab,
 /obj/item/melee/transforming/cleaving_saw,
@@ -4910,9 +7938,26 @@
 /area/f13/bunker)
 "haq" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"haM" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"haX" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hbb" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -4921,7 +7966,7 @@
 /area/f13/underground/cave)
 "hbn" = (
 /obj/structure/toilet{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -4949,6 +7994,45 @@
 "hbR" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"hbW" = (
+/obj/machinery/light{
+	dir = 8;
+	flickering = 1;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"hcm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hcW" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"hcZ" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"hdd" = (
+/obj/machinery/vending/nukacolavendfull,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hdA" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -4969,10 +8053,18 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker)
+"hdP" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/bunker)
 "hdQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "hdS" = (
@@ -4982,6 +8074,18 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hdU" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"hdY" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "heR" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -4990,10 +8094,33 @@
 "heT" = (
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"hfc" = (
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hfv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"hfw" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hfE" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "hfI" = (
 /obj/item/candle/tribal_torch,
 /obj/structure/flora/grass/wasteland{
@@ -5005,6 +8132,26 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hfO" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hge" = (
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"hgg" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
 "hgk" = (
 /obj/item/target/alien,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5019,6 +8166,13 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"hhx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hiQ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -5027,6 +8181,38 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"hjQ" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_y = 2
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = 17
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"hkw" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"hlt" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hlU" = (
 /obj/structure/chair{
 	dir = 4
@@ -5046,6 +8232,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"hne" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "hns" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5062,10 +8255,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"how" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"hoD" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "hoN" = (
 /obj/structure/fireplace,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"hpb" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hph" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "hpj" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood/random,
@@ -5113,9 +8332,29 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"hqk" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hqm" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/water,
+/area/f13/bunker)
+"hqq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/secure/science{
+	req_one_access_txt = "1"
+	},
+/obj/item/clothing/head/kitty/genuine{
+	desc = "Smells like fur and fills you with dread.";
+	max_integrity = 10000;
+	name = "horrific experiment"
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "hqJ" = (
 /obj/structure/chair{
@@ -5127,14 +8366,34 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
 /area/f13/wasteland)
+"hrb" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "hrc" = (
 /obj/item/toy/cards/singlecard,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hrK" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hsl" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hsD" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hte" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -5146,6 +8405,22 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"hvg" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hvq" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hvs" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "hvx" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5153,12 +8428,12 @@
 "hvH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/legion)
 "hwh" = (
 /obj/structure/chair{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -5172,14 +8447,30 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hwF" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"hxg" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "hxi" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"hxk" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/destructible/tribal_torch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hxr" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -5191,16 +8482,49 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/bunker)
+"hxJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"hyr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/seedling{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
+"hyF" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "hzj" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"hzm" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hzt" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "hzY" = (
@@ -5208,6 +8532,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hAQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
+"hAY" = (
+/obj/machinery/button/door{
+	id = "vaultshutters";
+	name = "overseer button"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "hBr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -5223,13 +8563,19 @@
 /area/f13/legion)
 "hBE" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowdestroyed";
+	icon_state = "ruinswindowdestroyed"
 	},
 /obj/structure/curtain{
 	color = "#845f58"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hCd" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "hDa" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -5237,6 +8583,17 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"hDk" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
 "hDz" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -5244,11 +8601,33 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"hDM" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"hEi" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 5
+	},
+/area/f13/radiation)
+"hEl" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "hEp" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"hEq" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "hFc" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -5280,6 +8659,32 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hGu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"hGC" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hGM" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "hGQ" = (
 /obj/machinery/power/rtg,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -5292,7 +8697,7 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "hHy" = (
@@ -5308,12 +8713,18 @@
 "hHC" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
 "hHJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"hIm" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "hIq" = (
@@ -5344,13 +8755,24 @@
 "hJj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "hJx" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"hJA" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"hJC" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "hJS" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -5364,7 +8786,7 @@
 "hKh" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -5375,6 +8797,34 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"hLT" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"hLU" = (
+/obj/machinery/door_timer{
+	id = "vaultc1";
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"hMb" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"hMf" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hMy" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -5393,6 +8843,14 @@
 /obj/item/reagent_containers/food/snacks/salad/jungle,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"hNi" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/neck/apron/chef,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "hNJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -5408,6 +8866,32 @@
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"hOL" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"hPw" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"hQh" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"hQi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
 	},
 /area/f13/bunker)
 "hRh" = (
@@ -5432,6 +8916,16 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"hRO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "hRY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5453,13 +8947,31 @@
 "hTh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"hTk" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "hTu" = (
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"hTW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"hUg" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "hUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -5476,9 +8988,22 @@
 "hUs" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
-	icon_state = "outerborder";
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"hUE" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "hUG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plating/tunnel{
@@ -5489,12 +9014,40 @@
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"hVk" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/nest/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "hVG" = (
 /obj/structure/girder/reinforced,
 /obj/structure/sign/poster/ripped,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
+/area/f13/bunker)
+"hVK" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"hWB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hWJ" = (
 /obj/structure/chair/office/dark{
@@ -5504,6 +9057,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"hWL" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "hWN" = (
 /obj/structure/nest/securitron{
 	max_mobs = 2;
@@ -5513,11 +9074,19 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"hXc" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "hXL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "hYn" = (
@@ -5531,12 +9100,75 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"hYv" = (
+/obj/structure/table/optable,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"hYz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"hZW" = (
+/obj/item/bodypart/chest/monkey,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "iaA" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"iaE" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/storage/box/syringes,
+/obj/structure/closet,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
+/obj/item/fermichem/pHmeter,
+/obj/item/fermichem/pHmeter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"iaI" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
+"ibz" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"ibZ" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"icx" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "icA" = (
 /obj/machinery/light/sign/kebab,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5544,6 +9176,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"icF" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"icR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "idb" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
@@ -5570,20 +9217,35 @@
 "idP" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"idY" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/doorButtons/wornvaultButton,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "ien" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "iep" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt";
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"iey" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 6;
+	pixel_y = -8
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "ieO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2right";
+	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
 "ifx" = (
@@ -5597,6 +9259,15 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
+"ifF" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 4
+	},
+/area/f13/bunker)
 "ifN" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -5624,6 +9295,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"igZ" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "ihq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/holofloor/carpet,
@@ -5637,6 +9323,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"iiL" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "iiS" = (
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/molerat,
@@ -5656,11 +9347,55 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"iju" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"ijE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
 "iko" = (
 /obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/salad/desertsalad,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ilr" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ily" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
+"ilz" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ilL" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
@@ -5672,6 +9407,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"img" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"imp" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "imw" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -5693,6 +9439,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ink" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "inP" = (
 /obj/structure/chair{
 	dir = 8
@@ -5704,19 +9455,59 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"ipc" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "ipi" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ipt" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "ipy" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"ipE" = (
+/obj/machinery/button{
+	id = 666;
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"ipH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/f13/bunker)
+"ipU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iqa" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"iqr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "iqx" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5732,13 +9523,20 @@
 "iqH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
-	icon_state = "outerborder";
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"iqI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "iqR" = (
 /obj/item/ammo_casing,
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "irk" = (
@@ -5748,34 +9546,130 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"irr" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "isf" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/ncr)
+"isj" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "isk" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"itg" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"itH" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"iuf" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/wreck/trash/machinepiletwo{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "iur" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/wasteland)
+"ivg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ivj" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"ivr" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/f13/bunker)
+"ivv" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/effect/mob_spawn/human/corpse/vault,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "ivy" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"ivT" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"iwg" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"iwF" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "iwI" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowdestroyed";
+	icon_state = "ruinswindowdestroyed"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -5785,6 +9679,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ixz" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "ixW" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
@@ -5792,9 +9691,16 @@
 /obj/structure/decoration/hatch,
 /obj/item/ammo_casing,
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
+"iyi" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "izp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5825,6 +9731,27 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland)
+"iAi" = (
+/obj/structure/debris/v3,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"iAo" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"iAu" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"iAx" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "iAD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/medsprays,
@@ -5837,11 +9764,15 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"iAW" = (
+/obj/structure/sign/poster/contraband/have_a_puff,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "iBd" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "iBu" = (
@@ -5876,6 +9807,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"iDY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
 "iEn" = (
 /obj/structure/table/glass,
@@ -5916,6 +9851,15 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"iFk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "iFl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5925,16 +9869,51 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iFq" = (
+/obj/machinery/vending/coffee{
+	pixel_y = 1
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "iFv" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"iFY" = (
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "iGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"iGt" = (
+/obj/structure/table,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"iGP" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "iGW" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -5949,12 +9928,36 @@
 "iHO" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/ncr)
+"iJs" = (
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "iKc" = (
 /obj/item/candle/tribal_torch,
 /turf/open/water,
+/area/f13/bunker)
+"iKr" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 9
+	},
+/area/f13/bunker)
+"iMp" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/corner{
+	dir = 1
+	},
 /area/f13/bunker)
 "iMU" = (
 /mob/living/simple_animal/cow/brahmin,
@@ -5967,6 +9970,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"iNY" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iOg" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -5975,6 +9988,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"iOn" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"iOQ" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"iPS" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "iPY" = (
 /obj/structure/chair/f13chair1{
@@ -6011,6 +10043,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"iRj" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/north{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"iRr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "iRt" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -6022,7 +10069,7 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "iSk" = (
@@ -6064,6 +10111,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"iUn" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "iUz" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -6073,20 +10127,46 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iUG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"iVq" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "iVS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iWx" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "iWD" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_2";
+	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"iWM" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "iXL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -6098,6 +10178,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"iYg" = (
+/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "iYh" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -6108,7 +10193,7 @@
 	},
 /obj/item/soap/homemade,
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
 "iZp" = (
@@ -6143,14 +10228,28 @@
 /area/f13/bunker)
 "jbc" = (
 /obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor6-old";
+	icon_state = "floor6-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"jbL" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -13
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "jcm" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "jcx" = (
@@ -6167,6 +10266,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/radiation)
+"jdy" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "jdE" = (
 /obj/structure/chair{
 	dir = 8
@@ -6179,10 +10286,21 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jeq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"jeP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "jfs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -6194,6 +10312,11 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jgD" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "jgW" = (
 /obj/structure/table/glass,
 /obj/item/healthanalyzer,
@@ -6213,6 +10336,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"jhz" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "jhY" = (
 /obj/structure/stone_tile/slab,
 /obj/item/candle/tribal_torch,
@@ -6222,6 +10350,28 @@
 /obj/structure/stone_tile/burnt,
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"jii" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"jim" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"jio" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "jit" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6241,6 +10391,15 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"jks" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "jku" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /obj/structure/barricade/wooden/planks,
@@ -6250,6 +10409,11 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
+	},
+/area/f13/bunker)
+"jkW" = (
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "rubblepillar"
 	},
 /area/f13/bunker)
 "jla" = (
@@ -6265,6 +10429,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jlx" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"jly" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "jlI" = (
 /obj/item/ammo_casing/a762,
 /turf/open/floor/f13/wood{
@@ -6276,6 +10459,13 @@
 	icon_state = "verticalrightborderlefttop"
 	},
 /area/f13/wasteland)
+"jmk" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jms" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -6298,6 +10488,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jno" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Raider"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "jns" = (
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
@@ -6309,6 +10506,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"jny" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"jnC" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "jnS" = (
 /obj/structure/rack,
@@ -6327,6 +10533,17 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"jol" = (
+/obj/structure/timeddoor,
+/obj/structure/debris/v3,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
+"joo" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "joZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -6342,9 +10559,21 @@
 "jph" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"jpv" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jpL" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "jqq" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_tl,
@@ -6353,6 +10582,20 @@
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"jrh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"jro" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "jrZ" = (
 /obj/structure/table,
 /obj/item/bodybag,
@@ -6362,6 +10605,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"jsc" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"jtl" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "jtm" = (
 /obj/machinery/microwave/stove,
 /obj/machinery/light{
@@ -6386,6 +10639,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"jul" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "jux" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6414,6 +10671,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"jvH" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "jvM" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/molerat,
@@ -6438,6 +10700,13 @@
 /obj/structure/debris/v1,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"jwv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "jxD" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -6448,12 +10717,62 @@
 /obj/item/seeds/tower,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"jxG" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"jxJ" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "jxK" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jyv" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "jzG" = (
 /obj/structure/barricade/wooden,
@@ -6473,6 +10792,19 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"jAy" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"jAO" = (
+/obj/machinery/door/airlock/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "jBz" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -6501,13 +10833,13 @@
 /area/f13/bunker)
 "jBR" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
 "jCo" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubblecorner";
+	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
 "jCO" = (
@@ -6516,12 +10848,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jCP" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 6
+	},
+/area/f13/radiation)
 "jCY" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jDe" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"jDl" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "jDy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -6536,10 +10888,28 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"jDZ" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "jEp" = (
 /obj/item/candle/tribal_torch,
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"jEv" = (
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "jEY" = (
 /obj/machinery/light{
@@ -6549,10 +10919,36 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"jFe" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jFM" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"jHv" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "jHK" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"jIi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/structure/closet/crate/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "jIj" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -6576,18 +10972,37 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"jIR" = (
+/obj/effect/decal/waste,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "jJS" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"jJT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"jJW" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "jKm" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
 /obj/item/kitchen/rollingpin,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "jKu" = (
@@ -6612,7 +11027,7 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "jMO" = (
@@ -6627,6 +11042,26 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"jNB" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"jOT" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
+"jPo" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "jPq" = (
 /obj/machinery/door/airlock/grunge/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -6642,10 +11077,31 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"jQx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"jQC" = (
+/obj/structure/table/glass,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "jQJ" = (
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "jRE" = (
@@ -6655,6 +11111,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"jRX" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"jSy" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "jSA" = (
 /obj/item/ammo_box/magazine/w308/empty,
 /obj/effect/decal/cleanable/dirt,
@@ -6662,6 +11132,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"jSH" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "jST" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -6671,10 +11148,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jTp" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jTs" = (
 /obj/structure/chair/left,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"jTI" = (
+/obj/machinery/vending/donksofttoyvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "jTN" = (
 /obj/structure/debris/v3,
 /obj/structure/debris/v3{
@@ -6727,7 +11217,7 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "jWl" = (
@@ -6744,12 +11234,38 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"jWK" = (
+/obj/structure/chair/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jWN" = (
+/obj/item/stack/sheet/glass/ten,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"jXh" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "jXF" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"jXK" = (
+/obj/structure/reagent_dispensers/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"jXV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "jYk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -6769,10 +11285,26 @@
 /obj/structure/toilet,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"jYw" = (
+/obj/structure/table,
+/obj/item/ship_in_a_bottle,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "jZj" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"jZn" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "jZy" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -6799,10 +11331,28 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"kaN" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "kbb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"kbR" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
+"kbY" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"kcj" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kct" = (
 /obj/machinery/light{
@@ -6822,12 +11372,27 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"kcI" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "kdm" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"keg" = (
+/obj/structure/sign/poster/prewar/protectron,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/bunker)
 "kej" = (
 /obj/machinery/door/airlock/hatch,
@@ -6850,14 +11415,25 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kfQ" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "kfV" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "kgd" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/water,
+/area/f13/bunker)
+"kgl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kgA" = (
 /obj/item/storage/trash_stack,
@@ -6891,9 +11467,21 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"khD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
 "khO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"kib" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "kix" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -6907,22 +11495,64 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"kjw" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kjF" = (
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
 /area/f13/wasteland)
 "kkb" = (
 /obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old";
+	icon_state = "floor5-old"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"kkh" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"kkF" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "klB" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"klR" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"kmd" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "kne" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -6951,15 +11581,33 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "kpf" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"kpp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "kpx" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/freezer,
 /area/f13/followers)
+"kpM" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "kqh" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
@@ -7010,7 +11658,7 @@
 /obj/machinery/light/small,
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "ksA" = (
@@ -7023,6 +11671,11 @@
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ktB" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ktN" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7035,14 +11688,27 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "ktT" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubble"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/wasteland)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "kuh" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/legion)
+"kuK" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "kuL" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/desert,
@@ -7080,7 +11746,7 @@
 	pixel_x = -12
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ncr)
 "kwc" = (
@@ -7093,7 +11759,7 @@
 /area/f13/bunker)
 "kwf" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -7106,7 +11772,7 @@
 /area/f13/underground/cave)
 "kwO" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
 "kwR" = (
@@ -7125,9 +11791,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kyH" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"kyJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "kyK" = (
 /turf/closed/wall/mineral/iron,
 /area/f13/ncr)
+"kzc" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "kzB" = (
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "31"
@@ -7144,6 +11829,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"kzP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "kzQ" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
@@ -7161,6 +11855,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"kCh" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "kCN" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7175,6 +11874,66 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/underground/cave)
+"kDq" = (
+/obj/structure/flora/ausbushes/palebush{
+	pixel_x = 9
+	},
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/lavendergrass{
+	pixel_x = 20
+	},
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_x = -3
+	},
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"kDF" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 20;
+	pixel_y = 3
+	},
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"kDV" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"kDZ" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"kED" = (
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"kFh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"kFq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "kFI" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -7184,7 +11943,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "kFX" = (
@@ -7206,6 +11965,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"kGb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "kGB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -7216,6 +11981,11 @@
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"kGX" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kHa" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/food,
@@ -7226,10 +11996,36 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"kHC" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"kIw" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kIx" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"kIH" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	network = list("Vault")
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "kIJ" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7261,6 +12057,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"kJn" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kJx" = (
 /obj/structure/barricade/wooden{
 	max_integrity = 30;
@@ -7276,6 +12080,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"kJQ" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "kJZ" = (
 /obj/structure/window{
 	dir = 8
@@ -7294,9 +12104,25 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"kKg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"kKu" = (
+/obj/machinery/vending/coffee,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "kKx" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -7316,6 +12142,15 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"kMx" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "kMS" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/green,
@@ -7340,6 +12175,23 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"kNS" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "kOP" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -7354,6 +12206,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"kPr" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "kPt" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7379,10 +12239,35 @@
 "kQb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/followers)
+"kQz" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"kRb" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
 "kRA" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "kSo" = (
@@ -7395,10 +12280,39 @@
 /obj/item/clothing/glasses/night/syndicate,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"kSq" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"kSs" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"kSW" = (
+/obj/effect/decal/waste{
+	pixel_x = 18;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "kSZ" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"kTd" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "kTA" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -7407,18 +12321,22 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/f13,
 /area/f13/followers)
+"kUx" = (
+/obj/structure/timeddoor,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "kUW" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "kVV" = (
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/ncr)
 "kWd" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_2";
+	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -7444,6 +12362,38 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"kXO" = (
+/obj/structure/sign/departments/botany,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"kYj" = (
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"kYt" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"kYO" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "kZn" = (
 /obj/item/reagent_containers/pill/patch/bitterdrink,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7452,7 +12402,7 @@
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife/butcher,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "kZI" = (
@@ -7460,9 +12410,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"kZJ" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"lao" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "las" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"laE" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"laK" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"laL" = (
+/obj/structure/easel,
+/obj/item/paper/pamphlet/ruin/originalcontent/yelling,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "laW" = (
 /obj/structure/stone_tile/burnt,
@@ -7483,6 +12467,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"lbs" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "lbJ" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7491,7 +12484,7 @@
 /obj/structure/dresser,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "lbQ" = (
@@ -7517,7 +12510,7 @@
 /area/f13/followers)
 "lex" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbrokenvertical";
+	icon_state = "ruinswindowbrokenvertical"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -7568,6 +12561,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"lgg" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"lgn" = (
+/obj/machinery/chem_master/advanced,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "lgD" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -7579,6 +12585,16 @@
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lgV" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "lhe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -7604,7 +12620,7 @@
 "lir" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/legion)
 "lit" = (
@@ -7617,15 +12633,36 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ljY" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/poddoor/shutters{
+	id = "meat";
+	name = "Old Suspicious Wall"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "lki" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ncr)
+"lkr" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"lkw" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lkz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -7637,11 +12674,44 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"lkB" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"lkD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"llq" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lly" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"llI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
 "lmb" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
@@ -7657,11 +12727,33 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"lmH" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lmX" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/f13/vault,
+/turf/open/water,
+/area/f13/bunker)
+"lnK" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "lnL" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "lnQ" = (
@@ -7679,6 +12771,29 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lom" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
+"lor" = (
+/obj/item/storage/belt/utility/full/engi,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "loR" = (
 /obj/machinery/light{
 	dir = 4
@@ -7687,6 +12802,16 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"lpq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"lpv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "lqa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -7694,11 +12819,10 @@
 	},
 /area/f13/bunker)
 "lqv" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "lqU" = (
 /obj/structure/decoration/rag,
 /turf/closed/indestructible/riveted/boss{
@@ -7734,6 +12858,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"lsr" = (
+/obj/structure/table,
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "lsu" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 4
@@ -7747,6 +12881,13 @@
 	},
 /turf/closed/wall/mineral/iron,
 /area/f13/ncr)
+"lty" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "ltA" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7754,10 +12895,16 @@
 "ltC" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"ltF" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ltN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -7782,6 +12929,15 @@
 /obj/effect/decal/riverbank,
 /turf/open/water,
 /area/f13/wasteland)
+"lul" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
 "lum" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7792,6 +12948,12 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"luz" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
 "luG" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -7844,7 +13006,7 @@
 	},
 /obj/item/soap/deluxe,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "lwL" = (
@@ -7859,10 +13021,47 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"lxr" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"lxG" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"lxR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "lyG" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lyL" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/guides/jobs/engi/solars{
+	info = "<h1>Welcome</h1><p>At Vault-Tec, your survival is our number one priority, enclosed within is a notice on your Casp System.</p><p>Thank you for joining in Vault-Tec's mandatory testing of the brand new C.A.S.P. system! The CASP, or Computerized Auto-Synthesis Protofabricator, is a new high tech design using a simple 'points' system to create anything you need! Simply feed the requested high priority items orany day to day crates and metals to synthesize points.</p><p>That's all there is to it!</p>";
+	name = "paper- 'Your very first C.A.S.P. system!'"
+	},
+/obj/item/stamp/qm,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "lzU" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -7876,6 +13075,11 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"lAi" = (
+/obj/machinery/power/terminal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "lAC" = (
 /obj/structure/guncase,
 /turf/open/floor/f13{
@@ -7884,11 +13088,11 @@
 /area/f13/ncr)
 "lAI" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "lBe" = (
@@ -7907,9 +13111,30 @@
 /obj/machinery/light/floor,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"lBH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
+/area/f13/radiation)
 "lBO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"lCm" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/mob/living/simple_animal/hostile/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "lCx" = (
 /obj/structure/decoration/rag,
@@ -7931,9 +13156,21 @@
 	light_color = "#c1caff"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"lDz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"lDC" = (
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "lDQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7965,7 +13202,7 @@
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "lFS" = (
@@ -7974,9 +13211,26 @@
 	light_color = "#706891"
 	},
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"lFU" = (
+/obj/structure/sign/departments/medbay,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"lGt" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "lGv" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -7992,11 +13246,30 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lHm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"lHY" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lIb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"lIl" = (
+/obj/structure/bedsheetbin,
+/obj/structure/table,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lIo" = (
 /obj/structure/rack,
 /obj/item/seeds/berry,
@@ -8019,12 +13292,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"lJf" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "lJw" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"lJB" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/bunker)
 "lJS" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/indestructible/vaultdoor,
@@ -8040,11 +13332,44 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"lKH" = (
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"lKQ" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"lLN" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "lLW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"lMd" = (
+/obj/item/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "lMw" = (
 /obj/structure/ladder/unbreakable{
 	desc = "A long march back to the camp down-river... fun...";
@@ -8057,10 +13382,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lMD" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"lNi" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "lNt" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
+	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "lNN" = (
@@ -8070,6 +13404,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"lNR" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "lNS" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -8083,16 +13424,41 @@
 "lOu" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"lOU" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"lPa" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "lPk" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
+"lPp" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "lPB" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
+	},
+/area/f13/bunker)
+"lPD" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
 "lPL" = (
@@ -8105,12 +13471,23 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lQm" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8;
+	flicker_chance = 20;
+	light_color = "#e8eaff"
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "lQn" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "lQv" = (
@@ -8128,7 +13505,7 @@
 /area/f13/ncr)
 "lRh" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
@@ -8163,6 +13540,32 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"lTo" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"lTz" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"lTT" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "lTV" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -8198,12 +13601,30 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"lWw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"lXr" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "lXy" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"lXG" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/bunker)
 "lXH" = (
 /obj/structure/closet,
@@ -8218,21 +13639,31 @@
 /area/f13/bunker)
 "lXR" = (
 /obj/structure/toilet{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ncr)
+"lYr" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "lZe" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/ncr)
 "lZr" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"lZz" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "lZM" = (
 /obj/structure/table,
@@ -8249,6 +13680,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"mai" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
 "mal" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -8286,6 +13725,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"mbw" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mbP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -8331,6 +13778,14 @@
 /obj/structure/chalkboard,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"mew" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "meG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -8348,6 +13803,18 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"meT" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "meV" = (
 /obj/structure/chair{
 	dir = 4
@@ -8358,16 +13825,77 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mfm" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"mfv" = (
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"mfJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mgb" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/wasteland)
+"mgm" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
+/area/f13/bunker)
+"mgD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "mhQ" = (
 /obj/structure/fireplace,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"mhV" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "mig" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/ruins,
@@ -8378,6 +13906,42 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"miZ" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/collectable/tophat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"mjV" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"mjX" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"mkK" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"mlf" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"mlu" = (
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "mlw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button{
@@ -8394,6 +13958,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"mlO" = (
+/obj/structure/sign/poster/official/foam_force_ad,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "mmd" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -8407,6 +13976,9 @@
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
+"mnh" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "mnL" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8425,6 +13997,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/legion)
+"moW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"mpl" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "mpp" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -8437,20 +14022,53 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"mpQ" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "mpT" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"mqh" = (
+/obj/structure/chair/office/light,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "mqp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"mqv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "mqE" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"mrd" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mrw" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "mrI" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 8
@@ -8466,6 +14084,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mrX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "msa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -8480,6 +14106,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"msr" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/f13/bunker)
 "mtl" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
@@ -8503,6 +14134,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"mtA" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "mtB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -8515,11 +14151,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mtT" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "mvo" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/desert,
@@ -8541,11 +14176,39 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/bunker)
+"mwU" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mxd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"mxh" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mxq" = (
 /turf/closed/indestructible/wood{
 	desc = "A wall with wooden plating. Stiff, and knocking on it indictates that the wood is just a covering for some heavily-reinforced machinery."
 	},
 /area/f13/underground/cave)
+"mxI" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "myb" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/f13/wood{
@@ -8562,6 +14225,19 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"myL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"myX" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "mzy" = (
 /obj/structure/safe/floor,
@@ -8601,12 +14277,40 @@
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"mBb" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"mBt" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"mBx" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/bunker)
 "mBD" = (
 /obj/structure/fence/corner{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mBM" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "mBR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -8636,6 +14340,12 @@
 "mCR" = (
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
 /area/f13/wasteland)
+"mDd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mDF" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
@@ -8666,6 +14376,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"mEL" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "mFp" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8679,6 +14394,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"mFy" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/remains/human,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "mFX" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/carpet/green,
@@ -8688,12 +14409,18 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"mGw" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "mGy" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "mHn" = (
 /obj/structure/debris/v4{
 	pixel_x = -10;
@@ -8720,11 +14447,26 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mIf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/bunker)
 "mIo" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
+	},
+/area/f13/bunker)
+"mIZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mJS" = (
+/obj/item/dice/d20,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
 "mJU" = (
@@ -8734,6 +14476,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"mKt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"mKA" = (
+/obj/structure/toilet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"mKS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/human/core,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "mLd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8741,6 +14496,27 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"mLo" = (
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
+"mLK" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"mMe" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "mNp" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -8763,18 +14539,63 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "mNU" = (
 /obj/structure/debris/v3,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
-"mQi" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+"mOz" = (
+/mob/living/simple_animal/hostile/raider/firefighter,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"mOX" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"mPh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/f13/bunker)
+"mPD" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"mPJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"mQi" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"mQk" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "mQl" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8782,19 +14603,27 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mQy" = (
+/obj/structure/table/reinforced,
+/obj/item/scalpel,
+/obj/item/surgical_drapes,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "mQB" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetUSA";
+	icon_state = "sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
 /obj/item/bedsheet{
-	icon_state = "sheetbrown";
+	icon_state = "sheetbrown"
 	},
 /obj/item/bedsheet{
-	icon_state = "sheetblue";
+	icon_state = "sheetblue"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -8802,11 +14631,32 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"mQZ" = (
+/obj/structure/table,
+/obj/item/kitchen/knife{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "mRc" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"mRi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
+"mRR" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "mRW" = (
 /obj/effect/decal/remains/human,
@@ -8852,11 +14702,17 @@
 "mTB" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/legion)
+"mUc" = (
+/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/water,
+/area/f13/bunker)
 "mUs" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "mUu" = (
@@ -8888,6 +14744,21 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mWU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/bunker)
+"mWY" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/bunker)
 "mXh" = (
 /obj/structure/closet/bus,
 /obj/structure/ladder/unbreakable{
@@ -8902,6 +14773,14 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"mXi" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/compact/combat,
+/obj/item/stock_parts/cell/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "mXj" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
@@ -8911,6 +14790,11 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/underground/cave)
+"mXz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "mXD" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/item/flag/legion,
@@ -8919,6 +14803,13 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"mXR" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "mYj" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -8930,6 +14821,20 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"mYv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"mZm" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "mZy" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -8956,10 +14861,21 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"naG" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "naO" = (
 /obj/structure/dresser,
 /obj/item/stack/medical/gauze/cyborg,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"nbg" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "nbq" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -8969,7 +14885,7 @@
 "nbA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar";
+	icon_state = "rubblepillar"
 	},
 /area/f13/wasteland)
 "nck" = (
@@ -9003,6 +14919,28 @@
 /obj/item/trash/f13/steak,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"neR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"nfu" = (
+/obj/structure/debris/v3{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"ngr" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/bunker)
 "nha" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -9015,7 +14953,7 @@
 "nhp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -9026,7 +14964,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "nif" = (
@@ -9045,6 +14983,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"nlg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "nma" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9088,6 +15030,29 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"noh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/decal/remains/human,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"noo" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"noP" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "noR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -9125,10 +15090,21 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nqq" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nqt" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nqG" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "nqI" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -9136,12 +15112,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"nqM" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nrc" = (
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"nru" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "1"
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
 	},
 /area/f13/bunker)
 "nrx" = (
@@ -9158,10 +15153,28 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"nsf" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "nsh" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nso" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"nsq" = (
+/obj/structure/rack,
+/obj/item/storage/box/donkpockets,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nss" = (
 /obj/effect/turf_decal{
 	dir = 9
@@ -9189,6 +15202,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nun" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/broken,
+/obj/structure/flora/junglebush/b,
+/obj/structure/mirelurkegg,
+/mob/living/simple_animal/hostile/mirelurk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "nux" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -9209,6 +15233,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nvs" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "nvZ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -9231,6 +15260,30 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"nwU" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"nxJ" = (
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"nxO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Crematorium"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nxQ" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -9247,12 +15300,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"nyc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "nye" = (
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"nyG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/multitool/uplink,
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "nyV" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -9265,19 +15337,29 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"nzm" = (
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "nzL" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"nAb" = (
+/obj/structure/campfire/barrel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "nAr" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt";
+/obj/machinery/door/airlock{
+	name = "Hydroponics"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "nBS" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/light,
@@ -9313,6 +15395,15 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr)
+"nDY" = (
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nED" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light,
@@ -9340,18 +15431,39 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"nFu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "nGs" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"nIf" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/medical.dmi';
+	name = "Vault 223 Chemestry area"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "nIh" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
+"nJg" = (
+/obj/structure/table/glass,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "nKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -9362,6 +15474,35 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"nKt" = (
+/obj/structure/table/reinforced,
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/water,
+/area/f13/bunker)
+"nLy" = (
+/obj/structure/sign/poster/prewar/corporate_espionage,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"nLC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"nLD" = (
+/obj/structure/table,
+/obj/item/crafting/duct_tape,
+/obj/item/crafting/duct_tape,
+/obj/item/crafting/lunchbox,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "nLF" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -9369,12 +15510,28 @@
 	},
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
+"nMd" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nMp" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "nMx" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar";
+	icon_state = "rubblepillar"
 	},
 /area/f13/ncr)
 "nMG" = (
@@ -9396,6 +15553,15 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"nNo" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "nNv" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/carpet/green,
@@ -9406,10 +15572,31 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"nNL" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"nNU" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"nOl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "nOq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "nOK" = (
@@ -9417,25 +15604,83 @@
 /obj/item/stack/medical/gauze/cyborg,
 /turf/open/floor/carpet/black,
 /area/f13/bunker)
+"nOO" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"nOQ" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "nOU" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"nOY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"nPg" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 20;
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "nPL" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
 /area/f13/underground/cave)
+"nQm" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side,
+/area/f13/bunker)
+"nQZ" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "nRc" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nRE" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "nSg" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/outside/desert,
@@ -9467,6 +15712,26 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"nUD" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"nVq" = (
+/obj/item/wallframe/button,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "nVX" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -9477,6 +15742,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"nWO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"nWW" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "nXK" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -9509,9 +15784,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"nZt" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "nZK" = (
 /obj/structure/toilet{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
@@ -9520,6 +15801,26 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"oac" = (
+/obj/structure/reagent_dispensers/barrel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oaO" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/door/airlock/science,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"obJ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "obK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/decal/cleanable/dirt,
@@ -9547,6 +15848,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ocQ" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "ocT" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light{
@@ -9563,6 +15870,12 @@
 /obj/item/trash/can,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"oef" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "oem" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold{
@@ -9581,6 +15894,20 @@
 	},
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"oeL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/f13/bunker)
 "oeT" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -9594,6 +15921,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"ofn" = (
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ofT" = (
 /obj/structure/timeddoor/sixtyminute,
 /obj/structure/obstacle/barbedwire{
@@ -9601,9 +15932,26 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ogs" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "ogw" = (
 /obj/structure/debris/v3,
 /obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"ogI" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ogM" = (
@@ -9616,7 +15964,7 @@
 "ohr" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "ohu" = (
@@ -9634,16 +15982,40 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ohX" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"oif" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
+/area/f13/bunker)
 "oih" = (
 /obj/item/flag/ncr,
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oin" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"oiz" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "oiD" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "oiE" = (
@@ -9655,6 +16027,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"oiT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
 	},
 /area/f13/bunker)
 "okb" = (
@@ -9710,6 +16091,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"olg" = (
+/obj/machinery/door/airlock/freezer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"olu" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "olH" = (
 /obj/machinery/doorButtons/vaultButton,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -9720,6 +16115,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"olV" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"omi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "omr" = (
 /obj/effect/turf_decal,
@@ -9738,6 +16147,13 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground,
 /area/f13/wasteland)
+"onQ" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "onX" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
@@ -9751,6 +16167,25 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"opn" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oqm" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"oqD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "oqP" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/f13{
@@ -9773,11 +16208,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"orJ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "orS" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"osa" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "osf" = (
 /obj/machinery/chem_master/primitive,
 /obj/effect/decal/cleanable/dirt{
@@ -9788,6 +16244,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/bunker)
+"osh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "osu" = (
 /obj/effect/turf_decal{
 	dir = 6
@@ -9796,12 +16261,45 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"osy" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"osO" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"otg" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "otN" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"otT" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ouu" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "ouE" = (
 /obj/item/rack_parts,
 /obj/item/storage/trash_stack,
@@ -9816,6 +16314,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"ovh" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "ovl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -9826,15 +16332,46 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"ovu" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ovJ" = (
 /obj/structure/table/wood,
 /obj/item/paper,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"owr" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"oxg" = (
+/obj/structure/timeddoor,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oxt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"oyq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
+"oyE" = (
+/obj/structure/window/plastitanium,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oyK" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -9848,16 +16385,26 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"ozh" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ozw" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "ozL" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken";
+	icon_state = "ruinswindowbroken"
 	},
 /obj/structure/curtain{
 	color = "#845f58"
@@ -9879,9 +16426,37 @@
 	},
 /turf/closed/wall/mineral/iron,
 /area/f13/underground/cave)
+"oAN" = (
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "oAO" = (
 /turf/open/indestructible/ground,
 /area/f13/wasteland)
+"oAX" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oBt" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"oCe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/water,
+/area/f13/bunker)
 "oCs" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -9903,11 +16478,23 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"oCQ" = (
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "oCX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"oDr" = (
+/obj/item/bodypart/l_leg/monkey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "oDM" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13{
@@ -9944,6 +16531,41 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/bunker)
+"oHn" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"oHz" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"oIK" = (
+/obj/structure/bed/dogbed,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"oIM" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oIO" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "oIQ" = (
 /obj/machinery/door/airlock/hatch{
@@ -9990,11 +16612,40 @@
 /obj/item/ammo_box/a762box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"oKD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/glowshroom/single,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"oKE" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"oKM" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "oKT" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oKW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "oLr" = (
 /obj/machinery/light{
@@ -10002,6 +16653,17 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"oLJ" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "oLN" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -10017,6 +16679,12 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"oMq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "oMF" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -10026,6 +16694,15 @@
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
+	},
+/area/f13/bunker)
+"oMH" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
 "oMJ" = (
@@ -10075,6 +16752,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"oNl" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -15
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"oNr" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "oOr" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -10084,7 +16775,7 @@
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "oOD" = (
@@ -10093,6 +16784,10 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"oOY" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "oPl" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -10104,6 +16799,14 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"oPB" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "oPI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -10113,17 +16816,43 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"oPM" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "oPO" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
 	},
 /area/f13/wasteland)
+"oQo" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "oQq" = (
 /obj/structure/fence{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oQH" = (
+/obj/effect/decal/remains/human,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
+"oRg" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "oRr" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -10138,9 +16867,20 @@
 "oRP" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/wasteland)
+"oRX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oSe" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -10152,6 +16892,22 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"oSu" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"oSz" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"oTE" = (
+/obj/structure/sign/departments/custodian,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "oUE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10163,6 +16919,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"oUP" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
 /area/f13/bunker)
 "oUQ" = (
 /obj/structure/fence/corner{
@@ -10185,6 +16947,16 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"oVm" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "oVn" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -10195,6 +16967,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"oVP" = (
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/reagent_containers/blood/universal,
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "oWb" = (
 /obj/effect/decal/remains/human,
@@ -10220,6 +17005,14 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"oXd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "oXI" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
@@ -10235,12 +17028,17 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "oXY" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"oYt" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "oZo" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -10249,6 +17047,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"oZr" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "oZP" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -10326,9 +17131,19 @@
 "pdg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pey" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "pez" = (
 /obj/structure/chair{
 	dir = 4
@@ -10348,6 +17163,22 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"peJ" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/paper_bin,
+/obj/item/stamp,
+/obj/item/stamp/denied,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"pfj" = (
+/obj/structure/closet/crate/radiation,
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "pfl" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -10357,19 +17188,34 @@
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"pfz" = (
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "pfQ" = (
 /obj/effect/landmark/poster_spawner/ncr,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr)
+"pgk" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pgv" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"pgD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 8
+	},
 /area/f13/bunker)
 "phh" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "phB" = (
@@ -10379,7 +17225,7 @@
 /area/f13/bunker)
 "phP" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -10395,6 +17241,20 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"pim" = (
+/obj/structure/table/booth,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/f13/rotten,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "piN" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -10419,6 +17279,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"pja" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pjh" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light/broken,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "pjm" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -10433,6 +17308,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"pjF" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "pjT" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10442,6 +17324,14 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
+/area/f13/bunker)
+"pkN" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "pkU" = (
 /obj/structure/table,
@@ -10460,6 +17350,10 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"plr" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "plB" = (
 /obj/machinery/light{
 	dir = 4
@@ -10475,6 +17369,24 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pma" = (
+/obj/effect/spawner/lootdrop/minor/bowler_or_that,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"pmi" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pmq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "pmQ" = (
 /obj/effect/decal/fakelattice,
@@ -10493,6 +17405,17 @@
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"pnm" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pnp" = (
+/obj/machinery/light/broken,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "pny" = (
 /obj/structure/car/rubbish2,
@@ -10523,6 +17446,11 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
+"pph" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "ppq" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat/security,
@@ -10531,6 +17459,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"ppx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "ppF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10563,15 +17496,65 @@
 /obj/machinery/light,
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"prg" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"prh" = (
+/obj/structure/sign/poster/official/report_crimes,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "psd" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
+"psm" = (
+/obj/structure/debris/v3{
+	pixel_y = -10
+	},
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"pug" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "pup" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/security,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
+/area/f13/bunker)
+"pvj" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "pvG" = (
 /obj/structure/simple_door/metal/barred,
@@ -10585,12 +17568,45 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"pxv" = (
+/obj/structure/table,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pxQ" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pxS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"pyq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "overseerexit";
+	name = "overseer button"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"pyA" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"pyZ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pzh" = (
 /obj/structure/rack,
@@ -10628,17 +17644,55 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"pBl" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+"pzH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pzK" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"pAv" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pAO" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"pBl" = (
+/obj/machinery/vending/hydronutrients,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "pBt" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"pBP" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "pBV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -10651,6 +17705,16 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pCG" = (
+/obj/structure/table,
+/obj/item/wrench/power,
+/obj/item/weldingtool/experimental{
+	pixel_x = -27;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "pDu" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -10672,6 +17736,18 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"pEy" = (
+/mob/living/simple_animal/hostile/mirelurk/baby,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"pEP" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "pEQ" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10682,6 +17758,28 @@
 /obj/item/reagent_containers/food/snacks/burger/superbite,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pFF" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"pFU" = (
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"pGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "pGc" = (
 /obj/machinery/light{
 	dir = 8
@@ -10709,6 +17807,49 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"pHQ" = (
+/obj/structure/simple_door/metal/barred,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"pHU" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"pIg" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"pIp" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"pIr" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "pII" = (
 /obj/item/soap/deluxe,
 /obj/effect/decal/cleanable/dirt,
@@ -10721,10 +17862,31 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"pJg" = (
+/obj/structure/flora/rock/pile/largejungle,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"pJh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "pJp" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/f13{
 	icon_state = "bar"
+	},
+/area/f13/bunker)
+"pJB" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "pKe" = (
@@ -10739,6 +17901,12 @@
 /obj/item/crafting/reloader,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"pKV" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "pLe" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -10782,10 +17950,30 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"pMD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "pMU" = (
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"pNo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pNr" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "pNs" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -10793,6 +17981,11 @@
 /obj/item/card/id/prisoner/five,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pNt" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "pNy" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -10819,6 +18012,25 @@
 /obj/item/key,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"pPc" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"pPe" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pPg" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "pPi" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate/freezer/blood,
@@ -10840,12 +18052,27 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"pPR" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "pQo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/underground/cave)
+"pQO" = (
+/obj/machinery/button/door{
+	id = "stalin";
+	name = "Overseer door button"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pQU" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -10857,6 +18084,12 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"pRz" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pRW" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -10890,6 +18123,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/bunker)
+"pSW" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/f13/mfp/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "pSZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -10900,10 +18141,25 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
 /area/f13/bunker)
+"pTv" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "pTK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pTS" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "pTX" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -10921,15 +18177,24 @@
 /turf/closed/indestructible/wood,
 /area/f13/city)
 "pVg" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	pixel_x = 14
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"pVK" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"pVO" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "pWp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -10949,6 +18214,63 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"pWZ" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"pXb" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"pXl" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"pXt" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"pXu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/timeddoor/sixtyminute,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/water,
+/area/f13/bunker)
+"pXG" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"pXU" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"pXV" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"pYh" = (
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/bunker)
 "pYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10962,6 +18284,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"pYU" = (
+/obj/machinery/light,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "pZh" = (
 /obj/item/candle/tribal_torch,
 /obj/structure/flora/grass/wasteland{
@@ -10974,7 +18304,7 @@
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
 "pZu" = (
@@ -10984,6 +18314,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"pZw" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "pZQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10992,6 +18329,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qay" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"qaE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "qaT" = (
 /obj/item/locked_box/misc/blueprints/tier1,
 /turf/open/floor/f13/wood{
@@ -11001,13 +18353,34 @@
 "qbd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
+	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
+"qbQ" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "qbS" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"qce" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qcl" = (
 /obj/effect/decal/waste,
 /obj/effect/mob_spawn/human/corpse,
@@ -11054,6 +18427,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"qeW" = (
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"qfs" = (
+/obj/structure/sign/departments/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "qfH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -11087,6 +18469,15 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"qgV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qgZ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -11112,6 +18503,17 @@
 	icon_state = "bluemark"
 	},
 /area/f13/followers)
+"qhE" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/empty_sleeper/nanotrasen{
+	desc = "A medical sleeper - this one appears broken. There are exposed bolts for easy disassembly using a wrench.";
+	name = "broken sleeper"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "qhO" = (
 /obj/structure/decoration/vent,
 /obj/machinery/shower{
@@ -11149,6 +18551,24 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"qkl" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"qkm" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"qkP" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/machinery,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "qkZ" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/f13/wood,
@@ -11162,6 +18582,13 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland)
+"qll" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qlZ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11175,6 +18602,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qmF" = (
+/obj/machinery/door/window/brigdoor{
+	icon_state = "rightsecure";
+	req_access_txt = "31"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution,
+/area/f13/radiation)
 "qnc" = (
 /obj/effect/decal/remains/robot,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -11186,6 +18621,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"qnA" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "qnF" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -11195,6 +18636,14 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"qnJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qnQ" = (
 /obj/item/surgical_drapes,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11208,14 +18657,32 @@
 /area/f13/underground/cave)
 "qos" = (
 /obj/structure/chair{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"qoz" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/poddoor/shutters{
+	id = "stalin";
+	name = "Old Suspicous Wall"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "qoA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"qoX" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "qpl" = (
 /obj/structure/rack,
@@ -11223,6 +18690,11 @@
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qpJ" = (
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qqa" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11230,7 +18702,7 @@
 "qqb" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "qql" = (
@@ -11267,11 +18739,30 @@
 /obj/item/key,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"qqR" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qrc" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"qrF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"qrN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "qrP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -11286,16 +18777,47 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qsn" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "qso" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"qss" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"qsy" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"qsz" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "qtf" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qtK" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "qtS" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/tentwall,
@@ -11303,9 +18825,16 @@
 "quK" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"qvf" = (
+/obj/machinery/button/door{
+	id = "meat";
+	name = "Unknown Button"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "qvi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11325,13 +18854,39 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"qvA" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "qvE" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"qwp" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"qwH" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "qwQ" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11392,7 +18947,7 @@
 /area/f13/legion)
 "qAk" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -11419,6 +18974,22 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qBl" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"qBm" = (
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "qBr" = (
 /obj/machinery/button/crematorium{
 	pixel_y = 19
@@ -11435,6 +19006,30 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/underground/cave)
+"qBQ" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/machinery/porta_turret/syndicate/vehicle_turret{
+	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
+	faction = list("raider");
+	lethal_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	name = "Repaired Turret";
+	scan_range = 9;
+	stun_projectile = /obj/item/projectile/bullet/a762/sport/simple;
+	stun_projectile_sound = 'sound/f13weapons/auto5.ogg';
+	throw_range = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"qBR" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "qCj" = (
 /obj/machinery/shower{
 	dir = 8
@@ -11453,9 +19048,35 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"qCx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "qCB" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"qCG" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
+"qDk" = (
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "qDm" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -11471,6 +19092,14 @@
 "qDz" = (
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"qDC" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "qDG" = (
 /obj/structure/toilet{
 	dir = 1
@@ -11480,9 +19109,14 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"qDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "qDX" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
+	icon_state = "rubbleplate"
 	},
 /area/f13/legion)
 "qEN" = (
@@ -11505,9 +19139,14 @@
 "qFN" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"qFT" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "qGv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11518,7 +19157,7 @@
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "qGS" = (
@@ -11540,6 +19179,27 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"qHz" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"qHD" = (
+/obj/structure/rack,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "qIK" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -11550,11 +19210,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "qJs" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/frame/machine,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "qJu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -11586,6 +19248,15 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"qKT" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 2;
+	id = "vaultc2";
+	name = "Cell 2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "qKV" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -11608,6 +19279,11 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qLh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
 "qLG" = (
 /obj/structure/fence{
 	dir = 4
@@ -11620,9 +19296,18 @@
 "qMB" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"qMG" = (
+/obj/structure/guncase/shotgun,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/f13/bunker)
 "qMQ" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Impassable Airlock"
@@ -11631,13 +19316,37 @@
 "qMS" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubblecorner";
+	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"qNT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"qNZ" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2"
+	},
+/obj/item/clothing/suit/f13/mfp/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"qOj" = (
+/obj/item/clothing/suit/toggle/lawyer,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qOo" = (
 /obj/structure/statue/sandstone/gravestone,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"qOu" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "qOQ" = (
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11656,15 +19365,24 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"qPk" = (
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "qPN" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"qQC" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "qTX" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "qUi" = (
@@ -11700,6 +19418,10 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"qVV" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qWe" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -11709,6 +19431,10 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qWh" = (
+/obj/structure/closet,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "qWp" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11716,20 +19442,46 @@
 "qWs" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetUSA";
+	icon_state = "sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
 	},
 /obj/item/bedsheet{
-	icon_state = "sheetgrey";
+	icon_state = "sheetgrey"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qXi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"qYN" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "qYU" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"qYW" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "qZC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11742,10 +19494,40 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qZR" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"raa" = (
+/obj/item/storage/fancy/rollingpapers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"raE" = (
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "raL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"raV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"rba" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "rbT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11763,9 +19545,19 @@
 "rcm" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"rcs" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rcu" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -11795,6 +19587,14 @@
 /obj/item/trash/f13/blamco_large,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"rdr" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
 "rdA" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/legion)
@@ -11804,6 +19604,10 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"rey" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "reI" = (
 /obj/structure/table,
@@ -11816,7 +19620,7 @@
 /area/f13/bunker)
 "reZ" = (
 /obj/structure/toilet{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -11873,11 +19677,27 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rgZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rhc" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bed/mattress/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"rhp" = (
+/obj/structure/nest/assaultron{
+	max_mobs = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rhv" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -11892,6 +19712,14 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"rhY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain{
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "rim" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11900,13 +19728,18 @@
 /area/f13/underground/cave)
 "riz" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
+	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"riO" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "riZ" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "rjm" = (
@@ -11942,6 +19775,14 @@
 	},
 /turf/open/water,
 /area/f13/underground/cave)
+"rll" = (
+/obj/structure/closet,
+/obj/item/instrument/violin/golden,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "rlS" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -11957,9 +19798,38 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/legion)
+"rmC" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"rmR" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rni" = (
 /obj/item/soap/homemade,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"rnu" = (
+/obj/structure/timeddoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"rnP" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "roj" = (
 /obj/structure/table,
@@ -11998,6 +19868,25 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"rpe" = (
+/obj/machinery/smartfridge/chemistry,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"rpj" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"rpr" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "rpF" = (
 /obj/structure/dresser,
 /turf/open/floor/f13{
@@ -12011,7 +19900,7 @@
 	},
 /turf/open/floor/f13{
 	dir = 10;
-	icon_state = "redmark";
+	icon_state = "redmark"
 	},
 /area/f13/legion)
 "rpO" = (
@@ -12020,6 +19909,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"rpQ" = (
+/obj/item/storage/wallet/random,
+/obj/structure/table,
+/obj/item/crafting/wonderglue,
+/obj/item/coin/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rqh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -12034,10 +19931,33 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"rqk" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = 102;
+	name = "Window Shutters"
+	},
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"rqt" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "rqD" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"rqL" = (
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "rqQ" = (
 /obj/structure/decoration/rag,
@@ -12048,6 +19968,18 @@
 	name = "temple wall"
 	},
 /area/f13/bunker)
+"rqW" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rrd" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "rri" = (
 /turf/open/water,
 /area/f13/underground/cave)
@@ -12055,11 +19987,62 @@
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"rrI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rrM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
+"rrR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"rrX" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"rse" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"rsi" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"rso" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rsN" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "rsR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13{
@@ -12074,10 +20057,41 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"rtb" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"rtc" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"rtf" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
 "rtm" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"rts" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "rtw" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
@@ -12091,6 +20105,10 @@
 	},
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rub" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rui" = (
 /obj/structure/simple_door/wood,
@@ -12151,6 +20169,10 @@
 "rwB" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/bunker)
+"rwM" = (
+/obj/effect/landmark/poster_spawner/prewar,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "rwX" = (
 /obj/structure/rack,
 /obj/item/clothing/under/syndicate/combat,
@@ -12179,6 +20201,15 @@
 "rym" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
+"ryr" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "ryN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -12188,15 +20219,98 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"ryT" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"rzi" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rzu" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
+"rzN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"rzU" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -32
+	},
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "rzV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"rAf" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"rAi" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"rAm" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
+"rBn" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"rBt" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"rBv" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "rBw" = (
 /obj/item/ammo_casing/a762,
@@ -12212,7 +20326,7 @@
 /area/f13/underground/cave)
 "rBF" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/wasteland)
 "rBI" = (
@@ -12230,10 +20344,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
+"rCa" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rCn" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"rCv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "rCA" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -12251,11 +20384,11 @@
 "rDD" = (
 /obj/structure/sink{
 	dir = 1;
-	pixel_y = 16;
+	pixel_y = 16
 	},
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "rDE" = (
@@ -12273,6 +20406,9 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"rEF" = (
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/bunker)
 "rEQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -12289,12 +20425,32 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"rFw" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"rFH" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "rGc" = (
 /obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowbroken";
+	icon_state = "ruinswindowbroken"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rGv" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "rGG" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12313,6 +20469,14 @@
 "rHH" = (
 /obj/structure/stone_tile/center/cracked,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"rIa" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "rIo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12338,12 +20502,25 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/water,
 /area/f13/underground/cave)
+"rJv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "rJx" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"rJD" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rKj" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light{
@@ -12362,9 +20539,14 @@
 "rLK" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rLU" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/radiation)
 "rMd" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -12381,7 +20563,7 @@
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab";
+	icon_state = "rubbleslab"
 	},
 /area/f13/ncr)
 "rNh" = (
@@ -12399,11 +20581,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"rNR" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck/syndicate,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"rOh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/vault{
+	locked = 1;
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rOn" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rOY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"rPk" = (
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "rPD" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -12416,7 +20626,7 @@
 "rQc" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
+	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
 "rQl" = (
@@ -12450,7 +20660,7 @@
 "rRy" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "rRN" = (
@@ -12462,7 +20672,7 @@
 "rSc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "rSo" = (
@@ -12472,10 +20682,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"rSu" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "rSw" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
 "rSx" = (
@@ -12499,9 +20714,17 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"rSI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "rTw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ncr)
 "rUC" = (
@@ -12540,9 +20763,16 @@
 "rVN" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate";
+	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"rVV" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rWt" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/f13/wood,
@@ -12570,11 +20800,29 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"rXJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "rYh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/radroach,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
+	},
+/area/f13/bunker)
+"rYA" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "rYL" = (
@@ -12588,14 +20836,33 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"rZa" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "rZh" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"rZt" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "rZx" = (
 /obj/structure/sign/poster/prewar/poster82,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"saz" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "sbC" = (
 /obj/effect/decal/cleanable/dirt{
@@ -12619,7 +20886,7 @@
 /area/f13/underground/cave)
 "scf" = (
 /obj/structure/decoration/rag{
-	icon_state = "skulls";
+	icon_state = "skulls"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -12631,6 +20898,14 @@
 "scR" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"sdi" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "sdj" = (
 /obj/structure/chair/wood/worn{
@@ -12654,11 +20929,29 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"seq" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "sev" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
 /area/f13/underground/cave)
+"seF" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"seM" = (
+/obj/structure/timeddoor,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "seN" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -12684,10 +20977,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"sgo" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 10
+	},
+/area/f13/bunker)
 "sgN" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/water,
+/area/f13/bunker)
+"sgO" = (
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
+/area/f13/bunker)
+"shh" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "shw" = (
 /obj/effect/decal/fakelattice,
@@ -12756,6 +21077,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"sjN" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"sko" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"skp" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "skB" = (
 /obj/machinery/shower{
 	dir = 1
@@ -12768,6 +21108,13 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/bunker)
+"skI" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/item/clothing/under/f13/vault,
+/turf/open/water,
+/area/f13/bunker)
 "skQ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/robot_debris/down,
@@ -12777,6 +21124,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"slh" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "slq" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/ruins,
@@ -12785,10 +21138,19 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"sml" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "smN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
@@ -12798,9 +21160,16 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"smX" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "sne" = (
 /obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
+	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -12818,6 +21187,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"soH" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"spi" = (
+/obj/structure/window/plastitanium,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "sqf" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -12828,12 +21212,45 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"sqr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/status_display/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"sqx" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sqy" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "sqO" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/underground/cave)
+"sqQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human{
+	layer = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sqR" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "sqU" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -12845,11 +21262,28 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"srL" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "ssJ" = (
 /obj/structure/closet/cabinet,
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
 /area/f13/underground/cave)
+"ssN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/bars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"str" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "stO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -12869,6 +21303,15 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"sut" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "suu" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -12901,6 +21344,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"svS" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/glowshroom/single,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "svU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12918,9 +21374,24 @@
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"swW" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sxd" = (
 /obj/item/trash/f13/cram,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"szh" = (
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "szp" = (
 /obj/structure/wreck/trash/machinepile,
@@ -12928,9 +21399,47 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"szv" = (
+/obj/structure/debris/v3,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"szB" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "szC" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/wasteland)
+"szG" = (
+/obj/item/folder/blue,
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "trap";
+	name = "Old Dusty Button"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sAd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"sAt" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "sAQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/mattress{
@@ -12956,12 +21465,20 @@
 "sCV" = (
 /obj/structure/closet,
 /obj/item/mop{
-	icon_state = "mopbucket";
+	icon_state = "mopbucket"
 	},
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"sDl" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "sDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/protectron{
@@ -12971,6 +21488,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"sEd" = (
+/obj/structure/debris/v3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"sEu" = (
+/mob/living/simple_animal/hostile/supermutant/legendary,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "sEC" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -12978,6 +21507,11 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"sEI" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "sET" = (
 /obj/effect/decal/remains/human,
@@ -12987,7 +21521,7 @@
 "sFp" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "twindowold";
+	icon_state = "twindowold"
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
@@ -13018,11 +21552,28 @@
 /obj/structure/chair/bench,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"sIx" = (
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "sIC" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
+"sID" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"sIP" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "sJn" = (
 /turf/closed/wall/f13/store,
 /area/f13/ncr)
@@ -13034,6 +21585,44 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"sJQ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"sJY" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"sJZ" = (
+/obj/structure/table,
+/obj/item/crafting/resistor,
+/obj/item/crafting/resistor,
+/obj/item/crafting/resistor,
+/obj/item/crafting/buzzer,
+/obj/item/crafting/capacitor,
+/obj/item/crafting/capacitor,
+/obj/item/crafting/diode,
+/obj/item/crafting/diode,
+/obj/item/crafting/diode,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "sKp" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13043,6 +21632,20 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"sKD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"sKF" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "sKJ" = (
@@ -13071,10 +21674,34 @@
 /obj/item/flag/oasis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"sMA" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "sMO" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"sMZ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
+"sNb" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "sNh" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -13088,6 +21715,12 @@
 /obj/structure/stone_tile/slab/burnt,
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"sOV" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "sPi" = (
 /obj/structure/timeddoor/sixtyminute,
@@ -13115,6 +21748,14 @@
 /obj/item/clothing/under/pants/black,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"sQg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "sQs" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -13147,6 +21788,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"sSH" = (
+/obj/structure/window/plastitanium,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "sSQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -13156,6 +21801,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"sSR" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
 "sST" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -13172,6 +21825,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/f13/underground/cave)
+"sTr" = (
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"sTt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "sTM" = (
 /obj/structure/table,
 /turf/open/floor/wood/wood_tiled,
@@ -13181,10 +21843,38 @@
 /obj/item/soap,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"sUk" = (
+/obj/item/wallframe/button,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
+"sUn" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/dresser,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "sUy" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"sUz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
 "sUH" = (
 /obj/structure/destructible/tribal_torch,
 /obj/item/flag/legion,
@@ -13206,18 +21896,69 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"sVo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"sVA" = (
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"sVP" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"sVY" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "sXf" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
-"sXK" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner";
+"sXh" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/bunker)
+"sXH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"sXK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "sXW" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13225,9 +21966,20 @@
 "sYe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
+"sZf" = (
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"sZh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "sZI" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13255,6 +22007,9 @@
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"tcp" = (
+/turf/closed/indestructible/rock,
+/area/f13/tunnel)
 "tdc" = (
 /obj/structure/chair/bench,
 /obj/machinery/light/small{
@@ -13269,12 +22024,26 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"tdM" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "teX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"tfs" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tfu" = (
 /obj/structure/spider/stickyweb,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -13291,6 +22060,11 @@
 /obj/item/flag/ncr,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"tgK" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "thb" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/candle/infinite{
@@ -13300,6 +22074,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"thc" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"tho" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "thD" = (
 /obj/structure/toilet{
 	dir = 4
@@ -13326,6 +22112,50 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"tiw" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"tiE" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -6
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
+"tiI" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old";
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"tiU" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"tjG" = (
+/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask,
+/obj/structure/rack,
+/obj/item/stack/crafting/electronicparts/three,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tjO" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
@@ -13333,15 +22163,26 @@
 /obj/structure/closet/fridge,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"tjW" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tjZ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "tkn" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13379,6 +22220,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"tly" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"tmq" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tmr" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing{
@@ -13414,6 +22264,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"toz" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "toC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -13426,6 +22279,20 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
+"tph" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"tpl" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "tpm" = (
 /obj/item/storage/trash_stack,
 /obj/structure/spider/stickyweb,
@@ -13433,6 +22300,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"tqt" = (
+/obj/structure/timeddoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "tqN" = (
 /obj/structure/wreck/trash/halftire,
@@ -13454,6 +22327,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"trH" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side,
+/area/f13/bunker)
 "trL" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/ruins,
@@ -13468,14 +22349,32 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tsb" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"tsk" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "tsJ" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("wastebot")
 	},
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"ttj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "ttw" = (
 /obj/structure/chair/wood/worn{
@@ -13492,6 +22391,29 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"tuh" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"tuO" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks,
+/turf/open/water,
+/area/f13/bunker)
 "tvF" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -13500,17 +22422,50 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"tvQ" = (
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "two" = (
 /obj/structure/simple_door/room{
-	icon_state = "glass";
+	icon_state = "glass"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"twX" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/spawner/lootdrop/glowstick/no_turf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "txb" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"txz" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"txL" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"txS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "txX" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -13553,15 +22508,46 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"tzJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
+"tAb" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "tAi" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"tBv" = (
+/obj/structure/campfire/stove,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "tCf" = (
 /obj/structure/stone_tile/block,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"tCz" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "tDi" = (
 /obj/item/trash/chips,
@@ -13586,6 +22572,32 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"tEN" = (
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tFs" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"tFJ" = (
+/mob/living/simple_animal/hostile/handy/assaultron/nsb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"tFW" = (
+/obj/item/storage/toolbox/electrical,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "tFY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -13596,6 +22608,36 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/bunker)
+"tGa" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/securitron/sentrybot{
+	color = "#FFFF00";
+	desc = "A pre-war military robot equipped with a high-yield gatling laser and improved dual fusion cores setup to detonate in the event of the robot's destruction. This one looks armored up and powered up to an exponential degree. Oh, fuck.";
+	extra_projectiles = 5;
+	health = 3500;
+	maxHealth = 3500;
+	melee_queue_distance = 15;
+	name = "legendary sentry bot"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tGk" = (
+/obj/structure/mirror,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
+"tGW" = (
+/obj/item/stack/crafting/electronicparts/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"tHb" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
 "tHp" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -13605,7 +22647,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "tHP" = (
@@ -13617,6 +22659,13 @@
 /area/f13/bunker)
 "tHQ" = (
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"tIg" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/f13/bunker)
 "tIn" = (
 /obj/item/ammo_casing/c9mm,
@@ -13632,6 +22681,21 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"tIZ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/handy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "tJb" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -13651,7 +22715,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "tKq" = (
@@ -13665,6 +22729,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"tKs" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "tKz" = (
 /obj/structure/bodycontainer/morgue,
 /obj/machinery/light/small{
@@ -13674,12 +22749,21 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/followers)
+"tLw" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tMi" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"tMv" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "tMG" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -13688,6 +22772,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/bunker)
+"tMK" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "tNd" = (
@@ -13704,6 +22795,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"tNQ" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "tNR" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -13711,16 +22809,52 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tOf" = (
+/obj/machinery/light/broken,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"tPj" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"tPo" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "tPK" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"tQq" = (
+/obj/item/clothing/under/f13/raiderharness,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "tQv" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"tRg" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress6"
+	},
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tRq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/f13/bunker)
 "tRH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -13735,19 +22869,33 @@
 /area/f13/underground/cave)
 "tSi" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"tSj" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 30
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "tSp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"tSt" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/kebab/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "tSv" = (
 /obj/item/storage/trash_stack{
@@ -13767,6 +22915,26 @@
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"tSP" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor4-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"tSV" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"tTf" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "tTi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -13774,6 +22942,16 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"tTB" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tTE" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "tTY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13829,16 +23007,88 @@
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"tXa" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "tXo" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
-"tXS" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2";
+"tXq" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"tXr" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"tXv" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"tXx" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"tXB" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/structure/toilet,
+/obj/item/seeds/apple/gold,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
+"tXL" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"tXS" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"tZi" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"tZj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/flask/survival,
+/turf/open/water,
+/area/f13/bunker)
 "tZn" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -13850,7 +23100,7 @@
 "tZr" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "tZG" = (
@@ -13882,21 +23132,80 @@
 /obj/item/rack_parts,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"ucX" = (
+/obj/machinery/door/airlock{
+	name = "Vault 223 Janitorial storage"
+	},
+/obj/structure/timeddoor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uda" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"udY" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"uea" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uef" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uel" = (
 /obj/structure/table,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ufr" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ufP" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"ugC" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"uha" = (
+/obj/machinery/camera/autoname{
+	dir = 9;
+	network = list("Vault")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/bunker)
+"uhl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "uhP" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "uhU" = (
@@ -13925,14 +23234,28 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uir" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "uiv" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"uiT" = (
+/obj/machinery/vending/snack/random,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "ujb" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/carpet/green,
@@ -13946,12 +23269,46 @@
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"ujF" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"ujL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "suka";
+	name = "Security shutters button"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "ujR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ukP" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex/nitrile{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/hooded/surgical{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "ulp" = (
 /obj/structure/chair/bench,
 /turf/open/floor/holofloor/carpet,
@@ -13963,13 +23320,34 @@
 "ulM" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"umg" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"umy" = (
+/obj/item/crafting/reloader,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "unv" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"unA" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "unM" = (
 /obj/machinery/seed_extractor,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -14009,6 +23387,20 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"upG" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
+"uqc" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "vaultshutters";
+	max_integrity = 999999999999;
+	resistance_flags = 242
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "uqg" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/legion)
@@ -14022,27 +23414,93 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"uqR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"uqW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
+"urj" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "uro" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"urp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "urr" = (
 /obj/item/ammo_casing/a762,
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"urz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "usZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"utc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_y = 32
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/f13/bunker)
+"utq" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "utv" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"utz" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/rock,
+/area/f13/tunnel)
 "utX" = (
 /obj/structure/stone_tile/center/burnt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14052,12 +23510,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"uua" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"uun" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "uuH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
+/area/f13/bunker)
+"uva" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "uvc" = (
 /turf/closed/wall/mineral/iron,
@@ -14069,6 +23547,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"uvE" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"uvG" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "uvS" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -14090,6 +23583,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"uwg" = (
+/obj/structure/bodycontainer/crematorium{
+	id = 700
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "uwh" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -14099,6 +23599,34 @@
 	icon_state = "purplefull"
 	},
 /area/f13/followers)
+"uwp" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"uwt" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uya" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/f13/bunker)
+"uyt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "uyw" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
@@ -14122,9 +23650,14 @@
 "uzL" = (
 /obj/item/shard,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
+"uzU" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "uAt" = (
 /obj/machinery/door/poddoor{
 	id = "lock3";
@@ -14139,14 +23672,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "uAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
 	dir = 4;
-	pixel_x = -15;
+	pixel_x = -15
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -14161,6 +23694,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uBg" = (
+/obj/effect/decal/remains/human,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
 "uBk" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -14172,10 +23709,18 @@
 /mob/living/simple_animal/chick,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uBt" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uCn" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
+	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
 "uDi" = (
@@ -14206,7 +23751,7 @@
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "uES" = (
@@ -14215,11 +23760,24 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"uEX" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "uFe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder";
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"uFj" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "uFm" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -14234,6 +23792,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"uGh" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "uGE" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -14241,6 +23803,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"uHp" = (
+/obj/machinery/button/door{
+	id = 103;
+	name = "Blast Doors";
+	pixel_x = 26
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "uHC" = (
 /obj/structure/closet/fridge,
 /obj/item/storage/fancy/egg_box,
@@ -14273,6 +23847,24 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"uIU" = (
+/obj/machinery/door/airlock/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"uJc" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"uJq" = (
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "uJu" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/item/stock_parts/cell/ammo/mfc,
@@ -14304,6 +23896,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"uLt" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
 "uLK" = (
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14313,6 +23913,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"uMy" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "uMG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -14326,6 +23932,31 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland)
+"uMQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/ammo_casing/c9mm,
+/obj/item/ammo_casing/c9mm,
+/obj/item/ammo_casing/c9mm,
+/obj/item/storage/fancy/heart_box,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"uNc" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uND" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "uNI" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -14336,6 +23967,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"uNQ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"uPk" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker)
 "uPo" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -14350,6 +23995,19 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/followers)
+"uQS" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"uQU" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "uQV" = (
 /obj/structure/table/wood/settler,
 /obj/item/phone,
@@ -14364,18 +24022,54 @@
 "uRG" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
+"uRU" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "uSh" = (
 /obj/effect/decal/remains{
-	icon_state = "remains";
+	icon_state = "remains"
 	},
 /obj/item/paper/crumpled{
 	desc = "Ran out food and had to hit Lyin' Todd's hideout, Lucky for us his whole crew was out and only left a couple kids that nearly shit themselves when we showed up, One kept whining something about a guy named Fat Man, aint never heard of him but hes welcome to come down and donate to the meat supply.";
 	name = "raider journal scrap"
 	},
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"uSm" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal,
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"uSq" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"uSv" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
 "uSx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14401,6 +24095,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"uSJ" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "uTN" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -14437,6 +24137,19 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"uVK" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
+"uVR" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "uWf" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -14445,6 +24158,15 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"uWm" = (
+/obj/machinery/light,
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "uWo" = (
 /obj/structure/flora/grass/wasteland{
@@ -14496,19 +24218,30 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"vah" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "vak" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomleft"
 	},
 /area/f13/wasteland)
 "vap" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
+"vaP" = (
+/obj/machinery/door/airlock,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vaR" = (
 /obj/structure/fence{
 	dir = 1
@@ -14525,9 +24258,43 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/underground/cave)
+"vcs" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/f13/radiation)
+"vcQ" = (
+/obj/structure/table,
+/obj/item/papercutter{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"vdk" = (
+/mob/living/simple_animal/hostile/handy/nsb,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"vdp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "vdq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
+	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "veh" = (
@@ -14552,6 +24319,14 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/wood/f13/old,
 /area/f13/legion)
+"vfx" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "vgx" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -14564,9 +24339,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"vgI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/f13/bunker)
+"vgK" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib4-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vgM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
 "vhE" = (
@@ -14583,6 +24377,23 @@
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"vhS" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"vhT" = (
+/obj/item/pen,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "vim" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -14595,7 +24406,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "viO" = (
@@ -14615,7 +24426,7 @@
 "vjN" = (
 /obj/item/ammo_casing,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/legion)
 "vjR" = (
@@ -14627,6 +24438,20 @@
 "vkb" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"vkG" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/bunker)
 "vkL" = (
 /obj/structure/table,
@@ -14647,6 +24472,26 @@
 /obj/effect/decal/waste,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"vme" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vmn" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_wood{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -14662,6 +24507,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/underground/cave)
+"vnh" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 27
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/mirelurkegg,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "vnl" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -14680,9 +24535,16 @@
 "vnC" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"vnK" = (
+/obj/structure/sign/departments/examroom,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "vor" = (
 /obj/item/flag/legion,
 /obj/structure/obstacle/barbedwire,
@@ -14691,6 +24553,20 @@
 "vow" = (
 /obj/structure/debris/v3,
 /turf/closed/indestructible/rock,
+/area/f13/bunker)
+"voE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"voH" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "voJ" = (
 /obj/machinery/light/small{
@@ -14733,6 +24609,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"vqD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib5-old"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "vqY" = (
 /obj/structure/chair/bench,
 /obj/item/clothing/under/f13/vault{
@@ -14751,6 +24633,12 @@
 /obj/structure/car/rubbish4,
 /turf/open/water,
 /area/f13/wasteland)
+"vrA" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "vrL" = (
 /obj/structure/flora/tree/cactus,
 /obj/structure/barricade/sandbags,
@@ -14776,10 +24664,20 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"vsO" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vtp" = (
 /obj/structure/chair/stool{
 	dir = 1;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -14835,6 +24733,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"vuS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/bunker)
 "vvv" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -14871,6 +24774,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vxe" = (
+/obj/item/detective_scanner,
+/obj/structure/closet,
+/obj/item/clothing/under/hosparademale,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "vxn" = (
 /obj/structure/chair/stool/bar{
 	desc = "The place you sit when all hope is lost.";
@@ -14882,6 +24792,19 @@
 /obj/structure/chair/right,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
+"vya" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
 "vyk" = (
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/dirt,
@@ -14904,6 +24827,25 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"vyR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "meat";
+	name = "Meat Storage"
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"vyZ" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "vAk" = (
 /obj/item/ammo_casing/c9mm,
 /obj/effect/spawner/lootdrop/trash,
@@ -14915,7 +24857,7 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "vBc" = (
@@ -14924,6 +24866,21 @@
 "vBy" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
+"vBN" = (
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"vCL" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vDr" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "vDV" = (
 /obj/structure/table,
@@ -14947,9 +24904,21 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vFV" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/water,
+/area/f13/bunker)
 "vGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/bunker)
+"vGG" = (
+/obj/structure/sign/departments/botany,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "vGQ" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -14966,6 +24935,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vHi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "overseerloot"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "vHC" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
@@ -14979,16 +24956,35 @@
 "vIq" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
+"vIu" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
+"vIx" = (
+/obj/structure/debris/v3,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vIL" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "vIM" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetUSA";
+	icon_state = "sheetUSA"
 	},
 /obj/item/bedsheet{
-	icon_state = "sheethos";
+	icon_state = "sheethos"
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
@@ -14997,10 +24993,49 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vJf" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"vJF" = (
+/obj/effect/decal/waste{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/effect/decal/remains/human,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"vJR" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"vJT" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
+"vKk" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
 "vKu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"vKE" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/vaultdoor{
+	icon_state = "open";
+	name = "busted vault door"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "vKV" = (
 /turf/closed/indestructible/rock,
 /area/f13/city)
@@ -15010,11 +25045,44 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
+"vLv" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
+"vLG" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "vLX" = (
 /obj/structure/chair/stool/bar,
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"vMa" = (
+/obj/structure/table/reinforced,
+/obj/item/crafting/coffee_pot{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
 "vMj" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/supermart,
@@ -15026,6 +25094,24 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"vNM" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
+"vNX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/storage/crayons,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "vOv" = (
 /obj/machinery/computer/robotics,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -15033,6 +25119,31 @@
 "vOG" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/city)
+"vOP" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"vQq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/bunker)
+"vQT" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/broken,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/mob/living/simple_animal/hostile/mirelurk/hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "vQV" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/indestructible/vaultdoor,
@@ -15042,28 +25153,61 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"vRz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"vSh" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "suka";
+	name = "Old Suspicous Wall"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker)
 "vTX" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"vTY" = (
+/obj/machinery/porta_turret/syndicate/vehicle_turret,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"vUd" = (
+/obj/structure/table/wood,
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
 /area/f13/bunker)
 "vUl" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"vUH" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "vUS" = (
 /obj/structure/sign/poster/ncr/loaded,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "vUY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "vVG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "vWA" = (
@@ -15075,6 +25219,42 @@
 "vWV" = (
 /turf/open/floor/pod,
 /area/f13/underground/cave)
+"vXy" = (
+/obj/structure/closet/cabinet{
+	name = "Vault 223 cabinet"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vXB" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/f13/radiation)
+"vXK" = (
+/obj/structure/glowshroom/single,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"vXP" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"vYk" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "vYK" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -15111,11 +25291,17 @@
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/f13/supermart,
 /area/f13/bunker)
+"vZx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "vZV" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/legion)
 "waj" = (
@@ -15134,6 +25320,24 @@
 /obj/structure/table/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"waA" = (
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"waP" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "wbu" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/mentats{
@@ -15143,6 +25347,11 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/bunker)
+"wbA" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "wbS" = (
 /obj/effect/turf_decal/loading_area{
@@ -15185,11 +25394,22 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "wex" = (
 /turf/closed/indestructible/rock,
+/area/f13/bunker)
+"wez" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wfa" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "wfM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -15216,6 +25436,16 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"wiD" = (
+/obj/structure/timeddoor/sixtyminute,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"wjp" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "wjO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -15228,14 +25458,31 @@
 "wke" = (
 /obj/structure/sink{
 	dir = 1;
-	pixel_y = 15;
+	pixel_y = 15
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"wkn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
+"wkq" = (
+/obj/machinery/door/window/southleft,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "wkP" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"wll" = (
+/mob/living/simple_animal/hostile/radroach,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "wlO" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -15244,10 +25491,28 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wmc" = (
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
+"wmj" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/venus_human_trap{
+	health = 150;
+	maxHealth = 150
+	},
+/turf/open/water,
+/area/f13/bunker)
 "wmn" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ncr)
+"wmu" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/bunker)
 "wmD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
@@ -15257,11 +25522,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/legion)
-"woL" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
+"wnn" = (
+/mob/living/simple_animal/hostile/handy/gutsy/nsb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/f13/bunker)
+"wnp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
 	},
-/area/f13/wasteland)
+/area/f13/bunker)
+"woL" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green,
+/area/f13/bunker)
 "woQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/sosjerky,
@@ -15284,6 +25560,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wpn" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"wqh" = (
+/obj/machinery/vending/clothing,
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "wqk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15304,12 +25593,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"wrv" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "wrY" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"wsd" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "wsE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -15318,6 +25622,16 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"wtc" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
 "wtd" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
@@ -15333,9 +25647,15 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"wtm" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "wtF" = (
 /turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "wtZ" = (
@@ -15352,6 +25672,34 @@
 "wuw" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"wuB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/f13/bunker)
+"wuE" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"wvk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "wvy" = (
 /obj/structure/table/wood/settler,
 /obj/item/newspaper,
@@ -15363,21 +25711,74 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
+"wvQ" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 3;
+	pixel_x = 32;
+	spawn_time = 40
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wvV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"wwd" = (
+/obj/item/clothing/glasses/meson,
+/obj/item/flashlight/lantern,
+/obj/item/storage/bag/ore,
+/obj/structure/table,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "wws" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wxb" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor7-old"
+	},
+/obj/effect/mob_spawn/human/corpse,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wxe" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "wxj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
+"wxE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wxF" = (
 /obj/machinery/processor,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "wxU" = (
 /turf/open/floor/f13{
-	icon_state = "purplefull";
+	icon_state = "purplefull"
 	},
 /area/f13/legion)
+"wxX" = (
+/obj/structure/table,
+/obj/item/storage/book/bible{
+	pixel_y = 2
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/soap{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/bunker)
 "wyM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/desert,
@@ -15390,7 +25791,7 @@
 "wyY" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/ncr)
 "wzm" = (
@@ -15399,6 +25800,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"wzo" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "wzx" = (
 /obj/structure/frame/machine,
 /obj/structure/window/spawner,
@@ -15406,6 +25814,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"wzG" = (
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/bunker)
 "wzJ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -15422,11 +25838,86 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"wAH" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"wAN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wBk" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"wBn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/tunnel)
+"wBK" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib3-old"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wBZ" = (
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"wCd" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "wCh" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wCv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/water,
+/area/f13/bunker)
+"wDr" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"wDI" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"wDO" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "wEk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15492,16 +25983,72 @@
 	light_color = "#e8eaff"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "wGu" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wGQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"wHq" = (
+/obj/structure/table,
+/obj/item/storage/fancy/rollingpapers,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"wHs" = (
+/mob/living/simple_animal/hostile/centaur,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
+"wHx" = (
+/obj/structure/rack,
+/obj/item/clothing/under/f13/vault,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/color/black,
+/obj/item/storage/belt/security,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/assembly/flash/handheld,
+/obj/item/restraints/handcuffs,
+/obj/item/gun/ballistic/automatic/pistol/n99,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/ammo_box/magazine/m10mm_adv/simple,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/riot/vaultsec,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
+"wHT" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "wIo" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -15509,6 +26056,22 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
+/area/f13/bunker)
+"wID" = (
+/obj/structure/table,
+/obj/item/pizzabox/mushroom{
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"wIF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
 /area/f13/bunker)
 "wJk" = (
 /obj/structure/closet/secure_closet/personal,
@@ -15529,6 +26092,10 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland)
+"wJP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wJZ" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15544,6 +26111,11 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wMM" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "wNj" = (
 /obj/structure/car/rubbish2,
 /obj/structure/tires/two,
@@ -15556,10 +26128,49 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"wNF" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
+/area/f13/bunker)
 "wNO" = (
 /obj/structure/stone_tile/burnt,
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker)
+"wOf" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
+"wOm" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"wOR" = (
+/obj/structure/sign/departments/engineering,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/vaultdoor,
+/area/f13/bunker)
+"wPe" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "wPz" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -15599,12 +26210,32 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"wSp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
+	},
+/area/f13/bunker)
 "wSI" = (
 /obj/item/storage/pill_bottle/chem_tin/mentats{
 	desc = "An experimental,  pre-war medication used to treat memory and mental degridation It seems to be empty...";
 	name = "Pre-War Medicine"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"wTf" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/table,
+/turf/open/water,
+/area/f13/bunker)
+"wTs" = (
+/obj/machinery/button/crematorium{
+	id = 700;
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "wUa" = (
 /obj/effect/decal/riverbank{
@@ -15623,13 +26254,29 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
+	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
 "wUu" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"wUP" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Vault1"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"wUZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "wVd" = (
 /obj/machinery/light{
@@ -15645,6 +26292,16 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/black,
+/area/f13/bunker)
+"wVo" = (
+/obj/structure/barricade/wooden/strong,
+/obj/machinery/door/poddoor/shutters{
+	id = "trap";
+	name = "Old Suspicous Wall"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "showroomfloor"
+	},
 /area/f13/bunker)
 "wVC" = (
 /obj/machinery/light,
@@ -15664,24 +26321,79 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"wWD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	icon_state = "rightsecure";
+	req_access_txt = "10, 11"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "wWN" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wWO" = (
+/obj/structure/nest/raider/melee{
+	max_mobs = 2;
+	pixel_y = 32;
+	spawn_time = 100
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"wWR" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
 "wXi" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
 	},
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"wXw" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "wXE" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"wYh" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 10
+	},
+/area/f13/radiation)
+"wYV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"wZv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/loot,
+/turf/open/water,
+/area/f13/bunker)
 "wZS" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	faction = list("bonnie")
@@ -15699,6 +26411,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"xaD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xaJ" = (
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
@@ -15715,12 +26432,72 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"xbo" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "suka";
+	name = "security shutters"
+	},
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "xbP" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xbT" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	network = list("Vault")
+	},
+/obj/machinery/button/door{
+	id = 103;
+	name = "Blast Doors"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"xcc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
+"xcA" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker)
+"xcX" = (
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"xcZ" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
+"xdj" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/bunker)
 "xdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -15730,6 +26507,21 @@
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xdu" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner,
+/obj/machinery/light/floor,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "xdH" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -15780,6 +26572,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"xfJ" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
+"xfY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/supermutant/playable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "xgd" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -15794,22 +26599,74 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"xhA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"xic" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
+"xix" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bunker)
 "xiC" = (
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xjX" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "xkT" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xla" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/bunker)
 "xle" = (
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xlt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/bunker)
 "xlu" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheetUSA";
+	icon_state = "sheetUSA"
 	},
 /obj/item/bedsheet{
 	icon_state = "sheetbrown"
@@ -15825,6 +26682,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"xlB" = (
+/obj/machinery/door_timer{
+	id = "vaultc2";
+	pixel_y = 32
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/bunker)
 "xlN" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -15835,6 +26703,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xmj" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "xmA" = (
 /obj/structure/table,
@@ -15851,6 +26726,16 @@
 /obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xnN" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "xnX" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -15863,6 +26748,13 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"xon" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/f13/bunker)
 "xpf" = (
 /obj/machinery/light{
 	dir = 4
@@ -15885,6 +26777,18 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"xpT" = (
+/obj/item/radio/intercom{
+	frequency = 1361;
+	name = "Vault Intercom";
+	pixel_x = -30
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/bunker)
 "xqd" = (
 /obj/effect/decal/riverbank,
 /obj/effect/decal/riverbank{
@@ -15909,10 +26813,25 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"xsn" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xsA" = (
 /obj/effect/landmark/poster_spawner/ncr,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
+"xsG" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"xtr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "xtB" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 1
@@ -15936,12 +26855,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xub" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/water,
+/area/f13/bunker)
 "xuH" = (
 /obj/effect/decal/riverbank{
 	dir = 4
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"xvl" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/freezer,
+/area/f13/bunker)
+"xvm" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/bunker)
+"xvF" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 14
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xwv" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -15969,9 +26915,13 @@
 "xwZ" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/ncr)
+"xxn" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
 "xxw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
@@ -15979,6 +26929,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"xym" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
 "xzK" = (
 /turf/open/floor/plating/f13,
 /area/f13/followers)
@@ -16023,18 +26979,50 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"xCm" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "xCs" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xCG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/deathclaw{
+	obj_damage = 500
+	},
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/bunker)
 "xCN" = (
 /obj/item/ammo_box/c9mm,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"xDh" = (
+/obj/structure/bed/oldalt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "xDP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xDQ" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 6
+	},
 /area/f13/bunker)
 "xEZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16048,7 +27036,7 @@
 	},
 /turf/open/floor/f13{
 	dir = 10;
-	icon_state = "redmark";
+	icon_state = "redmark"
 	},
 /area/f13/ncr)
 "xFY" = (
@@ -16057,7 +27045,7 @@
 /area/f13/wasteland)
 "xGD" = (
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32";
+	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
 "xGO" = (
@@ -16127,6 +27115,27 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"xKh" = (
+/obj/structure/flora/tree/jungle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
+"xKj" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 102;
+	name = "Vault Door Security Checkpoint"
+	},
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/f13/bunker)
+"xKL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/water,
+/area/f13/bunker)
 "xKQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -16143,6 +27152,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
+"xLU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/bunker)
 "xMf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -16150,7 +27164,7 @@
 "xMk" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "xNc" = (
@@ -16160,6 +27174,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/underground/cave)
+"xNH" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/bunker)
 "xNR" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -16176,15 +27195,30 @@
 /obj/structure/bed/mattress,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"xOm" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/jungle/mega_arachnid{
+	health = 450;
+	maxHealth = 450
+	},
+/turf/open/water,
+/area/f13/bunker)
 "xOr" = (
 /turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland)
 "xOB" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"xOC" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "xOO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -16207,6 +27241,29 @@
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"xPI" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/f13/electronic/toaster{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker)
+"xPL" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_mai{
+	anchored = 1;
+	max_integrity = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "xPM" = (
 /obj/structure/bookcase/random,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -16219,10 +27276,28 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xPY" = (
+/obj/item/bikehorn,
+/obj/structure/rack,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/bunker)
 "xQf" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"xQh" = (
+/obj/machinery/button/door{
+	id = "vaultshutters2";
+	name = "armory button";
+	pixel_x = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
+/area/f13/bunker)
 "xQr" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -16233,10 +27308,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
+"xRv" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "xRY" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
-	icon_state = "rubble";
+	icon_state = "rubble"
 	},
 /area/f13/wasteland)
 "xSo" = (
@@ -16252,7 +27331,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "xST" = (
@@ -16275,9 +27354,26 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"xVo" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "xVt" = (
 /turf/open/indestructible/ground/outside/savannah/bottomright,
 /area/f13/wasteland)
+"xWj" = (
+/obj/structure/sign/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/bunker)
 "xWl" = (
 /obj/structure/table,
 /obj/item/pen/fourcolor,
@@ -16293,6 +27389,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"xWV" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/bunker)
 "xXh" = (
 /obj/structure/table/glass,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -16300,11 +27401,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"xXw" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/showroomfloor,
+/area/f13/bunker)
+"xXH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/f13/radiation)
 "xYg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"xYR" = (
+/obj/structure/table/booth,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/bunker)
+"xYW" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/bunker)
 "xZk" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
@@ -16313,6 +27444,11 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"xZD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13,
+/area/f13/bunker)
 "xZG" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
@@ -16334,7 +27470,7 @@
 "yaP" = (
 /obj/structure/chair/stool{
 	dir = 4;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -16351,15 +27487,26 @@
 "ybd" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"ybw" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "ybQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/bunker)
+"ybU" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "ycb" = (
 /obj/structure/table,
@@ -16377,6 +27524,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"ycL" = (
+/obj/structure/barricade/wooden/planks,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/tunnel)
 "ycX" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fluff/railing{
@@ -16407,6 +27562,15 @@
 "yeh" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"yei" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib6-old";
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/bunker)
 "yeB" = (
 /obj/machinery/light{
 	dir = 4
@@ -16446,7 +27610,7 @@
 /area/f13/followers)
 "yfI" = (
 /obj/structure/toilet{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/light/small,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
@@ -16464,10 +27628,21 @@
 	icon_state = "housewood2"
 	},
 /area/f13/underground/cave)
+"ygs" = (
+/obj/item/clothing/head/welding,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/structure/closet,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "ygO" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "ygU" = (
@@ -16499,6 +27674,10 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland)
+"yhT" = (
+/obj/structure/door_assembly/door_assembly_hatch,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
 "yhU" = (
 /turf/closed/wall/mineral/iron,
 /area/f13/underground/cave)
@@ -16506,6 +27685,13 @@
 /obj/effect/landmark/map_load_mark/dungeons/north,
 /turf/closed/indestructible/rock,
 /area/f13/underground/cave)
+"yiV" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "yjo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16513,30 +27699,49 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"yjt" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 23;
+	pixel_y = -1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"yjH" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "yjS" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "ykl" = (
 /obj/structure/chair/stool{
 	dir = 9;
-	icon_state = "bench_center";
+	icon_state = "bench_center"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2";
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ncr)
 "ykL" = (
 /obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"ylh" = (
+/obj/structure/chair/wood,
+/mob/living/simple_animal/hostile/raider/legendary,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "ylt" = (
 /obj/structure/frame/machine,
 /turf/open/floor/f13{
@@ -16571,6 +27776,7 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
+
 (1,1,1) = {"
 heT
 heT
@@ -19790,14 +30996,14 @@ ndi
 ndi
 ndi
 ndi
-anj
+iAH
 wWN
 wWN
 wWN
 wWN
 wWN
 wWN
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -19830,10 +31036,10 @@ cVD
 ndi
 xGD
 iAH
-qJs
+wWN
 ifx
 woV
-sXK
+wXE
 nSg
 xlz
 ndi
@@ -20056,7 +31262,7 @@ ksx
 ksx
 lOu
 wWN
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -20090,13 +31296,13 @@ xPV
 ksx
 ekS
 der
-mGy
+ygO
 wyM
 xlz
 ndi
 ndi
 ndi
-woL
+xGD
 ndi
 ndi
 tWN
@@ -20315,7 +31521,7 @@ ksx
 hns
 lOu
 wWN
-sXK
+wXE
 ndi
 oSf
 ndi
@@ -20342,12 +31548,12 @@ bYA
 bYA
 ndi
 ndi
-pBl
+xle
 ksx
 ksx
 xbP
-lqv
-abo
+rSc
+gwL
 ndi
 xlz
 ndi
@@ -20573,7 +31779,7 @@ lgF
 ksx
 ksx
 lOu
-sXK
+wXE
 oSf
 ndi
 ndi
@@ -20602,7 +31808,7 @@ wlY
 xaX
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 xlz
@@ -20856,10 +32062,10 @@ bYA
 bYA
 ndi
 wEX
-tjZ
-lqv
-lqv
-abo
+ulM
+rSc
+rSc
+gwL
 ndi
 ndi
 ndi
@@ -21095,7 +32301,7 @@ ndi
 ndi
 ndi
 iAH
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -21112,7 +32318,7 @@ bYA
 bYA
 bYA
 iAH
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -21125,7 +32331,7 @@ ndi
 ndi
 tWN
 mvo
-anj
+iAH
 wWN
 dmd
 wWN
@@ -21144,7 +32350,7 @@ wWN
 wWN
 wWN
 wWN
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -21351,8 +32557,8 @@ xOr
 ndi
 iAH
 wWN
-iep
-mGy
+xPV
+ygO
 ndi
 xOr
 ndi
@@ -21368,19 +32574,19 @@ bYA
 bYA
 bYA
 bYA
-tjZ
-abo
+ulM
+gwL
 ndi
 ndi
 uyw
 iAH
-sXK
+wXE
 ndi
 ndi
 ndi
 ndi
 mvo
-anj
+iAH
 wWN
 xPV
 ksx
@@ -21606,7 +32812,7 @@ oSf
 ndi
 ndi
 iAH
-iep
+xPV
 mBD
 gLz
 dDN
@@ -21630,12 +32836,12 @@ ndi
 guL
 xGD
 ndi
-tjZ
+ulM
 oCs
 ndi
 ndi
 ndi
-anj
+iAH
 wWN
 xPV
 ksx
@@ -21862,7 +33068,7 @@ ygO
 oSf
 ndi
 eEe
-pBl
+xle
 ksx
 oQq
 ksx
@@ -21885,13 +33091,13 @@ ndi
 ndi
 ndi
 ndi
-woL
+xGD
 ndi
 ndi
 rvJ
 ndi
 xle
-bii
+lOu
 xPV
 ksx
 ksx
@@ -21900,18 +33106,18 @@ ksx
 ksx
 ksx
 ksx
-mtT
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
+xbP
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
 hpt
-nAr
+xfw
 ksx
 ksx
 ksx
@@ -22123,7 +33329,7 @@ iBd
 ksx
 oQq
 ksx
-mGy
+ygO
 ndi
 hwh
 tQv
@@ -22146,7 +33352,7 @@ wyM
 ndi
 ndi
 ndi
-anj
+iAH
 xPV
 ksx
 ksx
@@ -22157,7 +33363,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 mvo
 ndi
 ndi
@@ -22169,7 +33375,7 @@ iqB
 ndi
 mvo
 ulM
-nAr
+xfw
 ksx
 ksx
 ksx
@@ -22181,7 +33387,7 @@ ksx
 ntV
 ksx
 ntV
-mGy
+ygO
 mvo
 ndi
 ndi
@@ -22375,12 +33581,12 @@ ksx
 ygO
 oSf
 ndi
-pBl
+xle
 ksx
 ksx
 oQq
 ksx
-mGy
+ygO
 ndi
 hUr
 ndi
@@ -22403,7 +33609,7 @@ ndi
 rgU
 ndi
 mvo
-pBl
+xle
 ksx
 ksx
 ksx
@@ -22413,7 +33619,7 @@ ksx
 ksx
 ksx
 xbP
-lqv
+rSc
 gwL
 ndi
 ndi
@@ -22427,7 +33633,7 @@ ndi
 ndi
 ndi
 ulM
-nAr
+xfw
 ksx
 ksx
 ksx
@@ -22439,12 +33645,12 @@ ksx
 ksx
 ksx
 lOu
-sXK
-anj
+wXE
+iAH
 wWN
 wWN
 wWN
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -22632,12 +33838,12 @@ ksx
 ygO
 oSf
 guL
-pBl
+xle
 ksx
 ksx
 ksx
 xbP
-abo
+gwL
 ndi
 qos
 ndi
@@ -22660,7 +33866,7 @@ ndi
 ndi
 ndi
 ndi
-pBl
+xle
 ksx
 ksx
 ksx
@@ -22696,12 +33902,12 @@ rSc
 xfw
 ksx
 ksx
-mGy
+ygO
 xle
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 esJ
 rrp
@@ -22889,11 +34095,11 @@ hns
 ygO
 oSf
 iAH
-iep
+xPV
 ksx
 xbP
-lqv
-abo
+rSc
+gwL
 ndi
 ndi
 ndi
@@ -22911,20 +34117,20 @@ wPz
 wPz
 ndi
 ndi
-woL
+xGD
 ndi
 ndi
-woL
+xGD
 ndi
 ndi
-pBl
+xle
 ksx
 ksx
 ksx
 ksx
 ksx
 xbP
-lqv
+rSc
 gwL
 ndi
 xlz
@@ -22949,16 +34155,16 @@ lbQ
 tvH
 lbQ
 rdA
-qJs
+wWN
 xPV
 ksx
 ksx
-mGy
+ygO
 xle
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -23145,10 +34351,10 @@ ksx
 ksx
 ygO
 oSf
-tjZ
-lqv
-lqv
-abo
+ulM
+rSc
+rSc
+gwL
 ndi
 ndi
 fEF
@@ -23174,13 +34380,13 @@ ndi
 ndi
 rvJ
 mvo
-pBl
+xle
 ksx
 ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 mvo
 ndi
 ndi
@@ -23210,12 +34416,12 @@ ksx
 ksx
 ksx
 ksx
-eQe
+nht
 xle
 lfU
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -23400,7 +34606,7 @@ xtB
 ksx
 ksx
 xbP
-abo
+gwL
 oSf
 ndi
 ndi
@@ -23431,7 +34637,7 @@ ndi
 ndi
 ndi
 lQv
-pBl
+xle
 ksx
 ksx
 ksx
@@ -23467,12 +34673,12 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 xle
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -23724,12 +34930,12 @@ rSc
 xfw
 ksx
 ksx
-mGy
+ygO
 xle
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -23902,7 +35108,7 @@ ndi
 ndi
 ndi
 ulM
-nAr
+xfw
 ksx
 ksx
 ksx
@@ -23981,11 +35187,11 @@ ndi
 xle
 ksx
 ksx
-mGy
-tjZ
-lqv
-lqv
-lqv
+ygO
+ulM
+rSc
+rSc
+rSc
 gwL
 ndi
 ndi
@@ -24159,7 +35365,7 @@ ndi
 ndi
 ndi
 ndi
-tjZ
+ulM
 rSc
 nzL
 ksx
@@ -24233,12 +35439,12 @@ sQA
 dOG
 ksx
 ksx
-anu
+wep
 ndi
 xle
 ymg
 ksx
-mGy
+ygO
 ndi
 pny
 ndi
@@ -24459,7 +35665,7 @@ lfU
 ksx
 ksx
 ksx
-dVc
+oQq
 ksx
 hgk
 ksx
@@ -24495,7 +35701,7 @@ wWN
 xPV
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -24752,7 +35958,7 @@ ksx
 ksx
 ksx
 ksx
-bii
+lOu
 wWN
 wWN
 lAI
@@ -24973,7 +36179,7 @@ ksx
 ksx
 ksx
 ksx
-dVc
+oQq
 ksx
 ksx
 ksx
@@ -25004,8 +36210,8 @@ rPW
 ksx
 ksx
 ksx
-cor
-lqv
+mNT
+rSc
 xfw
 ksx
 ksx
@@ -25230,7 +36436,7 @@ ksx
 mnL
 ksx
 ksx
-dVc
+oQq
 ksx
 ksx
 ksx
@@ -25449,8 +36655,8 @@ mvo
 xle
 ksx
 ksx
-bii
-sXK
+lOu
+wXE
 ndi
 ndi
 ndi
@@ -25487,7 +36693,7 @@ ksx
 ksx
 ksx
 ksx
-dVc
+oQq
 ksx
 ksx
 tnn
@@ -25531,7 +36737,7 @@ tSi
 uEv
 rSc
 rSc
-abo
+gwL
 ndi
 ndi
 ndi
@@ -25781,9 +36987,9 @@ lex
 mTB
 mTB
 mXD
-gfw
-gfw
-gfw
+riZ
+riZ
+riZ
 uMH
 ndi
 ndi
@@ -26001,7 +37207,7 @@ ksx
 ksx
 ksx
 ksx
-dVc
+oQq
 ksx
 ksx
 ksx
@@ -26218,13 +37424,13 @@ ndi
 ndi
 ndi
 ulM
-nAr
+xfw
 ksx
 faA
-bii
+lOu
 wWN
 wWN
-sXK
+wXE
 ndi
 rgU
 ndi
@@ -26263,7 +37469,7 @@ wef
 bRa
 ksx
 ksx
-mGy
+ygO
 obO
 ndi
 fMG
@@ -26520,7 +37726,7 @@ wef
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 nyV
 fMG
@@ -26777,7 +37983,7 @@ wef
 ksx
 ymg
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -26990,7 +38196,7 @@ sJn
 sJn
 ndi
 ulM
-nAr
+xfw
 ksx
 ksx
 ksx
@@ -27034,7 +38240,7 @@ wef
 ksx
 ksx
 tnn
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -27248,8 +38454,8 @@ sJn
 jCY
 mvo
 ulM
-lqv
-nAr
+rSc
+xfw
 ksx
 ksx
 snQ
@@ -27263,7 +38469,7 @@ tsa
 tsa
 tsa
 wWN
-sXK
+wXE
 ndi
 ndi
 ndi
@@ -27291,7 +38497,7 @@ wus
 ksx
 tnn
 ksx
-mGy
+ygO
 rvJ
 ndi
 fMG
@@ -27805,7 +39011,7 @@ lWf
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -28062,7 +39268,7 @@ wef
 ksx
 ksx
 ymg
-mGy
+ygO
 ndi
 sne
 fMG
@@ -28105,8 +39311,8 @@ qKV
 mTB
 ndi
 ndi
-anj
-qJs
+iAH
+wWN
 bYA
 wPz
 qnQ
@@ -29134,7 +40340,7 @@ mTB
 ndi
 xle
 ksx
-mtT
+xbP
 bYA
 ohx
 fZG
@@ -29903,7 +41109,7 @@ gYQ
 lQJ
 idb
 pWR
-ktT
+xRY
 ndi
 ndi
 ndi
@@ -30929,9 +42135,9 @@ mTB
 hbM
 kzQ
 kRA
-qJs
-qJs
-qJs
+wWN
+wWN
+wWN
 cqL
 ndi
 hRJ
@@ -31146,7 +42352,7 @@ wef
 bRa
 ksx
 ksx
-mtT
+xbP
 uvi
 mcj
 fMG
@@ -31403,7 +42609,7 @@ wus
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -31441,7 +42647,7 @@ dAE
 fgG
 vIq
 qMS
-anj
+iAH
 xPV
 ksx
 ksx
@@ -31660,7 +42866,7 @@ wef
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -31917,7 +43123,7 @@ wef
 svf
 ksx
 ksx
-mGy
+ygO
 fee
 ndi
 fMG
@@ -32174,7 +43380,7 @@ wef
 ksx
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -32431,7 +43637,7 @@ wef
 bRa
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 fMG
@@ -32651,7 +43857,7 @@ ggj
 dQz
 dQz
 nXK
-tXS
+wEk
 ksx
 ksx
 ksx
@@ -32731,7 +43937,7 @@ ksx
 ksx
 ksx
 ksx
-mtT
+xbP
 jMI
 bYA
 wPz
@@ -32908,7 +44114,7 @@ qAC
 fRM
 xfw
 vdq
-bji
+ppF
 ksx
 ksx
 kWd
@@ -32945,7 +44151,7 @@ xle
 ksx
 ksx
 ksx
-bii
+lOu
 fMG
 erC
 jMO
@@ -32980,7 +44186,7 @@ ndi
 ndi
 ulM
 rSc
-abo
+gwL
 ndi
 ndi
 gBk
@@ -33454,7 +44660,7 @@ sHw
 qcW
 nmQ
 ndi
-anj
+iAH
 xPV
 ksx
 ksx
@@ -33973,7 +45179,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 xdM
@@ -34230,7 +45436,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 tin
 xdM
@@ -34482,7 +45688,7 @@ sHw
 sHw
 nmQ
 nmQ
-nAr
+xfw
 ksx
 svf
 ksx
@@ -34744,7 +45950,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 xtU
@@ -34965,8 +46171,8 @@ ndi
 xle
 vdq
 vUY
-mtT
-nAr
+xbP
+xfw
 lNt
 yeX
 yeX
@@ -35001,7 +46207,7 @@ ksx
 ksx
 ksx
 svf
-mGy
+ygO
 fMG
 qhW
 xdM
@@ -35223,7 +46429,7 @@ xle
 vdq
 vUY
 ygO
-pBl
+xle
 vdq
 yeX
 ctX
@@ -35258,7 +46464,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 lZM
@@ -35480,7 +46686,7 @@ xle
 vdq
 vUY
 ygO
-pBl
+xle
 vdq
 yeX
 bdx
@@ -35515,7 +46721,7 @@ svf
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 xWq
@@ -35733,11 +46939,11 @@ xAq
 xAq
 qAC
 chS
-iep
+xPV
 vdq
 vUY
 ygO
-pBl
+xle
 vdq
 yeX
 yeX
@@ -35772,7 +46978,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 xdM
@@ -35994,7 +47200,7 @@ gIc
 nXK
 vUY
 ygO
-pBl
+xle
 fpw
 dQz
 wGt
@@ -36029,7 +47235,7 @@ ksx
 ksx
 ksx
 ymg
-mGy
+ygO
 fMG
 xdM
 wRZ
@@ -36286,7 +47492,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 fMG
 xdM
 xWq
@@ -36513,7 +47719,7 @@ ndi
 ndi
 ndi
 sne
-pBl
+xle
 ksx
 xSK
 ndi
@@ -36770,7 +47976,7 @@ ndi
 ndi
 ndi
 ndi
-pBl
+xle
 ksx
 ygO
 ndi
@@ -37027,7 +48233,7 @@ uCn
 ndi
 ndi
 ndi
-pBl
+xle
 ksx
 xSK
 ndi
@@ -37284,7 +48490,7 @@ ndi
 ndi
 ndi
 ndi
-pBl
+xle
 ksx
 xSK
 ndi
@@ -37541,7 +48747,7 @@ xGD
 ndi
 xGD
 ndi
-pBl
+xle
 lfU
 xSK
 ndi
@@ -37798,7 +49004,7 @@ ndi
 ndi
 xGD
 ndi
-pBl
+xle
 ksx
 xSK
 rvJ
@@ -38055,7 +49261,7 @@ ndi
 ndi
 rgU
 ndi
-pBl
+xle
 ksx
 ygO
 ndi
@@ -38347,8 +49553,8 @@ ksx
 ksx
 ksx
 ksx
-mtT
-lqv
+xbP
+rSc
 tNR
 xfw
 ksx
@@ -38599,12 +49805,12 @@ ksx
 ksx
 ksx
 ksx
-mtT
-lqv
-pVg
-lqv
+xbP
+rSc
+uAu
+rSc
 wFU
-abo
+gwL
 ndi
 xlz
 xle
@@ -39105,9 +50311,9 @@ ksx
 ksx
 ksx
 xbP
-lqv
-lqv
-lqv
+rSc
+rSc
+rSc
 xfw
 ksx
 ksx
@@ -39356,12 +50562,12 @@ bYA
 bYA
 bYA
 bYA
-lqv
-lqv
-lqv
-lqv
-lqv
-abo
+rSc
+rSc
+rSc
+rSc
+rSc
+gwL
 ndi
 ndi
 rgU
@@ -39617,7 +50823,7 @@ ndi
 ndi
 ndi
 ndi
-woL
+xGD
 ndi
 ndi
 ndi
@@ -39878,7 +51084,7 @@ rgU
 xOr
 ndi
 tWN
-woL
+xGD
 xle
 ksx
 dpP
@@ -39889,7 +51095,7 @@ ndi
 ndi
 xOr
 ndi
-woL
+xGD
 ndi
 xle
 ksx
@@ -40643,11 +51849,11 @@ bYA
 ndi
 ndi
 ndi
-woL
+xGD
 ndi
 xlz
 ndi
-anj
+iAH
 wWN
 wWN
 xPV
@@ -41158,7 +52364,7 @@ ndi
 ndi
 mvo
 ndi
-anj
+iAH
 tsa
 wWN
 xPV
@@ -41423,10 +52629,10 @@ ksx
 ksx
 ksx
 ksx
-mtT
-lqv
-lqv
-abo
+xbP
+rSc
+rSc
+gwL
 ndi
 ndi
 nSg
@@ -41934,16 +53140,16 @@ ksx
 ksx
 ksx
 xbP
-lqv
-lqv
-lqv
-abo
+rSc
+rSc
+rSc
+gwL
 xlz
 ndi
 ndi
 ndi
 iAH
-qJs
+wWN
 wXE
 ndi
 ndi
@@ -42170,22 +53376,22 @@ ndi
 xle
 ksx
 dJu
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
-lqv
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
+rSc
 xfw
 bhW
-mtT
-lqv
-lqv
-lqv
-lqv
-lqv
+xbP
+rSc
+rSc
+rSc
+rSc
+rSc
 xfw
 ksx
 ksx
@@ -42199,9 +53405,9 @@ xlz
 xFY
 ndi
 vgx
-pBl
+xle
 pSu
-mGy
+ygO
 ndi
 tWN
 xle
@@ -42456,9 +53662,9 @@ wyM
 okb
 ndi
 ndi
-tjZ
+ulM
 asW
-mGy
+ygO
 ndi
 ndi
 goT
@@ -42681,7 +53887,7 @@ wWN
 wWN
 wWN
 wWN
-iep
+xPV
 ksx
 xSK
 ndi
@@ -42710,12 +53916,12 @@ ndi
 ndi
 ndi
 glz
-woL
+xGD
 ndi
 ndi
 ndi
 jUz
-mGy
+ygO
 ndi
 rrp
 xle
@@ -42951,7 +54157,7 @@ ndi
 ndi
 xle
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -42971,10 +54177,10 @@ ndi
 ndi
 lwh
 ndi
-pBl
-mGy
+xle
+ygO
 ndi
-boc
+xOr
 xle
 ksx
 rVh
@@ -43228,8 +54434,8 @@ ndi
 ndi
 ndi
 ndi
-tjZ
-abo
+ulM
+gwL
 tWN
 ndi
 xle
@@ -43465,7 +54671,7 @@ ndi
 ndi
 xle
 ymg
-mGy
+ygO
 oAO
 oAO
 bYA
@@ -43479,14 +54685,14 @@ bYA
 bYA
 bYA
 ndi
-woL
+xGD
 jPG
 lHl
 ndi
 ndi
-woL
+xGD
 ndi
-woL
+xGD
 rgU
 ndi
 xle
@@ -43722,7 +54928,7 @@ ndi
 mvo
 xle
 ksx
-mGy
+ygO
 oAO
 omL
 bYA
@@ -43979,7 +55185,7 @@ wWN
 wWN
 xPV
 ksx
-mGy
+ygO
 oAO
 oAO
 bRI
@@ -44001,8 +55207,8 @@ ndi
 ndi
 tWN
 ndi
-tjZ
-lqv
+ulM
+rSc
 xfw
 ksx
 rVh
@@ -44236,7 +55442,7 @@ ksx
 ksx
 ksx
 ksx
-mGy
+ygO
 oAO
 oAO
 scf
@@ -44253,12 +55459,12 @@ ndi
 ndi
 ndi
 ndi
-woL
+xGD
 ndi
 tWN
-boc
-vap
-qJs
+xOr
+yjS
+wWN
 wXE
 xle
 ksx
@@ -44515,8 +55721,8 @@ ndi
 ndi
 iAH
 igo
-mtT
-abo
+xbP
+gwL
 xle
 ksx
 rVh
@@ -44770,10 +55976,10 @@ ndi
 ndi
 okb
 ndi
-tjZ
-lqv
-abo
-boc
+ulM
+rSc
+gwL
+xOr
 xle
 bhW
 rVh
@@ -46039,7 +57245,7 @@ gxP
 xle
 ygO
 ndi
-tjZ
+ulM
 qEN
 ksx
 ksx
@@ -46297,12 +57503,12 @@ xle
 ygO
 ndi
 ndi
-tjZ
+ulM
 xfw
 ksx
 ksx
 xbP
-abo
+gwL
 bYA
 bYA
 bYA
@@ -46544,21 +57750,21 @@ bRI
 bRI
 bRI
 emN
-iep
+xPV
 ksx
 lOu
 wWN
 wWN
 wWN
-iep
-bii
+xPV
+lOu
 wXE
 ndi
 ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 bYA
 bYA
@@ -46815,7 +58021,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 bYA
@@ -47072,7 +58278,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -47329,7 +58535,7 @@ ndi
 xle
 ksx
 qwQ
-mGy
+ygO
 ndi
 lwh
 ndi
@@ -47586,7 +58792,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -47843,7 +59049,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -48100,7 +59306,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 ndi
@@ -48357,7 +59563,7 @@ ndi
 xle
 ksx
 ksx
-mGy
+ygO
 ndi
 ndi
 bYA
@@ -62570,7 +73776,7 @@ ppF
 ppg
 iXL
 bFp
-mQi
+vdq
 tzA
 heT
 "}
@@ -62823,7 +74029,7 @@ uPo
 gKr
 bsh
 wJM
-jeq
+vUY
 pjm
 iXL
 bFp
@@ -64108,11 +75314,11 @@ cKh
 gKr
 fIF
 qlj
-jeq
+vUY
 oOr
 sPs
 sPs
-mQi
+vdq
 fOC
 heT
 "}
@@ -64369,7 +75575,7 @@ nif
 oOr
 iXL
 sPs
-mQi
+vdq
 shZ
 heT
 "}
@@ -65140,7 +76346,7 @@ wEk
 pjm
 mpT
 wAv
-mQi
+vdq
 aYz
 heT
 "}
@@ -65397,7 +76603,7 @@ nIh
 oPO
 cKN
 jlQ
-mQi
+vdq
 fOC
 heT
 "}
@@ -79018,7 +90224,7 @@ bsh
 bsh
 bsh
 uWo
-lqv
+rSc
 lMw
 heT
 "}
@@ -79274,7 +90480,7 @@ yec
 bsh
 bsh
 mtM
-mGy
+ygO
 iAH
 xPV
 heT
@@ -79531,8 +90737,8 @@ qcp
 bsh
 bsh
 bsh
-mGy
-pBl
+ygO
+xle
 bsh
 heT
 "}
@@ -79788,8 +90994,8 @@ yec
 bsh
 bsh
 bsh
-mGy
-pBl
+ygO
+xle
 bsh
 heT
 "}
@@ -80045,8 +91251,8 @@ yec
 bsh
 bsh
 bsh
-mGy
-pBl
+ygO
+xle
 bsh
 heT
 "}
@@ -80302,8 +91508,8 @@ yec
 bsh
 bsh
 bsh
-mGy
-pBl
+ygO
+xle
 bsh
 heT
 "}
@@ -80559,7 +91765,7 @@ yec
 bsh
 bsh
 bsh
-mGy
+ygO
 ePY
 bsh
 heT
@@ -80808,16 +92014,16 @@ iDp
 ksx
 ksx
 hYn
-mGy
+ygO
 ndi
-pBl
+xle
 bsh
 bsh
 bsh
 bsh
 bsh
 uof
-kpf
+nOq
 bsh
 heT
 "}
@@ -81066,15 +92272,15 @@ qfH
 ksx
 ksx
 trz
-qJs
+wWN
 xPV
 pqa
 bsh
 bsh
 bsh
 iiV
-abo
-pBl
+gwL
+xle
 bsh
 heT
 "}
@@ -81319,7 +92525,7 @@ fdt
 aHp
 txX
 txX
-mtT
+xbP
 xfw
 ksx
 gfI
@@ -81329,7 +92535,7 @@ ksx
 ksx
 gzH
 rUH
-abo
+gwL
 iAH
 hBr
 bsh
@@ -81586,7 +92792,7 @@ ksx
 ksx
 loi
 gtb
-qJs
+wWN
 fNR
 bsh
 bsh
@@ -81850,6 +93056,29561 @@ bsh
 heT
 "}
 (255,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(256,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(257,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(258,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+pfj
+eSi
+afn
+oAl
+oAl
+oAl
+lZz
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(259,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gIU
+gIU
+pug
+wmc
+oUP
+oAl
+oQH
+rEF
+qsn
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(260,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gIU
+gIU
+kbY
+wSp
+wSp
+mxd
+jly
+wmc
+fEm
+lZz
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(261,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gIU
+gIU
+gIU
+gIU
+gIU
+jpL
+wmc
+jlx
+jly
+sVo
+mGw
+oAl
+oAl
+heT
+heT
+mnh
+mnh
+ouu
+vBN
+qWh
+dht
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(262,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gIU
+gIU
+gIU
+gIU
+oOY
+rEF
+rey
+wmc
+rEF
+ttj
+mBM
+oAl
+oAl
+oAl
+mnh
+mkK
+tyn
+szB
+bTs
+siS
+oqm
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(263,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+gIU
+gIU
+wex
+jxJ
+lZz
+lZz
+rEF
+oAl
+tXv
+wSp
+fiy
+tPj
+qkm
+ghj
+aOa
+qeW
+siS
+cPF
+oqm
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(264,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+xxn
+mai
+oAl
+oAl
+oAl
+oAl
+oAl
+heT
+mnh
+uua
+dlW
+dlF
+siS
+sDl
+dHD
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(265,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+mnh
+uSJ
+vLv
+qvf
+ljY
+mnh
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(266,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+heT
+heT
+heT
+heT
+wex
+mnh
+mnh
+ePM
+ayK
+oAl
+wex
+wex
+wex
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(267,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+kbR
+mIf
+wex
+qoz
+wex
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(268,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+oAl
+oAl
+oAl
+pJB
+wUZ
+wUZ
+wUZ
+xCG
+hRO
+oAl
+oAl
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(269,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+kYt
+acN
+acN
+kYt
+acN
+kYt
+acN
+acN
+acN
+kYt
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+lor
+ecq
+azB
+oAl
+jIR
+qrF
+mQk
+eyQ
+pyA
+iju
+ipc
+iDY
+pFU
+ygs
+kDV
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(270,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+sTt
+dxg
+osy
+uFj
+osy
+dxg
+sTt
+uFj
+sTt
+osy
+sTt
+bAg
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+kDV
+fia
+oKM
+dxU
+pJB
+jSH
+fNA
+dWc
+aIO
+iju
+dxU
+pJB
+hdU
+ipc
+hIm
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(271,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+sTt
+wZv
+ryr
+osy
+xKL
+pWZ
+tAb
+qOu
+sTt
+sTt
+sTt
+sTt
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+gTP
+kSW
+pJB
+dxU
+pJB
+lDz
+bHA
+jIi
+wkq
+wGQ
+pJB
+dxU
+dxU
+rYA
+ahl
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(272,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+kYt
+sTt
+osy
+osy
+cFb
+osy
+sTt
+osy
+dxg
+sTt
+sIx
+qOu
+uFj
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+kDV
+lkB
+dxU
+dxU
+dxU
+pKV
+ocQ
+dWc
+wHT
+wvk
+oKM
+dxU
+pJB
+pJB
+ipc
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(273,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+sTt
+osy
+osy
+sQg
+cgz
+sTt
+sTt
+sTt
+sQg
+xKh
+osy
+sTt
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+aOa
+aOa
+pJB
+chu
+dxU
+qDk
+qwH
+jyv
+aze
+iju
+pGa
+bPT
+kDV
+eIo
+ipc
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(274,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+kYt
+jdy
+dxg
+ryT
+dxg
+sQg
+fOM
+sTt
+sTt
+dxg
+gIO
+osy
+oCe
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+ahS
+nlg
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+dns
+chu
+chu
+chu
+uJq
+tho
+sXH
+xhA
+txS
+dxU
+pJB
+oAl
+oAl
+oAl
+oAl
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(275,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+sTt
+sTt
+pJg
+osy
+sTt
+sQg
+ltF
+dxg
+sTt
+osy
+osy
+osy
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+nlg
+nlg
+jXV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+vSh
+vSh
+vSh
+uBg
+lTo
+tho
+tpl
+dxU
+tdM
+jRX
+oAl
+heT
+oAl
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(276,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+xcX
+nyc
+ggw
+acN
+fZv
+sTt
+sTt
+sTt
+vZx
+xKL
+sQg
+twX
+qOu
+osy
+sTt
+oHz
+acN
+gww
+cna
+cna
+cna
+jTI
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+nlg
+jtl
+ahS
+nlg
+jXV
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+tiU
+mnh
+tiU
+tiU
+tiU
+mnh
+oAl
+heT
+heT
+heT
+mnh
+dzs
+mnh
+oAl
+heT
+mnh
+mnh
+fcp
+tho
+mnh
+heT
+heT
+heT
+heT
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(277,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+oKW
+iJs
+oKW
+acN
+acN
+osy
+sTt
+sTt
+xKh
+aBf
+sTt
+jdy
+sTt
+uFj
+dxg
+acN
+acN
+qBm
+cna
+cna
+cna
+wHq
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+nlg
+nlg
+nlg
+nlg
+wvV
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+mbw
+kYO
+ilz
+fBa
+rZa
+laK
+oAl
+oAl
+heT
+mnh
+mFy
+chu
+asb
+lPD
+heT
+heT
+heT
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(278,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wCv
+fSP
+fSP
+acN
+acN
+dxg
+sTt
+osy
+sTt
+sIx
+sIx
+dxg
+aBf
+sTt
+dxg
+acN
+mlO
+cna
+cna
+bSh
+cna
+wtm
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+mBb
+mxh
+wvV
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+nZt
+lty
+jmk
+vCL
+goC
+tjW
+wAN
+vme
+ybw
+oAl
+heT
+mnh
+oef
+chu
+chu
+ejc
+chu
+chu
+oAl
+heT
+heT
+oAl
+oAl
+oAl
+oAl
+xcA
+heT
+oAl
+oAl
+oAl
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(279,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+gpD
+sTt
+itH
+dKx
+sTt
+acN
+aBf
+dxg
+dxg
+jdy
+ryT
+dxg
+sQg
+sTt
+dxg
+osy
+acN
+acN
+umy
+cna
+cna
+cna
+nxJ
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+nZt
+tiU
+kHC
+ybw
+oIM
+gMy
+wxb
+jFe
+bpK
+oAl
+heT
+mnh
+mJS
+dns
+txL
+vhT
+tvQ
+chu
+chu
+lgg
+ejc
+klR
+mQy
+wNF
+fLs
+xcA
+nMp
+gAJ
+oAl
+dVf
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(280,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+hAY
+sIx
+sTt
+tMv
+dKx
+pWZ
+wCv
+sTt
+uFj
+osy
+dxg
+sTt
+sTt
+dxg
+dxg
+pWZ
+fZv
+acN
+acN
+uMQ
+lMd
+cna
+cna
+cna
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+bqn
+tiU
+vsO
+wBK
+riO
+ybw
+bpK
+oIM
+ybw
+sjN
+oAl
+heT
+slh
+oAl
+oAl
+oAl
+chu
+chu
+chu
+mLo
+asb
+jDZ
+icx
+lkD
+icx
+xcA
+mjV
+hcZ
+qay
+fIe
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(281,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+sUz
+hyr
+aBf
+peJ
+lyL
+sTt
+cZN
+aBf
+sTt
+dxg
+fZv
+dxg
+dxg
+dxg
+sTt
+qOu
+aBf
+acN
+acN
+giT
+cna
+tGW
+cna
+wll
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+nZt
+mnh
+uBt
+cuY
+jXK
+ybw
+ybw
+bXd
+jpv
+sJQ
+oAl
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+dlW
+aOa
+chu
+wVo
+icx
+pIp
+oMH
+saz
+aTD
+icx
+sMZ
+lKH
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(282,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+sUz
+wIF
+wIF
+aBf
+osy
+tHb
+aBf
+sTt
+dxg
+osy
+nzm
+sQg
+osy
+wWR
+osy
+sTt
+osy
+acN
+acN
+cyN
+cna
+wll
+rJD
+cna
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+hxJ
+mnh
+tiU
+tiU
+cEy
+cEy
+cEy
+tiU
+qMQ
+tiU
+tiU
+oAl
+oAl
+oAl
+oAl
+heT
+heT
+oAl
+bSM
+flv
+cZI
+saz
+rrd
+saz
+saz
+saz
+nIf
+mnh
+sNb
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(283,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+sUz
+osy
+fZv
+xub
+sTt
+tph
+acN
+udY
+dxg
+acB
+dxg
+xnN
+dxg
+icF
+sTt
+aBf
+sTt
+acN
+acN
+pma
+cna
+cna
+cna
+cna
+hne
+bga
+cna
+wbA
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+chu
+hEq
+ybw
+wAN
+wAN
+wAN
+wAN
+wAN
+hfc
+wAN
+hvq
+mnh
+hvq
+oAl
+oAl
+oAl
+heT
+oAl
+lPp
+flv
+heT
+saz
+pIp
+bHG
+bHG
+ccn
+icx
+pIp
+icx
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(284,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+sUz
+sUz
+acN
+sUz
+sUz
+sUz
+acN
+mUc
+nKt
+pXu
+acN
+sUz
+sAd
+sUz
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wll
+bsc
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+chu
+mfm
+iqr
+wAN
+ybw
+ybw
+ybw
+ybw
+wAN
+wAN
+ybw
+jnC
+ybw
+ybw
+pSW
+oAl
+heT
+oAl
+vJF
+dmn
+oAl
+heT
+icx
+haM
+icx
+icx
+lkD
+icx
+jQC
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(285,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+lmX
+sTt
+vfx
+nLC
+sTt
+fZv
+vUd
+rCv
+skI
+aQJ
+sTt
+rCv
+sQg
+sTt
+sTt
+rCv
+gFH
+fvo
+aQJ
+rCv
+wTf
+sTt
+bwJ
+nLC
+vUd
+sTt
+sIx
+nLC
+pfz
+nLC
+nLC
+brF
+tjG
+nLC
+nLC
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+jXV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+hEq
+hvq
+ybw
+nqM
+ybw
+tmq
+wvQ
+wAN
+ybw
+ybw
+mnh
+qNZ
+ybw
+auP
+pRz
+oAl
+heT
+iAi
+iAi
+gaY
+gaY
+wsd
+jDl
+icx
+icx
+icx
+icx
+nJg
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(286,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+ajM
+wmj
+cUH
+nLC
+pNr
+iFk
+cUH
+rCv
+lJf
+aBf
+iWx
+rCv
+sIx
+dxg
+svS
+rCv
+iWx
+iFk
+beZ
+rCv
+iWx
+osy
+oMq
+nLC
+cUH
+vXK
+beZ
+nLC
+cna
+fUH
+nLC
+tiw
+myX
+swW
+nLC
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+wAN
+ybw
+ybw
+mnh
+ybw
+tfs
+ybw
+tQq
+szG
+heT
+gaY
+gaY
+gaY
+szv
+oVP
+icx
+sml
+urj
+icx
+eAB
+wsd
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(287,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+rsN
+aBf
+mfv
+nLC
+evD
+aBf
+ckV
+nLC
+gpD
+sTt
+tZj
+rCv
+dxg
+itH
+twX
+nLC
+eQE
+sTt
+evD
+rCv
+ckV
+wmj
+evD
+nLC
+eQE
+aBf
+xDh
+nLC
+uRU
+cna
+ckR
+iUn
+ffU
+bNk
+nLC
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+qPk
+gIS
+srL
+uMy
+vyR
+tiU
+wAN
+ybw
+ybw
+mnh
+szv
+mnh
+jnC
+mnh
+mnh
+gaY
+szv
+hfO
+mnh
+mnh
+mnh
+mnh
+aXO
+mnh
+sNb
+sNb
+sNb
+szv
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(288,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+nLC
+hAQ
+nVq
+nLC
+nLC
+hAQ
+sUk
+rCv
+rCv
+hAQ
+nLC
+nLC
+urz
+sqr
+urz
+nLC
+nVq
+hAQ
+nLC
+rCv
+sUk
+bsa
+rCv
+rCv
+sUk
+bsa
+rCv
+rCv
+nLC
+cna
+nLC
+fXb
+qDC
+hpz
+nLC
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+hrb
+qPk
+qPk
+vqD
+kaN
+hEq
+ybw
+wAN
+wAN
+tmq
+nMd
+llq
+esZ
+oBt
+gaY
+gaY
+uhl
+rhp
+dns
+tLw
+dns
+aOa
+chu
+aOa
+dns
+tLw
+awP
+vow
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(289,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+sIx
+sTt
+fZv
+sTt
+osy
+sTt
+sTt
+sTt
+dxg
+qBR
+fZh
+sTt
+dxg
+dxg
+dxg
+dxg
+sTt
+osy
+osy
+sTt
+osy
+sQg
+dxg
+oKD
+qYN
+dxg
+sTt
+hEl
+hEl
+rCv
+raV
+nLC
+nLC
+dzM
+nLC
+nLC
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hEq
+bpD
+vqD
+kfQ
+qPk
+hvs
+tiU
+qYW
+wAN
+ybw
+ybw
+mfJ
+esZ
+voH
+aOa
+gaY
+gRC
+awP
+aOa
+aOa
+chu
+dns
+aOa
+aOa
+lXr
+dns
+awP
+aOa
+vow
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(290,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wmj
+sTt
+osy
+aBf
+sTt
+ibZ
+sQg
+kKg
+osy
+dxg
+sTt
+dxg
+sQg
+osy
+sTt
+qOu
+dxg
+dxg
+uEo
+sTt
+dxg
+acB
+aBf
+sTt
+hEl
+hEl
+deG
+deG
+deG
+nLC
+cna
+rCv
+ppx
+iUn
+hfw
+iAu
+acN
+acN
+acN
+hqq
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hEq
+vJR
+qPk
+qPk
+qPk
+qPk
+tiU
+pPe
+ybw
+ybw
+ybw
+noh
+voH
+ybw
+pXl
+gaY
+gRC
+dlW
+nZt
+aOa
+pBP
+aOa
+uPk
+tLw
+chu
+aOa
+pXl
+aOa
+wex
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(291,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+sTt
+tph
+how
+eZE
+udY
+nLC
+rCv
+rCv
+rCv
+rCv
+rCv
+rCv
+nLC
+bqa
+bqa
+tuO
+nLC
+nLC
+rCv
+rCv
+nLC
+nLC
+nLC
+nLC
+wqh
+lIl
+xjX
+fPL
+hEl
+nLC
+wll
+keg
+dTC
+eqo
+qDC
+wHs
+acN
+acN
+acN
+siS
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+jDe
+qPk
+bpx
+uQS
+oYt
+hEq
+tmq
+wAN
+ybw
+szv
+mnh
+pAO
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+tPo
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(292,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+sTt
+sTt
+aBf
+sTt
+fvo
+sTt
+ily
+aBf
+xla
+dxg
+ily
+sTt
+nzm
+sTt
+osy
+fZv
+aBf
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+eoU
+rCv
+rba
+mNC
+ujF
+drd
+acN
+acN
+mXz
+rOh
+mXz
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+jXV
+jXV
+wvV
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+oKE
+qPk
+qPk
+qPk
+aDF
+hEq
+tmq
+wAN
+ybw
+mnh
+dtT
+dOu
+euw
+lPB
+mnh
+aSZ
+ipt
+xWV
+mZm
+vNM
+xWV
+jkW
+jkW
+bWK
+sXh
+jFM
+rmC
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(293,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+nLC
+sTt
+sTt
+osy
+sTt
+aBf
+rCv
+rCv
+nLC
+rCv
+nLC
+nLC
+sTt
+dxg
+byu
+rCv
+rCv
+rCv
+rCv
+rCv
+nLC
+tHb
+oif
+xym
+sKD
+cna
+cna
+rpQ
+nLC
+eoU
+rCv
+ppx
+iUn
+gDO
+bys
+acN
+acN
+qMG
+kzP
+bey
+ivr
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+xvl
+olg
+bRG
+xvl
+xvl
+hEq
+ybw
+wAN
+ybw
+tiU
+sST
+jtJ
+sST
+sST
+mnh
+sqR
+rts
+rFw
+ipt
+nOO
+ipt
+lNR
+jkW
+mnh
+fYf
+jkW
+eYJ
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(294,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+sIx
+sTt
+sTt
+sTt
+osy
+nLC
+rCv
+rCv
+hEl
+hEl
+haX
+aBf
+osy
+dxg
+dxg
+sTt
+dxg
+osy
+haX
+kQz
+sTt
+rCv
+rCv
+nLC
+nLC
+nLC
+dEx
+eoU
+tFW
+nLC
+cna
+nLC
+rCv
+jNB
+nLC
+nLC
+acN
+acN
+tsb
+wxE
+qNT
+iaI
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hEq
+lJB
+sST
+neR
+sST
+xfD
+hkw
+ybw
+ybw
+ybw
+ivT
+euw
+sST
+dtT
+sST
+tiU
+sqR
+ipt
+ipt
+ipt
+ipt
+tSP
+wOm
+qQC
+tPo
+oqD
+exU
+rFw
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(295,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+aOu
+xOm
+hhx
+nLC
+rCv
+rCv
+hEl
+cgR
+hEl
+dxg
+dxg
+ngr
+dxg
+fZv
+osy
+nzm
+sTt
+dxg
+dxg
+fZv
+sTt
+sTt
+hEl
+rCv
+rCv
+nLC
+sJZ
+eoU
+nLD
+nLC
+cna
+rCv
+hdP
+dPI
+mgm
+pgD
+sgo
+acN
+jPo
+bJX
+qNT
+kRb
+acN
+pyq
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hEq
+vJT
+tSt
+xfD
+sST
+ixz
+mnh
+ybw
+lYr
+lYr
+mnh
+hVK
+sST
+sST
+sST
+mnh
+tMK
+gei
+lNR
+ipt
+rmC
+ipt
+xcZ
+xWV
+mnh
+ipt
+rqL
+lNR
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(296,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+oif
+sgO
+nLC
+rCv
+hrK
+hEl
+epC
+hEl
+dxg
+hEl
+hEl
+sTt
+sTt
+lpq
+sTt
+sTt
+osy
+sTt
+sTt
+dxg
+dxg
+osy
+jEv
+hEl
+wAH
+nLC
+nLC
+pfz
+nLC
+nLC
+eNe
+rCv
+oCQ
+gvv
+fDq
+thc
+fwv
+acN
+utc
+oQo
+iqI
+wuB
+oeL
+kGb
+ipH
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+hEq
+evB
+obJ
+sST
+neR
+neR
+mLK
+ybw
+wAN
+ybw
+mLK
+sST
+lPB
+oIO
+oIO
+ivT
+pIg
+mZm
+xWV
+xWV
+qQC
+gZE
+dDv
+tXr
+bWK
+owr
+ipt
+lNR
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(297,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vFV
+oif
+rCv
+oPM
+hEl
+fyI
+dxg
+dxg
+hEl
+dxg
+nLC
+nLC
+rCv
+rCv
+rCv
+ily
+nLC
+rCv
+rCv
+nLC
+sTt
+dxg
+dxg
+dxg
+hEl
+pjh
+nLC
+eoU
+eoU
+eoU
+cna
+rCv
+bOL
+gvv
+wJP
+qkl
+msr
+acN
+oiT
+bTD
+wJP
+wJP
+wJP
+bTD
+nQm
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+xwF
+mnh
+oIO
+dWO
+sST
+jtJ
+sST
+mLK
+ybw
+ybw
+pPe
+mLK
+sST
+bvV
+sID
+xRv
+mnh
+bWK
+bWK
+mnh
+tPo
+tPo
+mnh
+bWK
+bWK
+mnh
+eYJ
+rFw
+lNR
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(298,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kpM
+iGP
+bHv
+pTS
+gXJ
+acN
+vFV
+nLC
+rCv
+hEl
+hEl
+dxg
+hEl
+mOX
+nLC
+vLG
+nLC
+rCv
+vnh
+pEy
+sTt
+fZh
+dxg
+osy
+nun
+nLC
+nLC
+hEl
+hEl
+dxg
+sTt
+hEl
+nLC
+nLC
+cna
+cna
+nLC
+nLy
+qaE
+iPS
+rrX
+wJP
+fRX
+acN
+eLM
+nru
+nru
+lom
+mPh
+mPh
+vgI
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+hdY
+fGW
+ewI
+neR
+dxZ
+mLK
+ybw
+wAN
+ybw
+mLK
+sST
+bvV
+rNR
+sST
+mnh
+eYJ
+ipt
+ipt
+cgn
+ipt
+hCd
+ipt
+yei
+mnh
+vdk
+pey
+mRR
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(299,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+qvA
+oDr
+hZW
+kSq
+oHn
+eST
+sTt
+rCv
+jZn
+hEl
+dxg
+hEl
+hEl
+nLC
+nLC
+hEl
+eTK
+rCv
+kSs
+pnp
+nLC
+hVk
+tOf
+nLC
+nLC
+nLC
+nLC
+nLC
+mOX
+deG
+osy
+fZv
+uiT
+nLC
+kgl
+cna
+nLC
+iKr
+iMp
+wXw
+nLC
+aiw
+mRi
+acN
+sUz
+sUz
+acN
+qfs
+vuS
+vuS
+qfs
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+ivT
+aYo
+mWY
+neR
+neR
+rso
+mnh
+kjw
+lYr
+wAN
+tiU
+sST
+bvV
+sID
+xfD
+mnh
+nUD
+eUi
+owr
+rmC
+nOO
+ipt
+cVm
+qZR
+mnh
+fIO
+jWN
+mpQ
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(300,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+rdr
+xXw
+cKg
+pjF
+dRY
+acN
+nLC
+rCv
+hEl
+dxg
+hEl
+hEl
+hEl
+nLC
+oSz
+qOj
+qce
+rCv
+qHz
+nzm
+nLC
+kNS
+dxg
+lCm
+vQT
+nLC
+nLC
+cWI
+acr
+hEl
+dxg
+sTt
+kKu
+nLC
+nLC
+cna
+rCv
+xon
+iPS
+wJP
+efc
+oLJ
+qkP
+nLC
+wez
+hpz
+acN
+pEP
+kGB
+pMD
+eFA
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+toz
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+oIO
+oIO
+oIO
+neR
+neR
+pXV
+wAN
+ybw
+ybw
+xYW
+xfD
+ylh
+sID
+lPB
+tiU
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+rAm
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(301,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+frm
+acN
+acN
+nLC
+mOX
+hEl
+deG
+fZv
+hEl
+nLC
+nLC
+nLC
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+rtf
+hEl
+dxg
+mOX
+fPL
+nLC
+hXc
+rCv
+efc
+wJP
+iPS
+wJP
+wJP
+azk
+nLC
+qpJ
+iUn
+vHC
+vHi
+kGB
+kGB
+kIH
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+mnh
+mnh
+wex
+hEq
+aIr
+hdY
+hdY
+sST
+xfD
+tiU
+wAN
+ybw
+ybw
+hEq
+sST
+sST
+sST
+sST
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+box
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(302,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+abo
+gfw
+mQi
+pBl
+acN
+sMA
+hNi
+ahc
+oNl
+jJT
+vMa
+xPI
+nLC
+hEl
+cob
+deG
+sTt
+nLC
+nLC
+mtA
+mdr
+acN
+hoD
+hbW
+ohX
+rAi
+acN
+uQU
+voE
+uVR
+uVR
+vyZ
+bvY
+hjQ
+dAV
+sdi
+hEl
+dxg
+hEl
+vOP
+nLC
+psm
+nLC
+eSF
+wJP
+gvv
+qkl
+bTD
+aaU
+rCv
+hpz
+qDC
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tGk
+aaS
+gUL
+cfd
+mnh
+wex
+mnh
+mOz
+aYo
+evB
+sST
+jtJ
+mnh
+aOL
+wAN
+ybw
+hEq
+sST
+xfD
+sST
+sST
+dzs
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+chu
+nZt
+box
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(303,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+anj
+iep
+lqv
+pVg
+acN
+lkr
+rBn
+jJT
+jJT
+jJT
+rBn
+ipE
+nLC
+hEl
+mOX
+wBZ
+hEl
+tSV
+xix
+lxG
+mdr
+acN
+iFY
+wJP
+iYg
+hwF
+acN
+aIq
+khO
+khO
+khO
+fJB
+bvY
+jbL
+umg
+hEl
+fyI
+deG
+osy
+rBt
+rCv
+raV
+nLC
+cal
+wJP
+iPS
+wJP
+wJP
+trH
+rCv
+tiw
+iUn
+nLC
+xic
+rzU
+kGB
+kGB
+rqk
+acN
+acN
+acN
+acN
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+ivT
+mKA
+ybw
+ybw
+tiU
+wex
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+ybw
+wAN
+pgk
+mnh
+ivT
+tiU
+tiU
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+chu
+mnh
+mnh
+mnh
+box
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(304,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+anu
+jeq
+iep
+qJs
+acN
+dHF
+jJT
+ufP
+rsi
+dGE
+jJT
+jJT
+cjC
+hEl
+hEl
+deG
+hEl
+fBp
+lnK
+icR
+oVn
+acN
+eTp
+bTD
+eTp
+acN
+acN
+khO
+khO
+khO
+khO
+fJB
+bvY
+euR
+agR
+sTt
+hEl
+deG
+sTt
+jTp
+rCv
+bga
+nLC
+fUz
+hQi
+hQi
+ifF
+hQi
+xDQ
+rCv
+hpz
+iUn
+nLC
+idY
+kGB
+rAf
+uJc
+xbT
+acN
+acN
+acN
+acN
+wvV
+bsh
+bsh
+bsh
+rqt
+rqt
+qCx
+qCx
+qCx
+rqt
+gTl
+toz
+toz
+toz
+toz
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+yhT
+vDr
+tiU
+vDr
+mnh
+mnh
+jks
+eWb
+hOL
+iAo
+mnh
+tmq
+ybw
+ybw
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+chu
+mnh
+heT
+mnh
+olu
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(305,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bii
+iep
+ktT
+sXK
+acN
+jJT
+lOU
+ezk
+vrA
+eSB
+jJT
+rBn
+wWD
+siS
+siS
+deG
+mOX
+nLC
+tTB
+nvs
+mdr
+acN
+eTp
+wJP
+eTp
+acN
+oNr
+edO
+bpv
+bpv
+khO
+vIu
+nLC
+mDd
+nLC
+tSj
+hEl
+deG
+sTt
+fPL
+rCv
+pfz
+nLC
+gyG
+rZt
+mpl
+oaO
+kED
+nLC
+eSt
+iUn
+qfs
+pzK
+nLC
+xKj
+xKj
+xKj
+nLC
+tXL
+acN
+acN
+acN
+bzn
+utz
+tcp
+tcp
+upG
+fRY
+fRY
+fRY
+fRY
+sIP
+gTl
+toz
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+rqW
+ybw
+ybw
+ybw
+ybw
+nbg
+ivT
+nOQ
+hdA
+gsq
+hdA
+mnh
+mnh
+pmi
+uyt
+hEq
+mnh
+mnh
+ghv
+bro
+jio
+ybw
+qss
+mnh
+bUg
+ybw
+mnh
+chu
+mnh
+heT
+mnh
+chu
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(306,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bii
+iep
+ktT
+tjZ
+acN
+jJT
+gha
+jJT
+bIl
+jJT
+dba
+jJT
+iuf
+hpz
+hpz
+tIg
+siS
+rSI
+mdr
+mdr
+dOa
+acN
+acN
+uqc
+acN
+acN
+jsc
+khO
+hyF
+dfo
+cXM
+fJB
+rhY
+hEl
+mOX
+hEl
+hEl
+deG
+hEl
+mOX
+hzm
+vJf
+hpz
+gCB
+ivg
+iUn
+iUn
+iUn
+sVY
+rgZ
+qDC
+fsQ
+wnp
+gDg
+kJn
+hpz
+nQZ
+gLH
+kib
+acN
+vKE
+hDk
+dgA
+seM
+fRY
+fRY
+wBn
+fRY
+fRY
+uqW
+fRY
+tXq
+gTl
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+ivT
+meT
+ybw
+pPe
+ybw
+ybw
+fVY
+tiU
+uSq
+hdA
+hdA
+tiU
+ybw
+ybw
+ybw
+ybw
+ybw
+tiU
+mnh
+cUq
+ybw
+ybw
+ybw
+ybw
+vKk
+ybw
+ybw
+tGk
+chu
+mnh
+heT
+mnh
+dzs
+iAW
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(307,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bji
+kpf
+lqv
+tXS
+acN
+vaP
+acN
+pVO
+pPR
+pPR
+oiz
+acN
+nLC
+hpz
+iUn
+hpz
+nxW
+nLC
+nLC
+pph
+nLC
+nLC
+mgD
+fJB
+mWU
+xlt
+khO
+wmu
+sut
+bpv
+cXM
+fJB
+xlt
+lul
+vJf
+vJf
+aic
+siS
+vJf
+siS
+fxw
+hpz
+iUn
+iUn
+iUn
+hpz
+sqQ
+hpz
+qDC
+ivg
+hpz
+fsQ
+wnp
+hpz
+clb
+hpz
+daL
+fiS
+ogI
+fyx
+eYk
+wnp
+pXb
+seM
+pXt
+fRY
+cmQ
+fRY
+fRY
+fRY
+fRY
+hJC
+gTl
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+hvq
+ybw
+ybw
+ybw
+jWK
+ghv
+mnh
+lbs
+hdA
+hEq
+hQh
+ybw
+qVV
+qVV
+qVV
+ofn
+ybw
+ivT
+bhG
+ybw
+ybw
+ybw
+ybw
+mnh
+ybw
+ybw
+dzs
+chu
+mnh
+mnh
+mnh
+rzi
+hvq
+ghv
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(308,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bii
+ktT
+iep
+kpf
+kXO
+hGM
+uvG
+lHm
+cHN
+kFh
+kFh
+lHm
+osa
+ufr
+iUn
+hpz
+eoK
+rCv
+oIK
+kDZ
+tZi
+nLC
+xWj
+gvi
+xWj
+nLC
+mMe
+khO
+khO
+gtA
+cXM
+fJB
+rhY
+etq
+hpz
+ivg
+iUn
+iUn
+hpz
+iUn
+shh
+qDC
+hpz
+ozh
+hpz
+ivg
+aqw
+iUn
+hpz
+uHp
+hpz
+fsQ
+wnp
+uva
+eDb
+eHS
+qll
+hpz
+ogI
+acN
+eYk
+uha
+xtr
+seM
+uqW
+fRY
+sSR
+fRY
+uqW
+fRY
+fRY
+wwd
+gTl
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+szv
+mnh
+jnC
+mnh
+sSH
+sSH
+mnh
+szv
+yjH
+tiU
+ybw
+hvg
+lxR
+sVA
+sVA
+hvq
+ybw
+hEq
+mnh
+mnh
+jnC
+mnh
+mnh
+mnh
+ctn
+ctn
+mnh
+mnh
+mnh
+mnh
+rqW
+ybw
+wAN
+ybw
+ybw
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(309,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bii
+ktT
+kpf
+ktT
+byB
+lHm
+mrX
+hGM
+hGM
+lHm
+mrX
+hGM
+hcW
+iUn
+acL
+eoK
+bKH
+rCv
+erA
+eWc
+icR
+nLC
+gjB
+wiD
+biu
+nLC
+oNr
+edO
+bpv
+vcQ
+nOl
+nRE
+nLC
+xZD
+nLC
+hph
+hpz
+iUn
+hpz
+nxW
+nLC
+fgL
+nLC
+nLC
+ezM
+lFU
+uIU
+hWL
+nLC
+nLC
+dcQ
+nLC
+pzK
+nLC
+acN
+acN
+acN
+acN
+tXL
+acN
+acN
+acN
+bzn
+utz
+tcp
+tcp
+upG
+fRY
+fRY
+fRY
+fRY
+wwd
+gTl
+toz
+bsh
+toz
+bsh
+bsh
+toz
+toz
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+mnh
+mnh
+mnh
+ybw
+ybw
+ybw
+hEq
+ybw
+laK
+ybw
+ybw
+ybw
+ivT
+ybw
+sVA
+voH
+hQh
+lMD
+sVA
+ybw
+hEq
+ybw
+pxv
+pPe
+lYr
+wAN
+wAN
+wAN
+wAN
+wAN
+wAN
+ybw
+mnh
+ybw
+ybw
+gas
+pQO
+pPe
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(310,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+bii
+iep
+kpf
+jeq
+vGG
+hGM
+qrN
+lHm
+hGM
+hGM
+qrN
+wjp
+ecS
+kMx
+hpz
+eoK
+lsr
+rCv
+tTB
+mew
+oVn
+nLC
+rll
+mdr
+wiD
+nLC
+nLC
+khO
+khO
+khO
+khO
+fJB
+bvY
+kDq
+xZD
+cyi
+hpz
+hpz
+iUn
+dvR
+nLC
+mBt
+nLC
+seF
+dFO
+lQm
+xfY
+hPw
+nwU
+nLC
+bjX
+rSu
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+bsh
+bsh
+bsh
+rqt
+rqt
+ycL
+ycL
+ycL
+rqt
+gTl
+bsh
+toz
+bsh
+bsh
+bsh
+toz
+toz
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+ivT
+eZD
+wAN
+aXY
+oyE
+ybw
+ybw
+ybw
+hUg
+ybw
+ybw
+ybw
+ybw
+wDI
+jnC
+ybw
+pHQ
+ybw
+vUH
+fQz
+sVA
+ybw
+pmi
+ybw
+ybw
+wAN
+wAN
+ybw
+wAN
+wAN
+wAN
+wAN
+wAN
+wAN
+lHY
+ybw
+ybw
+irr
+cQf
+pgk
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(311,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+boc
+iep
+kpf
+vap
+acN
+lao
+wjp
+lHm
+lHm
+mrX
+kyH
+lHm
+nLC
+iUn
+hpz
+hpz
+jdE
+rCv
+vxe
+nvs
+mdr
+nLC
+onQ
+tGa
+mdr
+sUn
+nLC
+fJB
+khO
+nOl
+nOl
+fJB
+bvY
+brn
+xZD
+cyi
+hpz
+qDC
+iUn
+waP
+nLC
+mBt
+nLC
+wrv
+dFO
+sAt
+jwv
+gKj
+nso
+rCv
+pNt
+cna
+iRr
+nsq
+cna
+cna
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+tGk
+qoX
+ybw
+wAN
+ybw
+oyE
+ybw
+ofn
+ybw
+jxG
+laK
+ybw
+tmq
+pnm
+hQh
+tiU
+ybw
+sVA
+mwU
+ybw
+gze
+lxr
+ybw
+mnh
+ybw
+pxv
+ybw
+pxv
+ybw
+ybw
+pPe
+ybw
+ybw
+ybw
+ybw
+mnh
+qYW
+ybw
+mEL
+fMr
+ybw
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(312,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+cor
+jeq
+kpf
+woL
+acN
+lHm
+iVq
+lHm
+wjp
+hLT
+lHm
+mrw
+nLC
+kkF
+iUn
+hpz
+rJv
+rCv
+nLC
+ugC
+urp
+nLC
+uSm
+lnK
+icR
+wiD
+nLC
+lWw
+kzc
+mlf
+mlf
+tly
+bvY
+tiE
+osh
+iUn
+iUn
+ivg
+hpz
+lgV
+nLC
+nfu
+nLC
+nLC
+uIU
+nLC
+prg
+hWL
+rCv
+nLC
+wll
+rJD
+acN
+kpp
+bjX
+wll
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+kIw
+kIw
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+mnh
+mnh
+tiU
+iOQ
+vXP
+tiU
+rmR
+ybw
+pyZ
+tiU
+qYW
+ybw
+ybw
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+tiU
+ybw
+ipU
+sVA
+sVA
+sVA
+hvq
+hQh
+tiU
+mnh
+mnh
+jnC
+mnh
+mnh
+mnh
+ctn
+ctn
+mnh
+mnh
+mnh
+mnh
+ybw
+wAN
+pPe
+ybw
+ybw
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(313,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+anu
+lqv
+iep
+coo
+acN
+qbQ
+cip
+lHm
+lHm
+xYR
+lHm
+pim
+nLC
+rBv
+hpz
+qDC
+hpz
+hpz
+rCv
+nLC
+nLC
+nLC
+jYw
+gEd
+mdr
+ivv
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+hlt
+hpz
+hpz
+kgA
+iwg
+nLC
+mxI
+nLC
+wfa
+stO
+pPg
+nOY
+stO
+fIy
+rCv
+vRz
+cna
+acN
+acN
+acN
+pfz
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+toz
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+mnh
+usZ
+uir
+wAN
+wAN
+jnC
+wAN
+wAN
+ybw
+mBx
+ybw
+ybw
+ybw
+eev
+opn
+voH
+pPe
+laK
+mnh
+ivT
+wvQ
+ybw
+qVV
+qVV
+qVV
+ybw
+ybw
+tiU
+uEX
+ybw
+pPe
+ybw
+ybw
+mnh
+bUg
+ybw
+dzs
+chu
+chu
+mnh
+mnh
+ybw
+ybw
+ybw
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+"}
+(314,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+mtT
+nAr
+acN
+acN
+lHm
+iVq
+lHm
+hxg
+fyq
+lHm
+wDr
+nLC
+rCv
+hpz
+iUn
+hpz
+iUn
+kgA
+nLC
+nLC
+nLC
+acN
+nLC
+rrR
+nLC
+acN
+kJQ
+bga
+bga
+bga
+aRg
+fqN
+xPL
+iUn
+hpz
+iUn
+hpz
+hdd
+rCv
+nLC
+vhS
+nLC
+bnR
+rpr
+oVm
+olV
+rpr
+laE
+rCv
+fUH
+cna
+pfz
+bga
+fUH
+gSH
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+mnh
+usZ
+ivT
+iRj
+dxY
+mnh
+pRz
+itg
+hQh
+hEq
+uef
+ybw
+ybw
+eev
+gze
+esZ
+tRg
+ybw
+mnh
+mnh
+tGk
+ybw
+ybw
+ybw
+ybw
+gCc
+mnh
+mnh
+cUq
+wAN
+wAN
+wAN
+ybw
+oin
+wAN
+wAN
+tGk
+mnh
+chu
+chu
+mnh
+mnh
+jnC
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(315,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+dVc
+iep
+jeq
+hfE
+acN
+iFq
+lHm
+lHm
+lHm
+hGM
+qrN
+cap
+nLC
+rCv
+aeB
+iUn
+hpz
+iUn
+hpz
+rCv
+nLC
+nLC
+acN
+vkG
+fok
+fok
+acN
+bga
+bga
+bga
+cna
+fqN
+nLC
+nLC
+hpz
+hpz
+qDC
+hpz
+kGX
+rCv
+nLC
+jrh
+nLC
+iGt
+pZw
+olV
+jhz
+sVP
+fIy
+nLC
+raa
+bjX
+acN
+acN
+pfz
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+ekr
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+mnh
+usZ
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+hEq
+bpK
+oac
+mrd
+hEq
+aoN
+ssN
+ssN
+cmR
+mnh
+iOQ
+lmH
+hEq
+ybw
+hfc
+ybw
+hEq
+chu
+dzs
+rtc
+ghv
+laL
+ybw
+vXy
+mnh
+wAN
+wAN
+mnh
+mnh
+mnh
+chu
+mnh
+hvq
+ybw
+ybw
+mnh
+bYA
+heT
+heT
+heT
+heT
+heT
+"}
+(316,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+eQe
+mGy
+lqv
+kYj
+acN
+vah
+wjp
+lHm
+unA
+wtc
+unA
+bdq
+nLC
+rCv
+rCv
+hpz
+iUn
+qDC
+qDC
+hpz
+rCv
+nLC
+acN
+tXB
+xQh
+skB
+acN
+bga
+bga
+rrI
+hTW
+nLC
+nLC
+gcg
+acL
+hpz
+hpz
+iUn
+rCv
+nLC
+nLC
+nLC
+cYB
+rpr
+qsz
+stO
+stO
+stO
+jSy
+nLC
+bga
+cna
+acN
+vRz
+cna
+xPY
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+toz
+toz
+toz
+heT
+heT
+heT
+heT
+mnh
+usZ
+mnh
+heT
+heT
+hEq
+wAN
+tEN
+wAN
+oyE
+ybw
+ybw
+wAN
+mBx
+wAN
+xaD
+wAN
+wAN
+jnC
+wAN
+wAN
+ivT
+hvq
+ybw
+ybw
+mnh
+chu
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+chu
+dzs
+ybw
+ybw
+ybw
+dzs
+bYA
+bYA
+heT
+heT
+heT
+heT
+"}
+(317,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+aXn
+miZ
+tRq
+mYv
+ogs
+eDB
+acN
+nLC
+nLC
+nLC
+rIa
+hpz
+acL
+hpz
+iUn
+hpz
+hpz
+oTE
+acN
+acN
+acN
+acN
+rCv
+rCv
+rCv
+rCv
+rCv
+iUn
+hpz
+hpz
+hpz
+iUn
+cPC
+nLC
+nLC
+nLC
+nLC
+lXG
+stO
+fqm
+rCv
+rCv
+nLC
+acN
+nLC
+acN
+kcj
+acN
+cna
+cna
+vNX
+acN
+acN
+acN
+acN
+wvV
+wvV
+jXV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+mnh
+usZ
+mnh
+heT
+heT
+tiU
+qVV
+pXG
+tEN
+oyE
+wAN
+ybw
+bpK
+tiU
+hvq
+wAN
+wAN
+wAN
+vDr
+wxe
+sqx
+mnh
+tmq
+ybw
+ybw
+tiU
+dzs
+mnh
+vDr
+tiU
+tiU
+mnh
+mnh
+mnh
+mnh
+aRx
+iWM
+mnh
+heT
+mnh
+mnh
+nWO
+dWY
+vXy
+mnh
+bYA
+bYA
+heT
+heT
+heT
+heT
+"}
+(318,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+kkh
+mKt
+tRq
+mKt
+bcG
+acN
+sZf
+gGH
+nLC
+nLC
+gbd
+hpz
+hpz
+hpz
+iUn
+hpz
+iUn
+hpz
+ivg
+hpz
+iUn
+hpz
+kgA
+ktB
+ivg
+hpz
+hpz
+iUn
+ivg
+iUn
+qnJ
+rCv
+nLC
+nLC
+nLC
+nLC
+nLC
+rpr
+qsz
+egJ
+jul
+lGt
+noo
+acN
+acN
+acN
+acN
+pfz
+iRr
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+jXV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+lNi
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+mnh
+usZ
+mnh
+mnh
+tGk
+tiU
+wAN
+ilr
+wAN
+mnh
+jXK
+bpK
+ghv
+mnh
+ybw
+tmq
+wAN
+rVV
+mnh
+dzs
+mnh
+mnh
+ybw
+ybw
+ybw
+ivT
+ghW
+gnh
+gnh
+gnh
+sOV
+hEq
+jQx
+erU
+ghW
+pzH
+pzH
+vTY
+mnh
+heT
+mnh
+mnh
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(319,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+lTT
+mKt
+mKt
+tRq
+uya
+iUG
+tFJ
+pTv
+nLC
+nLC
+rCv
+rCv
+hpz
+iUn
+hpz
+qDC
+hpz
+qDC
+iUn
+qDC
+hpz
+iUn
+hpz
+hpz
+hpz
+acL
+hpz
+hpz
+cFR
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+fuI
+xpT
+stO
+pXU
+nLC
+jJW
+jJW
+tsk
+acN
+acN
+tBv
+cna
+cna
+wpn
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+mnh
+usZ
+dsp
+iOQ
+vXP
+mnh
+egQ
+wAN
+wAN
+mBx
+ybw
+wAN
+ybw
+hEq
+mnh
+wAN
+wAN
+mnh
+mnh
+rXJ
+usZ
+qnA
+pPe
+ybw
+ybw
+xbo
+ghW
+xvm
+gnh
+gnh
+uea
+hTk
+pNo
+fea
+ibz
+ghW
+ghW
+xvm
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(320,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+eGp
+tuh
+akr
+dkm
+ePA
+acN
+pVK
+pVK
+nLC
+cZy
+cZy
+moW
+osO
+rCv
+bmZ
+sKF
+hpz
+hpz
+hpz
+acL
+hpz
+hpz
+iUn
+qDC
+oRX
+hGC
+iwg
+rCv
+rCv
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+qhE
+sVP
+jhz
+qsz
+nLC
+xZD
+xZD
+xZD
+acN
+acN
+mQZ
+fUH
+mlu
+pFF
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+mnh
+mnh
+ivT
+wAN
+wAN
+jnC
+wAN
+wAN
+wAN
+ivT
+ybw
+wAN
+ybw
+hEq
+fGK
+ybw
+wAN
+gDI
+mnh
+box
+mnh
+ivT
+ybw
+ybw
+wAN
+xbo
+gnh
+ibz
+gnh
+gnh
+sOV
+hEq
+vya
+fea
+ghW
+pmq
+pmq
+vTY
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(321,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nLC
+nLC
+nLC
+wJP
+wJP
+pxS
+iPS
+rCv
+nLC
+nLC
+nLC
+nFu
+nLC
+dnO
+hMb
+rCa
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+wkn
+oVm
+kCh
+olV
+vnK
+ddK
+qDT
+jul
+tTf
+acN
+wID
+xcc
+cna
+utq
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+jXV
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+sqx
+hxk
+mnh
+pyZ
+ybw
+nAb
+tiU
+ybw
+wAN
+wAN
+tiU
+ybw
+ghv
+xsn
+wAN
+mnh
+seq
+tGk
+hEq
+ybw
+ybw
+ybw
+xbo
+gnh
+gnh
+gnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+bLI
+kuK
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(322,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+gPD
+qBl
+gIr
+nLC
+eNT
+iPS
+wJP
+gvv
+wJP
+nLC
+nLC
+eDN
+mKS
+qLh
+nLC
+hpz
+xdu
+bSQ
+kPr
+pvj
+igZ
+jii
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+rpr
+qsz
+dEP
+stO
+egJ
+jul
+wYV
+iOn
+hYv
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+jXV
+bsh
+bsh
+bsh
+bsh
+xsG
+kIw
+qsy
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+mnh
+szv
+szv
+rOY
+aeb
+aeb
+hEq
+ybw
+wAN
+ybw
+mnh
+wAN
+ybw
+ybw
+ybw
+hEq
+rcs
+uwp
+hEq
+qYW
+ybw
+ybw
+vDr
+gnh
+ghW
+gnh
+hTk
+gnh
+gnh
+gnh
+xvm
+rwM
+mnh
+mnh
+mnh
+mnh
+mnh
+ivT
+mnh
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(323,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+nNU
+pYh
+dFy
+nLC
+gvv
+eOx
+iPS
+eOx
+vYk
+nLC
+nLC
+jgD
+vQq
+gME
+nLC
+hpz
+hpz
+iUn
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+nLC
+cuq
+bpn
+nLC
+nLC
+nLC
+rpr
+qsz
+joo
+joo
+nLC
+fwr
+sTr
+jul
+jXh
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+kIw
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+tmq
+wAN
+wAN
+wAN
+ybw
+jXK
+wAN
+wAN
+dwV
+mBx
+wAN
+wAN
+wAN
+naG
+oSu
+imp
+wAN
+hEq
+wAN
+ybw
+naG
+mBx
+ghW
+gnh
+ghW
+mnh
+eBY
+gnh
+gnh
+jro
+mnh
+tiU
+euh
+gnh
+ghW
+nqq
+gnh
+dzs
+bYA
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(324,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+aGh
+wzG
+cfB
+cTw
+wJP
+eBc
+wJP
+eBc
+wJP
+nLC
+nLC
+nLC
+nLC
+nLC
+prh
+aNo
+qDC
+aNo
+aTj
+rGv
+nsf
+emT
+uND
+dIP
+ink
+nLC
+xZD
+wDO
+nLC
+nLC
+nLC
+bEW
+qsz
+nLC
+nLC
+nLC
+nLC
+xfJ
+dfn
+ukP
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+wAN
+wAN
+wAN
+wAN
+ghv
+ghv
+wAN
+wAN
+pPe
+mnh
+eYS
+wAN
+wAN
+ybw
+mnh
+wxe
+cRc
+hEq
+hvq
+ybw
+pPe
+ivT
+gnh
+ghW
+gnh
+pPc
+ujL
+glc
+ghW
+aGV
+mnh
+hEq
+uNc
+gnh
+uwt
+nqq
+skp
+hEq
+bYA
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(325,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+oPB
+fxn
+wuE
+nLC
+wJP
+wJP
+smX
+wJP
+hYz
+nLC
+nLC
+aCI
+drG
+uWm
+nLC
+hpz
+iUn
+hpz
+aTj
+bET
+sko
+mPJ
+eVv
+kGB
+kGB
+cMg
+iyi
+qFT
+nLC
+nLC
+nLC
+oVm
+olV
+xLU
+iaE
+tgK
+nLC
+nLC
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+hMf
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+tiU
+pyZ
+wAN
+ybw
+wAN
+ghv
+bpK
+ovu
+dxY
+ybw
+hEq
+aoW
+cZQ
+otT
+vXy
+mnh
+qnA
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+wWO
+gnh
+ghW
+pPc
+qHD
+gnh
+gnh
+dgI
+mnh
+ivT
+xvm
+ghW
+eai
+ghW
+ghW
+hEq
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(326,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+rPk
+fPK
+rzN
+hWB
+iUn
+ivg
+hpz
+aTj
+qwp
+kcI
+oRg
+uND
+dkE
+mXR
+acN
+coJ
+wnn
+acN
+acN
+acN
+gZV
+sVP
+pkN
+jul
+kTd
+tTE
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+cJS
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+ivT
+wAN
+wAN
+bpK
+tiU
+mnh
+mnh
+mnh
+vDr
+yiV
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+hcm
+mnh
+heT
+heT
+heT
+heT
+anv
+ghW
+gnh
+gnh
+mnh
+pPc
+pPc
+pPc
+mnh
+vDr
+vDr
+mnh
+hTk
+tiU
+sNb
+sNb
+szv
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(327,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+dCV
+uSv
+pJh
+vcs
+gdB
+fFd
+oyq
+wYh
+xNH
+xmj
+uVK
+wOR
+hpz
+iUn
+qqR
+dJE
+acN
+acN
+acN
+acN
+hLU
+ybU
+acN
+acN
+acN
+acN
+acN
+acN
+qsz
+dEP
+rpe
+hPw
+mqh
+lgn
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+toz
+bsh
+bsh
+kIw
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+rnu
+tqt
+plr
+plr
+oxg
+plr
+plr
+wAN
+tXx
+oAN
+mnh
+qgV
+usZ
+aSz
+usZ
+rXJ
+usZ
+usZ
+usZ
+tHQ
+mnh
+heT
+heT
+heT
+tiU
+ghW
+xvm
+gnh
+gnh
+ibz
+gnh
+gnh
+ghW
+gnh
+vgK
+ghW
+ibz
+ghW
+gnh
+ghW
+vIx
+vIx
+szv
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(328,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vXB
+aEW
+aEW
+jeP
+nyG
+iiL
+lpv
+cml
+cSQ
+xmj
+rzN
+oXd
+wPe
+qDC
+hpz
+sZh
+nWW
+nsf
+bbt
+uND
+gZb
+ybU
+acN
+byT
+ohX
+acN
+acN
+acN
+qsz
+stO
+ckv
+gUS
+gNj
+waA
+acN
+acN
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+toz
+bsh
+bsh
+bsh
+kIw
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+aeb
+wAN
+ybw
+wAN
+wAN
+ybw
+ucX
+wAN
+mIZ
+hvq
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+luz
+abi
+img
+oAl
+heT
+heT
+hEq
+rFH
+gnh
+ghW
+ghW
+omi
+tiI
+ghW
+nNo
+gnh
+gnh
+ghW
+ghW
+ghW
+xvm
+ghW
+soH
+aAz
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(329,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+czO
+eoI
+rLU
+nqG
+xXH
+lAi
+uzU
+cml
+szh
+jHv
+mqv
+acN
+qBQ
+iUn
+aNo
+sZh
+bET
+bET
+wnn
+qKT
+pMD
+mXR
+acN
+otg
+iPS
+acN
+acN
+acN
+qsz
+stO
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+toz
+bsh
+bsh
+bsh
+kIw
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+aeb
+mIZ
+ybw
+wAN
+wAN
+ybw
+plr
+xCm
+pPe
+xOC
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+mnh
+oAl
+img
+pjq
+oAl
+heT
+mnh
+mnh
+mnh
+spi
+dnz
+sqy
+mnh
+sNb
+fzm
+sNb
+mnh
+sNb
+fzm
+sNb
+mnh
+sEd
+ghW
+vIx
+szv
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(330,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+czO
+nqG
+ats
+frR
+alR
+lpv
+lpv
+qmF
+rzN
+rzN
+lDC
+acN
+hpz
+iUn
+iUn
+sZh
+uLt
+oRg
+bET
+uND
+kGB
+amH
+acN
+gUn
+iPS
+acN
+acN
+acN
+oAX
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+toz
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+mnh
+mnh
+mnh
+ybw
+ybw
+aeb
+plr
+mnh
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+tHQ
+tHQ
+oAl
+oAl
+heT
+heT
+tiU
+gnh
+gnh
+ghW
+tiU
+evu
+gnh
+gnh
+ivT
+ghW
+mBR
+ghW
+mnh
+vIx
+tFs
+uNQ
+szv
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(331,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+czO
+doz
+frR
+eoI
+xXH
+lAi
+wMM
+cml
+jHv
+rzN
+rzN
+acN
+hpz
+all
+qDC
+qfs
+acN
+sUz
+sUz
+acN
+xlB
+kGB
+acN
+jny
+iPS
+acN
+acN
+acN
+jwv
+rnP
+sEI
+sEI
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+jXV
+jXV
+jXV
+jXV
+jXV
+jXV
+jXV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+cJS
+hsD
+xsG
+jim
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+mnh
+mnh
+mnh
+hvq
+ybw
+aeb
+jol
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+tHQ
+tHQ
+pjq
+oAl
+oAl
+gmK
+egg
+eai
+nDY
+hEq
+cCP
+tCz
+nDY
+mnh
+iNY
+lLN
+nDY
+mnh
+ovh
+ghW
+dLF
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(332,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+ijE
+tzJ
+myL
+vdp
+dNu
+raE
+iiL
+cml
+ghw
+qXi
+kyJ
+acN
+ivg
+hpz
+iUn
+uqR
+kGB
+bQl
+kGB
+cMg
+kGB
+mXR
+xVo
+iPS
+hJA
+acN
+acN
+acN
+kmd
+hDM
+jul
+csG
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+mnh
+ybw
+ybw
+ybw
+ybw
+wAN
+jol
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+tHQ
+img
+tHQ
+tHQ
+gmK
+mnh
+ivT
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+tiU
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(333,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+hEi
+lBH
+khD
+gfy
+khD
+hgg
+llI
+jCP
+pCG
+rzN
+iwF
+acN
+hpz
+hpz
+hpz
+mPD
+mXR
+wBk
+mXR
+aAk
+aPt
+mXR
+byO
+jvH
+iPS
+acN
+acN
+acN
+jAy
+jul
+sEI
+sEI
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+xsG
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+mnh
+jno
+ybw
+wAN
+ybw
+wAN
+jol
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+oAl
+tHQ
+gmK
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(334,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+xNH
+rzN
+kZJ
+acN
+dnO
+ivg
+qqR
+qfs
+acN
+acN
+acN
+acN
+kGB
+ybU
+acN
+cmZ
+iPS
+acN
+acN
+acN
+hUE
+jul
+sTr
+jul
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+hMf
+xsG
+hsD
+xsG
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+mnh
+mnh
+tiU
+wAN
+hpb
+aeb
+kUx
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+oAl
+oAl
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(335,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+aiq
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+hpz
+ktB
+hpz
+acN
+gLw
+lPa
+dKb
+sJY
+gqT
+pYU
+acN
+dQl
+iPS
+acN
+acN
+acN
+acN
+nxO
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+cJS
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+heT
+heT
+heT
+heT
+plr
+plr
+plr
+plr
+plr
+plr
+plr
+kUx
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(336,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+jii
+cun
+pfz
+hpz
+hpz
+hpz
+acN
+isj
+kGB
+dkE
+pMD
+kGB
+mXR
+acN
+cli
+wJP
+acN
+acN
+acN
+wTs
+rub
+rub
+mXi
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(337,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+jii
+jii
+sUz
+aNo
+nxW
+aNo
+acN
+str
+gZb
+wzo
+kGB
+mXR
+kGB
+acN
+wHx
+wJP
+acN
+acN
+acN
+uwg
+aLY
+sEu
+wxX
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+gTB
+nPg
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(338,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+acN
+acN
+acN
+sUz
+sUz
+sUz
+acN
+acN
+acN
+acN
+acN
+mhV
+hGu
+acN
+acN
+acN
+acN
+acN
+acN
+rub
+rub
+rub
+kFq
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+kDF
+xsG
+gTB
+yjt
+pHU
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+kIw
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(339,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+acN
+acN
+acN
+ivj
+orJ
+tXa
+acN
+tIZ
+xdj
+acN
+iAx
+rse
+icR
+rtb
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+txz
+xsG
+xvF
+cJS
+kIw
+iey
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+kIw
+lkw
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(340,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+cjN
+noP
+lKQ
+acN
+vIL
+hpz
+pja
+gkx
+tNQ
+mdr
+pIr
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+hqk
+xsG
+xsG
+xsG
+xsG
+bsh
+xsG
+gTB
+xsG
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(341,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+qCG
+nNL
+qCG
+vmn
+tKs
+iUn
+acN
+uun
+fSb
+lxG
+oZr
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+acN
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+gTB
+ebp
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bqj
+bsh
+bsh
+bsh
+bsh
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(342,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+rpj
+eIv
+pAv
+sUz
+acN
+jAO
+acN
+uvE
+mdr
+mdr
+wOf
+acN
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+hge
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bqj
+bsh
+bsh
+bsh
+bsh
+xsG
+lNi
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(343,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+acN
+acN
+acN
+sUz
+sUz
+sUz
+acN
+acN
+aLZ
+acN
+lTz
+qtK
+mjX
+qtK
+acN
+acN
+acN
+acN
+acN
+wvV
+wvV
+wvV
+wvV
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+xsG
+gTB
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+kIw
+bsh
+bsh
+bsh
+hsD
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(344,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+jOT
+jOT
+eTQ
+jOT
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+kIw
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(345,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+jOT
+wCd
+wCd
+jOT
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+kIw
+bsh
+bsh
+bsh
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(346,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+jOT
+wCd
+uGh
+jOT
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bqj
+bsh
+bsh
+xsG
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(347,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+jOT
+wUP
+wCd
+jOT
+bsh
+bsh
+bsh
+toz
+bsh
+toz
+bsh
+fNm
+xsG
+xsG
+xsG
+xsG
+xsG
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(348,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+vHC
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+bsh
+bsh
+jOT
+jOT
+jOT
+jOT
+bsh
+bsh
+bsh
+toz
+bsh
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+toz
+toz
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+bsh
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(349,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(350,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(351,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(352,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(353,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(354,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(355,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(356,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(357,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(358,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(359,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(360,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(361,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(362,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(363,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(364,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(365,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(366,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(367,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(368,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(369,1,1) = {"
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+heT
+"}
+(370,1,1) = {"
 heT
 heT
 heT

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -91,6 +91,10 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"az" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "aA" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -202,6 +206,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
+/area/f13/wasteland)
+"aS" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
 "aT" = (
 /obj/structure/barricade/wooden,
@@ -344,6 +356,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"bC" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "bE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window{
@@ -377,6 +399,16 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"bK" = (
+/obj/structure/dresser,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "bL" = (
 /obj/structure/railing{
 	color = null;
@@ -474,6 +506,7 @@
 /obj/structure/fence/wooden{
 	dir = 4
 	},
+/obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
 "ci" = (
@@ -525,6 +558,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"cu" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "cv" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -532,6 +569,18 @@
 /obj/effect/landmark/start/f13/ncrveteranranger,
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"cy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "cz" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -657,6 +706,18 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"cV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "cW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -668,12 +729,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "cY" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "da" = (
 /obj/item/flashlight/lamp/green,
 /obj/structure/table/wood,
@@ -755,6 +813,16 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
+"dw" = (
+/obj/structure/window/fulltile/wood/broken,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "dy" = (
 /obj/structure/table,
@@ -925,6 +993,11 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"ee" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "ef" = (
 /obj/structure/bed,
 /obj/item/bedsheet/gondola,
@@ -941,6 +1014,16 @@
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
+"ek" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "eo" = (
@@ -1145,6 +1228,13 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"fe" = (
+/obj/structure/chair/stool,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "fg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -1229,12 +1319,36 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"fx" = (
+/obj/structure/chair/stool/retro/backed,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "fz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
+/area/f13/building)
+"fB" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "fE" = (
 /obj/structure/table,
@@ -1336,6 +1450,18 @@
 	},
 /turf/closed/wall/f13/store/constructed,
 /area/f13/ncr)
+"gc" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "ge" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -1492,6 +1618,10 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/blueyellow,
 /area/f13/followers)
+"gR" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "gT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1521,6 +1651,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"gW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack{
+	name = "equipment rack"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "gX" = (
 /obj/structure/decoration/rag,
 /obj/structure/fence/wooden{
@@ -1579,6 +1718,12 @@
 "hg" = (
 /obj/structure/sign/poster/prewar/poster82,
 /turf/closed/wall/f13/store,
+/area/f13/building)
+"hh" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "hi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1742,6 +1887,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"hI" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "hJ" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -1749,6 +1901,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"hK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/stool/retro/backed{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "hL" = (
 /turf/open/transparent/openspace,
 /area/f13/legion)
@@ -2126,6 +2287,23 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
+"jA" = (
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/machinery/light,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "jB" = (
 /obj/machinery/door/airlock/hatch{
 	name = "NCR Captain's Office";
@@ -2145,6 +2323,10 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"jE" = (
+/obj/structure/bed/old,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "jF" = (
 /obj/effect/overlay/junk/sink{
 	pixel_y = 15
@@ -2181,6 +2363,9 @@
 	sunlight_state = 1
 	},
 /area/f13/legion)
+"jN" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "jO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -2370,10 +2555,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"kq" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "ks" = (
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"ku" = (
+/obj/structure/table/wood,
+/obj/item/binoculars,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "kv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2406,6 +2600,17 @@
 "kC" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"kF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -11;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "kG" = (
 /obj/structure/closet/fridge/standard{
 	storage_capacity = 22
@@ -2452,15 +2657,11 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/ncr)
 "kR" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "kS" = (
 /obj/structure/sign/poster/prewar/poster81,
 /turf/closed/wall/f13/wood,
@@ -2519,6 +2720,12 @@
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
+"lg" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "lh" = (
 /obj/structure/rack,
 /turf/open/floor/wood/wood_large,
@@ -2999,6 +3206,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"mH" = (
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "mI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3195,6 +3409,12 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/followers)
+"nw" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "nx" = (
 /obj/structure/simple_door/room{
 	name = "Sergeant Bunks"
@@ -3290,6 +3510,14 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"nQ" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "nR" = (
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -3304,6 +3532,18 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nT" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "nU" = (
 /obj/structure/guncase{
 	anchored = 1
@@ -3504,6 +3744,34 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"ow" = (
+/obj/structure/table,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"oz" = (
+/obj/structure/table,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"oB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "oC" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -3677,6 +3945,18 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"pp" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "ruinswindow"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "pr" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -3828,12 +4108,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "pU" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "pV" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -3846,6 +4126,13 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
+"pX" = (
+/obj/structure/simple_door/house,
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "pZ" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/ncr_formal_uniform,
@@ -3890,6 +4177,13 @@
 	name = "skulls"
 	},
 /obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"qk" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ql" = (
@@ -4025,11 +4319,22 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
+"qM" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "qO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"qS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "qT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4122,6 +4427,15 @@
 /obj/item/paper/crumpled,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"rm" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "rn" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
@@ -4284,6 +4598,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
 	},
+/area/f13/building)
+"sc" = (
+/obj/structure/simple_door/glass,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "sf" = (
 /obj/structure/decoration/rag{
@@ -4663,7 +4981,7 @@
 "ty" = (
 /obj/structure/bed/mattress,
 /obj/item/bedsheet{
-	icon_state = "sheetgrey";
+	icon_state = "sheetgrey"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
@@ -4930,6 +5248,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "ux" = (
 /obj/structure/table/wood/settler,
 /obj/item/pestle,
@@ -4988,6 +5318,18 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/building)
+"uP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack{
+	name = "equipment rack"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "uQ" = (
 /obj/structure/railing{
@@ -5086,9 +5428,9 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/wasteland)
 "vj" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/obj/item/kirbyplants/random,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "vl" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -5198,6 +5540,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"vG" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "vI" = (
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/f13/wood,
@@ -5245,6 +5594,13 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"vR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "vS" = (
 /obj/machinery/computer/operating,
 /obj/effect/decal/cleanable/dirt{
@@ -5291,6 +5647,15 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"vZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "wa" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -5329,6 +5694,13 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/f13/old,
+/area/f13/building)
+"wh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "wk" = (
 /obj/structure/chair/stool,
@@ -5515,18 +5887,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wX" = (
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "wY" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -5818,6 +6189,15 @@
 /obj/item/binoculars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"yi" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "yj" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -5858,6 +6238,16 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"yx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "yy" = (
 /obj/machinery/workbench,
 /obj/machinery/light{
@@ -5963,6 +6353,12 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
+"yV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "yW" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
@@ -6018,6 +6414,10 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"zm" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "zn" = (
 /turf/closed/wall/f13/store,
 /area/f13/followers)
@@ -6071,18 +6471,14 @@
 	},
 /area/f13/building)
 "zA" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "zB" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -6497,6 +6893,10 @@
 /obj/item/clothing/under/f13/ncr/ncr_dress,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Bn" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "Bo" = (
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/woodalt,
@@ -6536,10 +6936,18 @@
 /obj/item/phone,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"Bz" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "BA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -6577,6 +6985,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
+	},
+/area/f13/building)
+"BM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
 	},
 /area/f13/building)
 "BN" = (
@@ -6702,6 +7118,14 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"Ch" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "Ci" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/red,
@@ -6786,6 +7210,10 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"Cx" = (
+/obj/structure/simple_door/room/dirty,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Cz" = (
 /obj/machinery/light/small{
@@ -6926,7 +7354,7 @@
 /area/f13/brotherhood/surface)
 "Dd" = (
 /obj/structure/chair/wood{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -7000,6 +7428,12 @@
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"DA" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
 "DB" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -7041,6 +7475,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"DN" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/stack/f13Cash/random/med,
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "DP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7167,6 +7608,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"Eo" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Ep" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/carpet/arcade,
@@ -7182,16 +7630,20 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "Et" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Ew" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building)
+"Ey" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/holofloor/carpet,
 /area/f13/building)
 "Ez" = (
 /obj/structure/table,
@@ -7246,6 +7698,23 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"ES" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "ET" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/caves)
@@ -7268,26 +7737,26 @@
 "EZ" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Fe" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+"Fd" = (
+/obj/structure/chair/stool/retro/backed,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"Fe" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Ff" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
@@ -7726,6 +8195,10 @@
 "GW" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
+"GX" = (
+/obj/machinery/workbench,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "GY" = (
 /obj/structure/table/wood/settler,
 /obj/item/binoculars,
@@ -7973,6 +8446,13 @@
 /obj/structure/chair/stool/retro,
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
+"HO" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "HP" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/item/stack/sheet/metal/five,
@@ -7981,6 +8461,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"HQ" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/building)
 "HT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8069,6 +8556,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/corner{
 	dir = 1
 	},
+/area/f13/building)
+"Il" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "In" = (
 /obj/machinery/light{
@@ -8225,6 +8726,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"IR" = (
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "IT" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8379,6 +8884,10 @@
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
+/area/f13/building)
+"Jy" = (
+/obj/machinery/autolathe,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "Jz" = (
 /obj/structure/table/wood/settler,
@@ -8628,6 +9137,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"KB" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "KC" = (
 /obj/machinery/light{
 	dir = 1
@@ -8821,6 +9336,15 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
+"Lr" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Ls" = (
 /obj/machinery/light{
 	dir = 4
@@ -8958,6 +9482,15 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"LP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "LR" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -9041,6 +9574,10 @@
 	pixel_y = 2
 	},
 /turf/open/floor/holofloor/carpet,
+/area/f13/building)
+"Mi" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
 "Mj" = (
 /obj/structure/railing{
@@ -9146,6 +9683,10 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"MV" = (
+/obj/machinery/photocopier,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "MW" = (
 /obj/structure/decoration/clock/old/active{
 	pixel_y = 32
@@ -9190,6 +9731,15 @@
 /obj/item/binoculars,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"Ni" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "Nj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -9483,6 +10033,15 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"OD" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "OE" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt,
@@ -9558,7 +10117,7 @@
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
@@ -9749,6 +10308,19 @@
 "PO" = (
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
+"PR" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "PS" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -9792,6 +10364,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"PY" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "Qb" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -9828,18 +10408,13 @@
 	},
 /area/f13/brotherhood/surface)
 "Qm" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
+/obj/item/megaphone,
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Qn" = (
 /obj/item/trash/sosjerky{
 	pixel_x = -6
@@ -9925,6 +10500,35 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"QB" = (
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/obj/item/folder/documents,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
+"QE" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "QH" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -9991,6 +10595,18 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
+"QW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "QX" = (
 /obj/structure/railing{
 	dir = 1
@@ -10054,6 +10670,15 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"Ri" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Rk" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -10077,7 +10702,7 @@
 /obj/structure/decoration/rag,
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
@@ -10208,7 +10833,7 @@
 "RM" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -10334,6 +10959,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/brotherhood/surface)
+"Sr" = (
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "St" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -10452,6 +11083,15 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building)
+"SS" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "ST" = (
 /obj/structure/railing{
 	dir = 8
@@ -10510,7 +11150,7 @@
 "Tk" = (
 /obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
@@ -10538,6 +11178,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"Tt" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Tu" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -10547,6 +11193,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Tw" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
+	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
+	name = "strange meat"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Tx" = (
 /obj/item/flashlight/lamp/green,
 /obj/structure/table/wood,
@@ -10586,7 +11240,7 @@
 "TF" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -10679,6 +11333,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"Ud" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ue" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10718,6 +11378,18 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
+"Uk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Ul" = (
 /obj/structure/decoration/rag,
 /obj/machinery/door/unpowered/securedoor{
@@ -10794,6 +11466,19 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"UB" = (
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "UC" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10955,6 +11640,16 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building)
+"Vm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/building)
 "Vn" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
@@ -11087,6 +11782,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood/surface)
+"VT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "VV" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -11110,6 +11814,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood/surface)
+"VY" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "Wa" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -11401,6 +12115,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Xi" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/building)
 "Xk" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -11536,6 +12256,19 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"Ya" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "Yb" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt{
@@ -11572,6 +12305,13 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
+"Yq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/wasteland)
 "Yr" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/item/stack/crafting/armor_plate/ten,
@@ -11712,6 +12452,15 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"Zd" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/building)
 "Ze" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11754,6 +12503,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
+/area/f13/building)
+"Zq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "Zr" = (
 /obj/structure/lattice/catwalk,
@@ -11854,6 +12614,13 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"ZI" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ZL" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -11941,6 +12708,7 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+
 (1,1,1) = {"
 Al
 Al
@@ -13788,13 +14556,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14045,13 +14813,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14302,13 +15070,13 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
+kC
+kC
+kC
+kC
+kC
+kC
+kC
 PL
 PL
 PL
@@ -14555,18 +15323,18 @@ Jd
 kC
 kC
 kC
+zB
+zB
+zB
+zB
+zB
+zB
+zB
+zB
+zB
 kC
 kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -14812,18 +15580,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
+zB
+cY
+vj
+zB
+Fe
+kq
+GX
+Mi
+zB
+jZ
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -15069,18 +15837,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+kR
+wX
+Et
+EM
+zA
+EM
+Mi
+pp
+yV
+vZ
+aJ
 PL
 PL
 PL
@@ -15326,18 +16094,18 @@ Jd
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+pU
+zA
+zB
+Qm
+zA
+zA
+Jy
+pp
+vZ
+vZ
+aJ
 PL
 PL
 PL
@@ -15583,18 +16351,18 @@ Jd
 kC
 kC
 lH
-kC
-kC
-kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+zB
+zB
+zB
+uP
+zA
+zA
+IR
+zB
+Uk
+vZ
+aJ
 PL
 PL
 PL
@@ -15843,15 +16611,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+gW
+zA
+FO
+FO
+Et
+vZ
+yV
+aJ
 PL
 PL
 PL
@@ -16100,15 +16868,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+EM
+XP
+zB
+zB
+zB
+vZ
+jZ
+aJ
 PL
 PL
 PL
@@ -16357,15 +17125,15 @@ kC
 kC
 kC
 kC
-kC
+zB
+FO
+Py
+zB
 Wx
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+vZ
+jZ
+aJ
 PL
 PL
 PL
@@ -16614,15 +17382,15 @@ kC
 kC
 kC
 kC
-kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+zB
+zB
+zB
+zB
+jZ
+cy
+yV
+jZ
+aJ
 PL
 PL
 PL
@@ -16872,14 +17640,14 @@ kC
 kC
 kC
 kC
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+TG
+cu
+Ri
+Fd
+Bz
+cV
+jZ
+aJ
 PL
 PL
 PL
@@ -17129,14 +17897,14 @@ kC
 kC
 kC
 kC
+TG
+Yq
+vZ
+fx
+aS
+QE
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17386,14 +18154,14 @@ kC
 kC
 kC
 kC
+TG
+cu
+vZ
+vZ
+hK
+jZ
 Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17643,14 +18411,14 @@ kC
 kC
 kC
 kC
+TG
+ku
+yV
+yV
 Wx
 Wx
 Wx
-Wx
-Wx
-Wx
-Wx
-PL
+aJ
 PL
 PL
 PL
@@ -17899,14 +18667,14 @@ kC
 kC
 kC
 kC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
 PL
 PL
 PL
@@ -28188,19 +28956,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+jN
+DA
+nw
+nw
+jN
+nw
+nw
+DA
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28440,24 +29208,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+jN
+jN
+jN
+jN
+jN
+gR
+az
+nM
+nM
+Ch
+vG
+zm
+zm
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28697,24 +29465,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+KB
+ow
+HD
+QB
+jN
+ee
+wh
+wh
+dc
+dc
+nM
+nM
+nM
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -28954,24 +29722,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+ZI
+PY
+HD
+HD
+Cx
+wh
+nM
+wh
+gc
+rm
+rm
+rm
+rm
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29211,24 +29979,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+HD
+HD
+HD
+MV
+jN
+nM
+dc
+nM
+OD
+Py
+Py
+Py
+Py
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29468,24 +30236,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+jA
+HD
+HD
+oz
+jN
+Py
+rm
+rm
+Py
+Py
+Py
+Py
+Py
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29725,24 +30493,24 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+jN
+jN
+jN
+jN
+jN
+Py
+Py
+Py
+Py
+Py
+Py
+Py
+Py
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -29987,19 +30755,19 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30254,9 +31022,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30511,9 +31279,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -30768,9 +31536,9 @@ kC
 kC
 kC
 kC
-kC
-kC
-PL
+CC
+CC
+CC
 PL
 PL
 PL
@@ -60570,17 +61338,17 @@ vX
 AM
 AM
 AM
-kC
-kC
-fu
-kR
-kC
-xj
 AM
 AM
 AM
 AM
-nd
+AM
+AM
+AM
+AM
+AM
+Hj
+aJ
 PL
 PL
 PL
@@ -60834,10 +61602,10 @@ AM
 AM
 AM
 AM
-AM
-AM
-Hj
-aJ
+UB
+ES
+nE
+PL
 PL
 PL
 PL
@@ -61081,19 +61849,19 @@ PL
 PL
 nE
 nE
-jS
-pU
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-wX
-Fe
 nE
+nE
+nE
+nE
+Ya
+nE
+nE
+Ya
+nE
+nE
+nE
+PL
+PL
 PL
 PL
 PL
@@ -61339,16 +62107,16 @@ PL
 PL
 PL
 PL
-nE
-nE
-nE
-Qm
-nE
-nE
-Qm
-nE
-nE
-nE
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -61853,18 +62621,18 @@ AM
 AM
 AM
 nL
-tY
-tY
-zA
-tY
-tY
-tY
-tY
-tY
-tY
-tY
-zA
-tY
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
+PL
 PL
 PL
 PL
@@ -62110,19 +62878,19 @@ Xt
 AM
 AM
 AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-AM
-pU
-aJ
+Ds
+tY
+PR
+tY
+tY
+tY
+tY
+tY
+tY
+tY
+PR
+tY
+PL
 PL
 PL
 PL
@@ -62364,8 +63132,6 @@ LA
 yZ
 oC
 Al
-Al
-Al
 AM
 AM
 AM
@@ -62373,13 +63139,15 @@ AM
 AM
 AM
 AM
-xo
-xo
-xo
 AM
 AM
 AM
-Ds
+AM
+AM
+AM
+AM
+qk
+aJ
 PL
 PL
 PL
@@ -62624,8 +63392,8 @@ kC
 kC
 BC
 Vo
-Al
-Al
+AM
+AM
 AM
 Xt
 AM
@@ -63129,7 +63897,7 @@ PL
 Mj
 Gl
 Gl
-kC
+Jk
 kC
 kC
 kC
@@ -63386,7 +64154,7 @@ PL
 Mj
 Gl
 mz
-kC
+fu
 kC
 kC
 kC
@@ -63646,12 +64414,12 @@ Gl
 Cb
 PL
 PL
-PL
-PL
-PL
-PL
 Jk
-Jk
+kC
+kC
+kC
+kC
+kC
 kC
 kC
 kC
@@ -63907,9 +64675,9 @@ PL
 PL
 PL
 PL
-PL
-PL
-lx
+kC
+kC
+kC
 kC
 kC
 kC
@@ -64164,10 +64932,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-Jk
+kC
+Al
+Al
+Al
 kC
 kC
 kC
@@ -64244,23 +65012,23 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+al
+al
+al
+al
+al
+al
+al
+mr
+al
+al
+al
 kC
 Ht
 Jk
 Jk
 Jk
-Et
+Ff
 kC
 kC
 kC
@@ -64421,12 +65189,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-SA
+kC
+kC
+kC
+Al
+Al
+Al
+Al
 kC
 kC
 kC
@@ -64435,7 +65204,6 @@ kC
 kC
 kC
 kC
-kC
 PL
 PL
 PL
@@ -64501,17 +65269,17 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+al
+SS
+SS
+Wl
+EM
+EM
+EM
+pX
+EM
+FO
+xd
 kC
 kC
 kC
@@ -64678,14 +65446,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-Jk
+fv
+Xv
+zc
 kC
+kC
+kC
+kC
+Al
 kC
 kC
 kC
@@ -64758,17 +65526,17 @@ lH
 kC
 kC
 kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
-kC
+al
+QW
+Ni
+Ey
+on
+Xi
+Py
+al
+bK
+EM
+xd
 kC
 kC
 kC
@@ -64934,14 +65702,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-gg
+Mj
+nt
+Vm
+ZO
+zB
+Xv
+HQ
+hI
 kC
 kC
 kC
@@ -65015,17 +65783,17 @@ kC
 kC
 kC
 lH
-lH
-kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-kC
-kC
+mr
+DN
+Ni
+yi
+on
+Lr
+al
+al
+Tt
+jE
+xd
 kC
 kC
 kC
@@ -65191,14 +65959,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Mj
+qV
+oB
+nQ
+EM
+fe
+Bn
+fv
 kC
 kC
 kC
@@ -65272,17 +66040,17 @@ kC
 kC
 kC
 kC
-kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-kC
+mr
+Sr
+Ni
+VY
+on
+Eo
+al
+al
+al
+al
+al
 kC
 kC
 PL
@@ -65448,14 +66216,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-Jk
+Mj
+HO
+oB
+oU
+EM
+Il
+Zq
+Xv
 kC
 kC
 kC
@@ -65529,18 +66297,18 @@ kC
 kC
 kC
 kC
-kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+mr
+VT
+Zd
+vR
+on
+eh
+qM
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -65705,14 +66473,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-BC
-kC
+Mj
+Nr
+oB
+dw
+EM
+yx
+kF
+Xv
 kC
 kC
 kC
@@ -65786,18 +66554,18 @@ kC
 kC
 kC
 kC
-kC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+mr
+Mi
+Tw
+uv
+EM
+gh
+al
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -65953,7 +66721,7 @@ Qp
 AM
 AM
 AM
-pg
+zI
 eA
 PL
 PL
@@ -65962,14 +66730,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-Jk
-kC
-kC
-kC
+Mj
+nT
+uc
+oU
+EM
+qS
+Bn
+Xv
 kC
 kC
 kC
@@ -66043,18 +66811,18 @@ PL
 PL
 PL
 PL
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+al
+al
+bC
+hh
+fB
+al
+al
+Wx
+Wx
+Wx
+Wx
+Wx
 PL
 PL
 kC
@@ -66210,7 +66978,7 @@ bk
 Lf
 AM
 vX
-yZ
+ad
 PL
 PL
 PL
@@ -66219,14 +66987,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-cY
-kC
-kC
-kC
-kC
+Mj
+qV
+BM
+fv
+ek
+XP
+Xv
+Xv
 kC
 kC
 kC
@@ -66301,17 +67069,17 @@ PL
 PL
 PL
 PL
+LP
 PL
 PL
 PL
-PL
+Ud
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-CC
 PL
 PL
 PL
@@ -66476,13 +67244,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-kC
-kC
-kC
+Mj
+mH
+yM
+sc
+FO
+Py
+fv
 kC
 kC
 kC
@@ -66730,16 +67498,16 @@ kC
 kC
 kC
 kC
-kC
-BC
 PL
 PL
 PL
 PL
-PL
-kC
-kC
-kC
+VB
+zc
+lg
+Xv
+Xv
+fv
 kC
 kC
 kC
@@ -66988,12 +67756,12 @@ kC
 kC
 kC
 kC
+BC
+PL
+PL
 kC
-gg
-PL
-PL
-PL
-vj
+kC
+kC
 kC
 kC
 kC
@@ -67246,9 +68014,9 @@ kC
 kC
 kC
 kC
+PL
+PL
 kC
-pg
-Jk
 kC
 kC
 kC
@@ -67504,7 +68272,7 @@ kC
 kC
 kC
 kC
-kC
+Jk
 kC
 kC
 kC
@@ -67759,8 +68527,8 @@ kC
 kC
 kC
 kC
-kC
-kC
+Al
+Al
 kC
 kC
 kC
@@ -68264,7 +69032,7 @@ AM
 xo
 xE
 AM
-Ht
+mm
 Gt
 kC
 kC

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -263,6 +263,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"afI" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "afL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -285,11 +293,16 @@
 	},
 /area/f13/wasteland)
 "agA" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 4
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
 	},
-/obj/structure/fluff/beach_umbrella/cap,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "agF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -316,6 +329,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building)
+"agR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 6;
+	icon_state = "outerpavement";
+	},
+/area/f13/wasteland)
 "agT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert{
@@ -391,6 +411,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"ahu" = (
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "ahI" = (
 /obj/structure/rack,
 /obj/item/flashlight/lantern,
@@ -480,8 +505,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "ajD" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
 	},
 /area/f13/wasteland)
 "ajI" = (
@@ -512,7 +538,7 @@
 /area/f13/caves)
 "akk" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -527,6 +553,17 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"akp" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/toolbox/drone,
+/obj/item/pickaxe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "aku" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -608,6 +645,19 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"alD" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/pill/patch/healpoultice,
+/obj/item/reagent_containers/pill/patch/healpoultice,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
+/area/f13/village)
 "alE" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -636,10 +686,11 @@
 	},
 /area/f13/wasteland)
 "amc" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "amd" = (
 /obj/item/pen,
@@ -712,6 +763,14 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/wasteland)
+"anH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/f13/cram,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "anP" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/water,
@@ -750,10 +809,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
-"apk" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2right"
+"aoV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
+"apk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "apm" = (
 /obj/structure/table/reinforced,
@@ -932,10 +1006,10 @@
 	},
 /area/f13/wasteland)
 "atk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "atI" = (
 /obj/structure/cargocrate,
@@ -970,10 +1044,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "aug" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "auk" = (
 /turf/open/floor/wood/f13/old/ruinedcornerendbl,
 /area/f13/wasteland)
@@ -1017,6 +1091,19 @@
 	icon_state = "plating"
 	},
 /area/f13/ncr)
+"auR" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bedsheetbin{
+	pixel_y = 10
+	},
+/obj/structure/table/wood{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "auU" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13{
@@ -1035,6 +1122,12 @@
 /obj/structure/fence/pole_b,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/building)
+"avf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
+/area/f13/village)
 "avh" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1055,6 +1148,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"avx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/interior,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/area/f13/village)
 "avP" = (
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1086,28 +1184,28 @@
 	},
 /area/f13/building)
 "awO" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "axo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/wasteland)
 "axr" = (
 /obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "axw" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "axA" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -1207,6 +1305,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"aAd" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/box/bowls{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "aAr" = (
 /obj/machinery/processor,
 /turf/open/floor/f13{
@@ -1276,9 +1391,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
 "aBH" = (
+/obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+	dir = 8;
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "aBJ" = (
@@ -1405,10 +1521,8 @@
 /area/f13/wasteland)
 "aFG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/obj/item/clothing/head/cone,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "aFK" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -1424,20 +1538,13 @@
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aFV" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
 "aFY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "aGc" = (
 /obj/structure/table,
@@ -1494,12 +1601,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "aHN" = (
-/obj/structure/fluff/beach_umbrella/security,
-/obj/structure/chair/comfy/plywood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
 /area/f13/village)
 "aIe" = (
 /obj/structure/fence/handrail_corner{
@@ -1624,6 +1729,16 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"aKk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
 "aKs" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -1771,6 +1886,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"aNR" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	},
+/area/f13/building)
 "aNU" = (
 /obj/item/reagent_containers/food/drinks/trophy/gold_cup,
 /obj/structure/displaycase,
@@ -1910,6 +2032,15 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"aRN" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/building)
 "aRU" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2018,7 +2149,18 @@
 	},
 /area/f13/village)
 "aUa" = (
-/turf/open/indestructible/ground/outside/water,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
 /area/f13/village)
 "aUl" = (
 /obj/structure/fence,
@@ -2073,9 +2215,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "aVn" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "aVq" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2093,6 +2240,13 @@
 	dir = 1
 	},
 /area/f13/village)
+"aVJ" = (
+/obj/structure/fence/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aWg" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -2183,7 +2337,7 @@
 /area/f13/wasteland)
 "aXM" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
@@ -2405,11 +2559,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "bbW" = (
-/obj/structure/simple_door/room,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/junk/micro,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "bca" = (
 /obj/machinery/iv_drip,
@@ -2453,15 +2604,14 @@
 /turf/open/water,
 /area/f13/caves)
 "bcF" = (
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty. You hear some weird noises behind these vents...";
-	pixel_x = -7;
-	pixel_y = -3
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/area/f13/enclave)
+/area/f13/village)
 "bcK" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -2600,7 +2750,7 @@
 /area/f13/caves)
 "beF" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -2653,12 +2803,15 @@
 	},
 /area/f13/wasteland)
 "bgq" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/stairs/north{
+	color = "#A47449"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/village)
 "bgs" = (
 /obj/item/clothing/suit/f13/sexymaid,
@@ -2872,10 +3025,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "bkc" = (
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "housewastelandsouth"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
 "bkk" = (
 /obj/structure/target_stake,
@@ -2937,11 +3090,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"blt" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "blu" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/wood/f13/oak,
@@ -3034,14 +3182,11 @@
 	},
 /area/f13/ncr)
 "bnz" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bnA" = (
 /obj/structure/chair{
@@ -3115,10 +3260,14 @@
 	},
 /area/f13/village)
 "box" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2left"
+/obj/structure/flora/grass/jungle,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "boz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3136,7 +3285,7 @@
 "boD" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "boN" = (
@@ -3329,6 +3478,10 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
+"bsz" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "bsF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3604,14 +3757,18 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"byq" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/ruins,
+/area/f13/village)
 "byv" = (
 /obj/structure/chair/stool{
 	dir = 4;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bzb" = (
@@ -3684,11 +3841,11 @@
 "bAe" = (
 /obj/structure/chair/stool{
 	dir = 8;
-	icon_state = "bench";
+	icon_state = "bench"
 	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bAh" = (
@@ -3848,6 +4005,25 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"bDK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "bDM" = (
 /obj/structure/stairs/north{
 	color = "#A47449"
@@ -3901,11 +4077,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bEu" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "bEw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3986,6 +4161,10 @@
 /obj/item/shard,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"bGV" = (
+/obj/item/trash/f13/dog,
+/turf/open/floor/wood/f13/old/ruinedcornerendtl,
+/area/f13/wasteland)
 "bGW" = (
 /obj/item/storage/trash_stack,
 /obj/effect/spawner/lootdrop/trash,
@@ -4097,11 +4276,13 @@
 	},
 /area/f13/wasteland)
 "bJB" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2right"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "bJQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -4205,6 +4386,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
+"bLP" = (
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "bLX" = (
 /obj/structure/ore_box,
 /obj/machinery/light/small{
@@ -4425,11 +4612,10 @@
 	},
 /area/f13/ncr)
 "bQr" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "bQL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -4507,17 +4693,19 @@
 	},
 /area/f13/building)
 "bRF" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner";
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "bRG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bRP" = (
@@ -4533,7 +4721,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bSR" = (
@@ -4541,7 +4729,7 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bSS" = (
@@ -4587,10 +4775,15 @@
 	},
 /area/f13/tunnel)
 "bTk" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/closed/wall/f13/store,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "bTl" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
@@ -4608,11 +4801,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "bUd" = (
-/obj/structure/table/wood/poker,
-/obj/item/storage/box/dice,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "bUj" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -4675,7 +4866,7 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "bVT" = (
@@ -5004,11 +5195,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/brotherhood/surface)
 "ccN" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/village)
 "ccZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5152,6 +5342,14 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland)
+"cgf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "cgN" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
@@ -5163,7 +5361,7 @@
 "cgS" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
 "chb" = (
@@ -5248,6 +5446,10 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"cjH" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "cke" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -5266,6 +5468,16 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/village)
+"cku" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "ckB" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
@@ -5358,7 +5570,7 @@
 "cmR" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "cmU" = (
@@ -5419,7 +5631,7 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "cnz" = (
@@ -5494,7 +5706,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "cov" = (
@@ -5526,9 +5738,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
 "coQ" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "coW" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -5593,7 +5805,7 @@
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /turf/open/floor/f13{
-	icon_state = "floorrusty";
+	icon_state = "floorrusty"
 	},
 /area/f13/caves)
 "cqt" = (
@@ -5755,10 +5967,11 @@
 	},
 /area/f13/building)
 "ctm" = (
-/obj/item/bedsheet,
-/obj/structure/bed/old,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
 /area/f13/village)
 "cts" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5873,6 +6086,18 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/building)
+"cxJ" = (
+/obj/structure/table/snooker{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
+/area/f13/village)
 "cxL" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6135,6 +6360,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"cDm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "cDr" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -6358,16 +6593,11 @@
 	},
 /area/f13/wasteland)
 "cIR" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "cJj" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -6472,6 +6702,13 @@
 	},
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"cLm" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
 "cLo" = (
 /obj/structure/bookcase,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -6502,7 +6739,7 @@
 /area/f13/building)
 "cLX" = (
 /turf/open/floor/f13{
-	icon_state = "floorrusty";
+	icon_state = "floorrusty"
 	},
 /area/f13/caves)
 "cMb" = (
@@ -6566,6 +6803,11 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/village)
+"cNE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "cNO" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -6685,13 +6927,14 @@
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/building)
 "cRc" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/pill/patch/jet{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "cRd" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -6718,6 +6961,15 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"cRJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/flour,
+/mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "cRM" = (
 /obj/item/twohanded/spear/scrapspear,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6813,7 +7065,7 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "cVx" = (
@@ -6839,11 +7091,9 @@
 	},
 /area/f13/building)
 "cVX" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	},
-/area/f13/wasteland)
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "cWq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -6870,7 +7120,7 @@
 	id = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "cWG" = (
@@ -6943,6 +7193,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"cXu" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "cXS" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7081,15 +7340,27 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty";
+	icon_state = "floorrusty"
 	},
 /area/f13/caves)
 "daU" = (
+/obj/structure/flora/grass/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
+"daX" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
+	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "dbg" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_br,
@@ -7201,9 +7472,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dcS" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/flora/grass/jungle,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "ddb" = (
 /obj/item/ammo_casing/caseless,
 /turf/open/floor/f13/wood,
@@ -7236,6 +7508,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
+"ddR" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "dea" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -7386,13 +7662,22 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"dgE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "dgK" = (
 /obj/structure/campfire/stove,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
 "dgU" = (
@@ -7595,6 +7880,15 @@
 	},
 /turf/open/floor/wood,
 /area/f13/village)
+"dkG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/tray,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "dkP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top"
@@ -7694,11 +7988,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dmg" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
 	},
-/area/f13/enclave)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "dmC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -7745,6 +8043,21 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dnk" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "dnm" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/item/pen/fountain/captain,
@@ -7803,10 +8116,12 @@
 	},
 /area/f13/village)
 "doh" = (
-/obj/structure/simple_door/metal/dirtystore,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "dol" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -7838,11 +8153,14 @@
 	},
 /area/f13/building)
 "doX" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 5;
-	icon_state = "dirt"
+/obj/structure/sign/poster/contraband/pinup_funk,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "dpg" = (
 /obj/structure/car/rubbish3,
 /turf/closed/wall/r_wall/rust,
@@ -7980,6 +8298,25 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/building)
+"drF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
+"drR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
 "dsf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8133,7 +8470,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "dvo" = (
@@ -8162,7 +8499,7 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "dwV" = (
@@ -8222,7 +8559,7 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "dxM" = (
@@ -8425,6 +8762,10 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"dBr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/old/ruinedcornerbl,
+/area/f13/wasteland)
 "dBu" = (
 /obj/structure/sign/poster/contraband/pinup_ride,
 /turf/closed/wall/f13/wood/house,
@@ -8507,7 +8848,7 @@
 "dCL" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "dCP" = (
@@ -8529,7 +8870,7 @@
 "dCX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "dDg" = (
@@ -8562,6 +8903,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dDx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "dDB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/rag,
@@ -8615,6 +8960,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"dDX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "dEc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8669,7 +9022,7 @@
 "dEW" = (
 /obj/structure/chair/wood{
 	dir = 1;
-	icon_state = "wooden_chair_settler";
+	icon_state = "wooden_chair_settler"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8679,6 +9032,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dFc" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "dFg" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -8698,10 +9056,14 @@
 	},
 /area/f13/village)
 "dFQ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2left"
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "dGK" = (
 /obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/barber{
@@ -8762,6 +9124,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/caves)
+"dIC" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "dIP" = (
 /obj/machinery/light{
 	dir = 4
@@ -8783,12 +9150,10 @@
 	},
 /area/f13/building)
 "dJn" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/car/rubbish3,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dJv" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/combat/swat,
@@ -8826,7 +9191,7 @@
 /obj/item/phone,
 /obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "dJX" = (
@@ -8868,6 +9233,11 @@
 	icon_state = "horizontalbottomborderbottom1"
 	},
 /area/f13/wasteland)
+"dLj" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "dLO" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building)
@@ -8957,10 +9327,14 @@
 	},
 /area/f13/wasteland)
 "dNW" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/closed/wall/f13/wood,
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "dOc" = (
 /obj/machinery/autolathe,
@@ -8968,10 +9342,10 @@
 /area/f13/building)
 "dOg" = (
 /obj/structure/chair/office{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "dOn" = (
@@ -9234,6 +9608,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"dUO" = (
+/obj/structure/fence/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/savannah/bottomcenter,
+/area/f13/building)
 "dUS" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/cloth/ten,
@@ -9405,10 +9786,14 @@
 	},
 /area/f13/building)
 "dXy" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
+/obj/structure/sign/poster/contraband/pinup_bed,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "dXF" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9603,12 +9988,17 @@
 	},
 /area/f13/building)
 "ebC" = (
-/obj/machinery/door/window{
-	dir = 8
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "ebI" = (
 /obj/structure/window{
 	dir = 8
@@ -9688,6 +10078,11 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
+"edu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "edx" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Facility";
@@ -9752,6 +10147,20 @@
 /obj/item/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"eej" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "eeo" = (
 /obj/structure/chair/wood/modern,
 /turf/open/floor/plasteel/grimy,
@@ -9852,7 +10261,7 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
+	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
 "efO" = (
@@ -9866,14 +10275,19 @@
 	},
 /area/f13/building)
 "ega" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/door/poddoor{
-	id = "vaultelevator"
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/enclave)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "egt" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -9945,7 +10359,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "ehG" = (
@@ -10014,12 +10428,20 @@
 	},
 /area/f13/wasteland)
 "ejp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ejD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -10093,16 +10515,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "elL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/village)
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "elN" = (
 /obj/structure/flora/grass/jungle/b,
 /mob/living/simple_animal/hostile/mirelurk/hunter,
@@ -10190,11 +10611,20 @@
 	},
 /area/f13/city)
 "enp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/sign/poster/contraband/pinup_pink,
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ent" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10210,7 +10640,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "enx" = (
@@ -10412,12 +10842,14 @@
 	},
 /area/f13/building)
 "erB" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/fence{
+	dir = 4
 	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	},
+/area/f13/wasteland)
 "erJ" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10803,7 +11235,7 @@
 /area/f13/legion)
 "ezo" = (
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
 "ezp" = (
@@ -10890,6 +11322,13 @@
 /obj/structure/table_frame/wood,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"eAT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
 /area/f13/village)
 "eBc" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -11054,6 +11493,15 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/building)
+"eEc" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "eEg" = (
 /obj/item/storage/box/drinkingglasses,
 /obj/structure/table,
@@ -11091,7 +11539,7 @@
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
+	icon_state = "shower"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -11099,7 +11547,7 @@
 /area/f13/building)
 "eEL" = (
 /obj/machinery/shower{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -11187,6 +11635,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"eIH" = (
+/obj/structure/wreck/trash/machinepile{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "eIN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11267,7 +11723,7 @@
 "eJR" = (
 /obj/structure/sink{
 	dir = 4;
-	pixel_x = 10;
+	pixel_x = 10
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -11310,6 +11766,14 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
+"eKd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/random,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "eKz" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -11328,7 +11792,7 @@
 /area/f13/building)
 "eKM" = (
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg2";
+	icon_state = "platingdmg2"
 	},
 /area/f13/caves)
 "eKN" = (
@@ -11379,6 +11843,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"eLf" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "eLl" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/black,
@@ -11633,14 +12104,11 @@
 	},
 /area/f13/ncr)
 "eQq" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/decoration/rag{
+	icon_state = "skin";
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "eQA" = (
 /obj/structure/dresser{
 	pixel_y = 10
@@ -11793,7 +12261,7 @@
 /area/f13/building)
 "eUD" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
+	icon_state = "tall_grass_4"
 	},
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/savannah/bottomleftcorner,
@@ -11854,7 +12322,7 @@
 "eWh" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -11946,12 +12414,8 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "eYa" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "eYj" = (
 /obj/structure/bed/mattress{
@@ -12009,7 +12473,7 @@
 /obj/item/soap/homemade,
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
+	icon_state = "shower"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12037,11 +12501,22 @@
 "eZI" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
+	icon_state = "straight"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"eZL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "eZW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12059,7 +12534,7 @@
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg1";
+	icon_state = "platingdmg1"
 	},
 /area/f13/caves)
 "faq" = (
@@ -12082,14 +12557,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fas" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/item/flag/khan,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "faC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -12212,6 +12688,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"fcJ" = (
+/obj/structure/sink/puddle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "fcK" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
@@ -12276,11 +12756,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/surface)
 "fdO" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/structure/reagent_dispensers/watertank{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "fdV" = (
 /obj/structure/flora/grass/wasteland{
@@ -12499,6 +12982,17 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"fhm" = (
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "fhq" = (
 /obj/structure/barricade/wooden,
 /obj/structure/sign/poster/contraband/pinup_topless{
@@ -12601,8 +13095,13 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "fjR" = (
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet2"
+	},
 /area/f13/village)
 "fkl" = (
 /obj/machinery/light/small{
@@ -12624,12 +13123,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fkU" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/decal/remains/human,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fkV" = (
 /obj/structure/shuttle/engine/router,
 /obj/structure/lattice/catwalk,
@@ -12652,6 +13154,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"flU" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "fmn" = (
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12677,11 +13188,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "fmR" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fmW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/pistachios,
@@ -12714,10 +13226,12 @@
 	},
 /area/f13/village)
 "fnB" = (
-/obj/item/toy/poolnoodle/blue,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fnE" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -12736,14 +13250,15 @@
 	},
 /area/f13/village)
 "fnP" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0";
+/obj/structure/chair/sofa/corner{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fnT" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg2";
+	icon_state = "platingdmg2"
 	},
 /area/f13/caves)
 "fnW" = (
@@ -12787,7 +13302,7 @@
 "fph" = (
 /obj/structure/rack,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "fpl" = (
@@ -12915,11 +13430,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fsl" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/structure/fence/pole_t,
+/obj/structure/chair/sofa,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fsm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
@@ -12939,6 +13456,15 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"fsR" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6";
+	},
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "fsV" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
@@ -13110,6 +13636,13 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"fwJ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "fxh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13387,6 +13920,21 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
+"fBQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
+"fBZ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "fCg" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13609,6 +14157,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerbordercorner"
+	},
+/area/f13/building)
+"fGx" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "fGS" = (
@@ -13873,12 +14427,11 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "fLx" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outermaincornerouter"
-	},
-/area/f13/wasteland)
+/obj/structure/chair/sofa/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fLB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -13985,13 +14538,15 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
 "fNq" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/punch_shit,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "fNs" = (
-/turf/closed/mineral/random/high_chance,
-/area/f13/tunnel)
+/obj/structure/chair/booth{
+	icon_state = "booth_east_north"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fNt" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -14019,13 +14574,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "fOs" = (
-/obj/effect/overlay/junk/sink{
-	pixel_y = 15
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fOu" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14043,11 +14598,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/village)
 "fPb" = (
-/obj/structure/table,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/the_griffin,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "fPv" = (
 /obj/structure/fence{
 	dir = 1
@@ -14185,7 +14738,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
 "fRZ" = (
@@ -14385,13 +14938,15 @@
 	},
 /area/f13/building)
 "fUs" = (
+/obj/structure/table/booth,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fUA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /obj/item/clothing/under/stripeddress,
@@ -14596,7 +15151,7 @@
 	},
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
+	icon_state = "housewood2"
 	},
 /area/f13/building)
 "fZb" = (
@@ -14660,6 +15215,11 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"gad" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "gak" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -14813,6 +15373,19 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
+"gdA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "gdN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -14940,7 +15513,7 @@
 /area/f13/wasteland)
 "ggs" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -15126,14 +15699,20 @@
 	},
 /area/f13/wasteland)
 "giU" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/village)
 "giZ" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "gjs" = (
-/obj/structure/chair/stool/retro/black,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -15184,6 +15763,10 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"gkG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "gkV" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15337,25 +15920,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "gnk" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -11;
-	pixel_y = 2;
-	},
-/obj/structure/barricade/bars{
+/obj/machinery/door/unpowered/securedoor{
 	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+	obj_integrity = 800;
+	req_access_txt = "125"
 	},
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gnv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -15371,19 +15942,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
 "goj" = (
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty, someone attempted to weld this vent.. but he was too late. You hear some weird noises behind these vents...";
-	pixel_x = -7;
-	pixel_y = -3
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6";
-	pixel_x = -28
-	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "goq" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross3"
@@ -15533,7 +16097,7 @@
 /obj/structure/window/fulltile/wood,
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -15661,12 +16225,12 @@
 	},
 /area/f13/building)
 "gsB" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/fence/pole_b,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gsM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15695,9 +16259,8 @@
 	},
 /area/f13/wasteland)
 "gtn" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	},
+/obj/structure/sign/poster/contraband/pinup_vixen,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "gts" = (
 /turf/closed/wall/f13/store,
@@ -15744,13 +16307,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "gtU" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "guh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -15769,9 +16333,13 @@
 	},
 /area/f13/wasteland)
 "gun" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housebase";
+/obj/structure/chair/booth{
+	dir = 8
 	},
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gus" = (
 /obj/structure/rack,
@@ -15798,9 +16366,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "guU" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/pinup_shower,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "guY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15984,11 +16552,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gxh" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "gxi" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16004,10 +16576,10 @@
 	obj_integrity = 800
 	},
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
+	icon_state = "housewood2"
 	},
 /area/f13/building)
 "gxo" = (
@@ -16127,7 +16699,7 @@
 /area/f13/caves)
 "gAt" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
+	icon_state = "tall_grass_2"
 	},
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -16251,7 +16823,7 @@
 /area/f13/building)
 "gBW" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -16377,9 +16949,16 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "gDL" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
+	},
+/area/f13/building)
 "gDW" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -16628,6 +17207,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"gKD" = (
+/obj/structure/wreck/trash/two_barrels,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gKG" = (
 /obj/structure/simple_door/house,
 /obj/structure/barricade/wooden/planks,
@@ -16638,6 +17224,9 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gLn" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "gLG" = (
 /obj/machinery/autolathe/ammo,
 /obj/machinery/light/small{
@@ -16744,15 +17333,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/brotherhood/surface)
 "gNA" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
+/obj/structure/sign/poster/prewar/poster71{
+	pixel_x = 32
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gND" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg1";
+	icon_state = "platingdmg1"
 	},
 /area/f13/caves)
 "gNG" = (
@@ -16762,6 +17351,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"gOx" = (
+/mob/living/simple_animal/hostile/rat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "gOA" = (
 /obj/machinery/light{
 	dir = 8;
@@ -16850,14 +17449,13 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "gPd" = (
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/storage/fancy/rollingpapers,
-/obj/item/lighter,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "gPn" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/road{
@@ -16905,7 +17503,7 @@
 /area/f13/wasteland)
 "gQy" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -16945,6 +17543,17 @@
 /obj/item/storage/box/dice,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"gRR" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
+"gRZ" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowdestroyed"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -16998,13 +17607,27 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
+	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "gTv" = (
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"gTH" = (
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty, someone attempted to weld this vent.. but he was too late. You hear some weird noises behind these vents...";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_x = -28
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "gTM" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -17086,10 +17709,15 @@
 	},
 /area/f13/building)
 "gWo" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innermaincornerinner"
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gWp" = (
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -17172,6 +17800,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"gYD" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "gYP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -17247,11 +17886,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "hau" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor{
+	max_integrity = 800;
+	obj_integrity = 800;
+	req_access_txt = "125"
 	},
-/area/f13/village)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "haA" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17262,7 +17904,7 @@
 	},
 /obj/structure/sink{
 	dir = 1;
-	pixel_y = 23;
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17329,6 +17971,15 @@
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"hco" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/building)
 "hcr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -17572,11 +18223,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
 "hfw" = (
-/obj/item/defibrillator/primitive,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "hfz" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall/f13/store/constructed,
@@ -17724,11 +18377,9 @@
 	},
 /area/f13/village)
 "hgX" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 6;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "hhd" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -17750,11 +18401,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hhC" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
+/area/f13/building)
 "hhG" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -17820,6 +18473,10 @@
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
+"hiJ" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "hiM" = (
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
@@ -17834,7 +18491,7 @@
 /area/f13/wasteland)
 "hiT" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
@@ -17909,10 +18566,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "hko" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hkr" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/oil,
@@ -17945,6 +18605,14 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
+"hkP" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "hkW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -17968,6 +18636,13 @@
 /obj/structure/chair/wood/worn,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hlp" = (
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "hlv" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
@@ -18061,7 +18736,7 @@
 /area/f13/clinic)
 "hmP" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18130,12 +18805,26 @@
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"hoe" = (
-/obj/machinery/light{
-	dir = 4
+"hnX" = (
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/area/f13/enclave)
+"hoe" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter"
+	},
+/area/f13/wasteland)
 "hom" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -18152,10 +18841,10 @@
 	},
 /area/f13/wasteland)
 "hoz" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/wood/f13/old/ruinedcornerendbl,
-/area/f13/village)
+/obj/structure/sign/barsign,
+/obj/structure/sign/barsign,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "hoD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18302,7 +18991,7 @@
 "hre" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "hrh" = (
@@ -18384,7 +19073,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
+	icon_state = "housewood2"
 	},
 /area/f13/building)
 "hsH" = (
@@ -18394,6 +19083,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hsN" = (
+/obj/structure/bed/mattress/pregame,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hsU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -18436,7 +19132,7 @@
 "hul" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg1";
+	icon_state = "platingdmg1"
 	},
 /area/f13/caves)
 "hum" = (
@@ -18623,7 +19319,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken";
+	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
 "hxx" = (
@@ -18843,18 +19539,20 @@
 	},
 /area/f13/wasteland)
 "hCg" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hCp" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2"
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/obj/item/shovel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hCs" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -18866,10 +19564,20 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
+/obj/item/stack/sheet/metal,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hCB" = (
+/obj/item/clothing/head/f13/rastacap,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/glasses/sunglasses/big,
+/obj/item/clothing/under/f13/gentlesuit,
+/obj/item/clothing/shoes/f13/fancy,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "hCC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -18891,6 +19599,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/caves)
+"hCW" = (
+/obj/structure/table,
+/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/area/f13/wasteland)
 "hDc" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -18944,12 +19656,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
-"hEh" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
+"hEd" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"hEf" = (
+/obj/structure/simple_door/tentflap_cloth,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/building)
+"hEh" = (
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hEj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -18990,10 +19718,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "hEX" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/pinup_topless,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "hFM" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -19038,18 +19765,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "hGm" = (
-/obj/machinery/button/door{
-	id = "vaultelevator";
-	name = "Blast Door Exit";
-	pixel_y = -27
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "hGr" = (
 /obj/structure/car/rubbish3,
 /obj/structure/car/rubbish2,
@@ -19203,9 +19927,11 @@
 	},
 /area/f13/building)
 "hIi" = (
-/obj/structure/fluff/fokoff_sign,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "hIA" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/boxing/green,
@@ -19457,11 +20183,21 @@
 	icon_state = "rubble"
 	},
 /area/f13/village)
+"hNs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "hNC" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/flora/grass/wasteland,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hNE" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/supermart,
@@ -19701,6 +20437,10 @@
 /obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"hTt" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "hTI" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -19822,14 +20562,23 @@
 	},
 /area/f13/ncr)
 "hVW" = (
-/obj/structure/chair/comfy{
-	dir = 8
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/village)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "hWd" = (
 /obj/structure/closet/fridge/standard{
 	pixel_x = 8
@@ -20092,6 +20841,16 @@
 /obj/structure/chair/f13foldupchair,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/wasteland)
+"iah" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "iam" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20204,6 +20963,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"ibz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "ibA" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -20243,12 +21009,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/wood,
-/area/f13/village)
-"icB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
 "icE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20336,7 +21096,7 @@
 "iez" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "ieK" = (
@@ -20379,6 +21139,16 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/village)
+"ifv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "Raider"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/village)
 "ifU" = (
 /obj/structure/chair/booth{
@@ -20490,7 +21260,7 @@
 "ijj" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/barber{
-	icon_state = "plating";
+	icon_state = "plating"
 	},
 /area/f13/caves)
 "ijC" = (
@@ -20645,10 +21415,10 @@
 	},
 /area/f13/building)
 "imR" = (
-/obj/item/mine/shrapnel,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "imT" = (
 /obj/structure/tires/five,
 /obj/structure/tires,
@@ -20680,7 +21450,7 @@
 /area/f13/wasteland)
 "inl" = (
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -20778,10 +21548,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ipE" = (
-/obj/structure/rack,
-/obj/item/storage/backpack,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ipF" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -20822,8 +21591,8 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/turf/open/floor/wood/f13/old/ruinedstraightwest,
+/area/f13/wasteland)
 "iqH" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
@@ -20853,6 +21622,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/building)
+"iqX" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iqY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20866,14 +21641,11 @@
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
 "ira" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	name = "towel boy pod";
-	pixel_y = 20
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/area/f13/building)
 "irr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/greyscale{
@@ -20944,7 +21716,7 @@
 "itj" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg3";
+	icon_state = "platingdmg3"
 	},
 /area/f13/caves)
 "itn" = (
@@ -20960,6 +21732,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"itB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/processor/chopping_block,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "itJ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -21017,6 +21800,11 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
+"iuJ" = (
+/obj/structure/decoration/vent/rusty,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "iuQ" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -21092,6 +21880,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"iwq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "iwG" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -21146,7 +21945,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
+	pixel_x = -12
 	},
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
@@ -21288,11 +22087,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iAU" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iBo" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21375,7 +22172,7 @@
 /area/f13/legion)
 "iCH" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21428,7 +22225,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "iDS" = (
@@ -21474,6 +22271,17 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"iFa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "iFk" = (
 /obj/structure/dresser,
 /obj/machinery/light/small/broken{
@@ -21527,6 +22335,12 @@
 /obj/structure/junk/small/bed,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
+"iGD" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "iGE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -21574,10 +22388,9 @@
 	},
 /area/f13/building)
 "iHk" = (
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	},
-/area/f13/wasteland)
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iHu" = (
 /obj/structure/headpike,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21616,7 +22429,7 @@
 /area/f13/building)
 "iHR" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
+	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -21746,7 +22559,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood2";
+	icon_state = "housewood2"
 	},
 /area/f13/building)
 "iKc" = (
@@ -21828,16 +22641,13 @@
 	},
 /area/f13/building)
 "iLD" = (
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iLK" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -21968,6 +22778,14 @@
 "iNU" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
+/area/f13/village)
+"iOe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "iOg" = (
 /obj/structure/chair/sofa/right{
@@ -22143,17 +22961,21 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"iQF" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "iQP" = (
 /obj/item/clothing/under/f13/legslave,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "iQR" = (
 /obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore";
+	icon_state = "brokenstore"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/barber{
-	icon_state = "plating";
+	icon_state = "plating"
 	},
 /area/f13/caves)
 "iQT" = (
@@ -22367,13 +23189,17 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "iTC" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iTF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/settler,
@@ -22381,7 +23207,7 @@
 /area/f13/building)
 "iTI" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
@@ -22566,13 +23392,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iXC" = (
-/obj/structure/wreck/trash/machinepile{
-	layer = 3
+/obj/structure/stairs/north{
+	color = "#A47449"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "iXE" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22687,6 +23511,10 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"iZV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/village)
 "jaa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -22724,14 +23552,12 @@
 	},
 /area/f13/bunker)
 "jay" = (
-/obj/item/radio/intercom{
-	frequency = 1365;
-	name = "Vault Intercom";
-	pixel_x = 1;
-	pixel_y = 25
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/item/flag/khan,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "jaI" = (
 /obj/structure/railing/handrail/blue{
 	dir = 4
@@ -22903,10 +23729,11 @@
 	},
 /area/f13/building)
 "jel" = (
-/obj/structure/closet/cabinet,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "jem" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/jungle,
@@ -22922,12 +23749,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "jeI" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "jeO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22985,12 +23811,32 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"jfO" = (
+/obj/item/kitchen/knife,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 7
+	},
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "jgq" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"jgs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "jgt" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -23082,6 +23928,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"jhy" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	},
+/area/f13/building)
 "jhO" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -23110,10 +23965,11 @@
 	},
 /area/f13/building)
 "jiv" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jix" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/cigarette,
@@ -23320,14 +24176,14 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jmq" = (
-/obj/item/clothing/head/f13/rastacap,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/glasses/sunglasses/big,
-/obj/item/clothing/under/f13/gentlesuit,
-/obj/item/clothing/shoes/f13/fancy,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jmt" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -23452,7 +24308,7 @@
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "joY" = (
@@ -23485,11 +24341,16 @@
 	},
 /area/f13/ncr)
 "jpB" = (
-/obj/effect/overlay/junk/shower{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jpO" = (
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/wood/f13,
@@ -23653,7 +24514,7 @@
 "jtc" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin";
+	icon_state = "skin"
 	},
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -23915,15 +24776,21 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/village)
-"jxD" = (
-/obj/item/trash/coal,
-/obj/item/trash/coal,
-/obj/item/trash/coal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+"jxB" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
+"jxD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/stairs/west,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jxH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
@@ -23961,6 +24828,13 @@
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jyr" = (
+/obj/structure/barricade/tentclothcorner,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "jyz" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23986,7 +24860,7 @@
 /area/f13/building)
 "jzC" = (
 /obj/machinery/seed_extractor,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jzN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24013,6 +24887,15 @@
 	dir = 4
 	},
 /area/f13/building)
+"jAh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/flour,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "jAq" = (
 /obj/structure/fence{
 	dir = 4
@@ -24096,8 +24979,19 @@
 	},
 /area/f13/wasteland)
 "jCH" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/greyscale{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "jCV" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -24128,7 +25022,7 @@
 /area/f13/bunker)
 "jDk" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
+	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -24308,10 +25202,17 @@
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "jIB" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "jIJ" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 1
@@ -24462,9 +25363,13 @@
 	},
 /area/f13/building)
 "jMd" = (
-/obj/structure/flora/tree/wasteland,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "jMr" = (
 /obj/structure/simple_door/metal,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -24502,8 +25407,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jMN" = (
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+	icon_state = "housewood2"
 	},
 /area/f13/village)
 "jMP" = (
@@ -24688,7 +25594,7 @@
 "jQz" = (
 /obj/structure/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair_settler";
+	icon_state = "wooden_chair_settler"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -24708,6 +25614,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"jRV" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "jRX" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24784,6 +25696,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"jTR" = (
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "jTX" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/button{
@@ -24911,7 +25839,7 @@
 "jVE" = (
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "jVM" = (
 /obj/effect/decal/riverbank,
 /obj/effect/decal/waste{
@@ -25019,7 +25947,7 @@
 /area/f13/building)
 "jXh" = (
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg1";
+	icon_state = "platingdmg1"
 	},
 /area/f13/caves)
 "jXj" = (
@@ -25168,6 +26096,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"kaC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "kaJ" = (
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -25179,7 +26117,7 @@
 /area/f13/wasteland)
 "kaP" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
@@ -25197,7 +26135,7 @@
 /area/f13/building)
 "kbw" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25456,11 +26394,18 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/village)
 "kgn" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/wasteland)
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "kgy" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/desert,
@@ -25516,7 +26461,7 @@
 "khn" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plasteel/barber{
-	icon_state = "plating";
+	icon_state = "plating"
 	},
 /area/f13/caves)
 "kho" = (
@@ -25596,7 +26541,7 @@
 /area/f13/building)
 "kin" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "innermaincornerinner";
+	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
 "kiC" = (
@@ -25899,9 +26844,20 @@
 	},
 /area/f13/wasteland)
 "koZ" = (
-/obj/effect/decal/remains/human,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "kpe" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -26114,6 +27070,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"kum" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	},
+/area/f13/building)
 "kuo" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -26228,10 +27190,26 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kwA" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -4;
+	pixel_y = 2;
+	},
+/obj/machinery/door/unpowered/securedoor{
+	req_access_txt = "125"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"kwB" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "kwK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26240,13 +27218,25 @@
 	},
 /area/f13/wasteland)
 "kwL" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/f13/cram,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -11;
+	pixel_y = 2;
 	},
-/area/f13/village)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kwN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26296,6 +27286,10 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/tunnel)
+"kyq" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kyt" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26343,6 +27337,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"kzZ" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "kAa" = (
 /obj/structure/chair/wood/worn{
 	dir = 8
@@ -26372,13 +27375,14 @@
 	},
 /area/f13/building)
 "kBd" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/area/f13/village)
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "kBg" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -26405,7 +27409,7 @@
 	},
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "kBV" = (
@@ -26491,6 +27495,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"kDu" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2right";
+	},
+/area/f13/wasteland)
 "kDK" = (
 /turf/closed/indestructible/rock,
 /area/f13/building)
@@ -26516,12 +27526,26 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/building)
+"kEe" = (
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "kEh" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
 "kEi" = (
 /obj/structure/chair/wood/modern,
 /turf/open/floor/wood,
+/area/f13/village)
+"kEk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
 /area/f13/village)
 "kEq" = (
 /obj/machinery/light/small,
@@ -26565,6 +27589,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/village)
+"kFc" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
+"kFf" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "kFn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26686,6 +27722,13 @@
 	icon_state = "verticalrightborderrighttop"
 	},
 /area/f13/building)
+"kId" = (
+/obj/structure/barricade/tentclothedge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/building)
 "kIf" = (
 /obj/structure/table/reinforced,
 /obj/item/bodypart/l_leg/robot,
@@ -26701,6 +27744,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kIp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "kIs" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
@@ -26802,6 +27853,10 @@
 "kLg" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
+"kLl" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kLn" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -26940,6 +27995,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"kOI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/village)
 "kOW" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
@@ -27111,6 +28178,9 @@
 /area/f13/building)
 "kTP" = (
 /obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
 	icon_state = "dirt";
@@ -27293,7 +28363,7 @@
 "kWW" = (
 /obj/item/seeds/feracactus,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "kXa" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -27391,10 +28461,12 @@
 	},
 /area/f13/building)
 "kYI" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "kYQ" = (
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /obj/effect/decal/cleanable/dirt{
@@ -27455,11 +28527,7 @@
 	},
 /area/f13/wasteland)
 "lag" = (
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "lak" = (
 /obj/item/radio,
@@ -27470,6 +28538,16 @@
 /obj/item/mining_scanner,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"lam" = (
+/obj/machinery/vending/nukacolavend,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -27524,7 +28602,7 @@
 "lbJ" = (
 /mob/living/simple_animal/hostile/wolf/playable,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building)
+/area/f13/wasteland)
 "lbO" = (
 /obj/structure/table/wood,
 /obj/item/wirecutters/crude,
@@ -27552,6 +28630,12 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"lcd" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "lcl" = (
 /obj/structure/barricade/wooden,
 /obj/structure/fence/wooden{
@@ -27669,10 +28753,14 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "leq" = (
-/obj/structure/simple_door/interior,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "les" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -27838,7 +28926,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "lgN" = (
@@ -27910,6 +28998,12 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"lhM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "lhW" = (
 /obj/structure/noticeboard{
 	layer = 2.5;
@@ -28216,7 +29310,7 @@
 /area/f13/building)
 "log" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/savannah,
@@ -28284,7 +29378,7 @@
 /area/f13/village)
 "lpL" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
+	icon_state = "tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
@@ -28302,14 +29396,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/city)
-"lqh" = (
-/obj/structure/fluff/beach_umbrella/science,
-/obj/structure/chair/comfy/plywood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/purple,
-/area/f13/village)
 "lqp" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13{
@@ -28359,6 +29445,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lrp" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "lrz" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -28425,6 +29515,15 @@
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"ltA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "ltC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28436,6 +29535,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"ltK" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	},
+/area/f13/wasteland)
 "luv" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -28478,6 +29583,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/farm)
+"luZ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "lvb" = (
 /obj/structure/chair/wood/modern{
 	dir = 1
@@ -28518,7 +29629,7 @@
 /area/f13/wasteland)
 "lvH" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -28616,7 +29727,7 @@
 /area/f13/building)
 "lxW" = (
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "lyg" = (
@@ -28770,9 +29881,9 @@
 	},
 /area/f13/village)
 "lBS" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/sign/poster/prewar/poster80,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "lBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -28942,7 +30053,7 @@
 /area/f13/building)
 "lFD" = (
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg3";
+	icon_state = "platingdmg3"
 	},
 /area/f13/caves)
 "lFL" = (
@@ -29072,6 +30183,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"lJk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "lJx" = (
 /obj/machinery/light{
 	dir = 8
@@ -29113,7 +30231,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "lLh" = (
@@ -29265,6 +30383,21 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"lNE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "lNL" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt{
@@ -29489,11 +30622,12 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "lSD" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2right"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lSO" = (
 /obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29542,7 +30676,7 @@
 /obj/effect/decal/marking,
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
 "lTG" = (
@@ -29629,6 +30763,18 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"lUw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "lUK" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -29688,7 +30834,7 @@
 /area/f13/wasteland)
 "lVS" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
@@ -29755,6 +30901,11 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"lWN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/junk/small/table,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "lWP" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
@@ -29772,13 +30923,14 @@
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "lXu" = (
-/obj/machinery/light/broken{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
 	},
-/area/f13/enclave)
+/area/f13/building)
 "lXy" = (
 /obj/structure/junk/small/tv{
 	desc = "A wall mounted television, sadly it's broken.";
@@ -29942,11 +31094,14 @@
 	},
 /area/f13/building)
 "lZP" = (
-/obj/structure/car,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "lZV" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright3"
@@ -30046,7 +31201,7 @@
 "mcf" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "mcp" = (
@@ -30086,9 +31241,12 @@
 	},
 /area/f13/building)
 "mdv" = (
-/mob/living/simple_animal/hostile/stalker,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "mdA" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -30096,6 +31254,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/followers)
+"mdB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/wood,
+/area/f13/village)
 "mdF" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Botanical Bay";
@@ -30216,11 +31381,17 @@
 	},
 /area/f13/wasteland)
 "mfR" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "mfV" = (
 /obj/machinery/light/small/broken,
 /turf/open/indestructible/ground/outside/road{
@@ -30294,7 +31465,7 @@
 /area/f13/wasteland)
 "mhJ" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
+	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -30493,11 +31664,9 @@
 	},
 /area/f13/building)
 "mlf" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "mlm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30570,12 +31739,24 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
-"mmT" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
+"mmS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/junk/cabinet{
+	pixel_y = 10
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood{
+	icon_state = "housewastelandnorth"
+	},
+/area/f13/village)
+"mmT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "mna" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -30611,6 +31792,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"mnl" = (
+/obj/structure/nest/ghoul{
+	layer = 2.07;
+	max_mobs = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mnC" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -30681,6 +31869,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"moH" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	},
+/area/f13/wasteland)
 "moV" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -30729,7 +31922,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "mpH" = (
@@ -30822,8 +32015,11 @@
 "mrq" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/building)
+"mrH" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mrQ" = (
-/obj/item/clothing/head/cone,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -30910,6 +32106,14 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"mtr" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "mtx" = (
 /obj/structure/showcase/machinery/tv{
 	name = "Pre-war television"
@@ -31108,6 +32312,17 @@
 /obj/item/seeds/feracactus,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
+"mxt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "mxO" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -31406,13 +32621,13 @@
 /area/f13/village)
 "mDM" = (
 /turf/open/floor/plasteel/barber{
-	icon_state = "plating";
+	icon_state = "plating"
 	},
 /area/f13/caves)
 "mEh" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "mEy" = (
@@ -31580,10 +32795,13 @@
 	},
 /area/f13/building)
 "mHW" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "mIc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31606,6 +32824,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"mIk" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "mIv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -31732,11 +32957,12 @@
 	},
 /area/f13/wasteland)
 "mKr" = (
-/obj/structure/table/wood/settler,
-/obj/item/trash/f13/borscht,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "mKu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31758,6 +32984,33 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"mKM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
+"mKU" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"mKV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "mLc" = (
 /obj/structure/cross,
 /obj/effect/mob_spawn/human/corpse,
@@ -31885,10 +33138,24 @@
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
+"mOe" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "mOk" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"mOo" = (
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/closet/fridge/standard,
+/obj/effect/decal/cleanable/generic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mOs" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -31925,11 +33192,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mOP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "mOS" = (
 /obj/machinery/light/small{
@@ -31967,6 +33237,17 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/village)
+"mPF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "mPL" = (
 /obj/item/poster/random_contraband,
 /turf/open/floor/f13/wood,
@@ -31979,11 +33260,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mPT" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "mQj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowleft"
@@ -32161,10 +33440,9 @@
 	},
 /area/f13/tunnel)
 "mTy" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mTF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -32272,6 +33550,10 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"mVs" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "mVv" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -32397,6 +33679,15 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"mWY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/syndi_cakes,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "mXe" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -32523,7 +33814,10 @@
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
 /area/f13/building)
 "mZn" = (
 /obj/structure/fence/wooden{
@@ -32749,10 +34043,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland)
 "nes" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
 	},
-/area/f13/enclave)
+/area/f13/building)
 "nev" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32841,19 +34136,23 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "ngr" = (
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/table/snooker{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "ngs" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
 "ngw" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "ngC" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -32972,9 +34271,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "niD" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "niI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -33084,11 +34385,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "nlO" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nlR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33168,6 +34468,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"nnB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "nnG" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -33205,6 +34512,16 @@
 	icon_state = "horizontaltopbordertopleft"
 	},
 /area/f13/wasteland)
+"noU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
+/area/f13/village)
 "npb" = (
 /obj/structure/anvil/obtainable/basic,
 /turf/open/indestructible/ground/inside/subway{
@@ -33316,6 +34633,16 @@
 	},
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/wasteland)
+"nqT" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "nqZ" = (
 /obj/structure/window{
 	dir = 1
@@ -33458,12 +34785,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ntz" = (
-/obj/structure/simple_door/interior,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6";
 	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ntI" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -33711,10 +35037,10 @@
 	},
 /area/f13/village)
 "nzN" = (
-/obj/structure/junk/micro,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "nAh" = (
 /obj/structure/barricade/wooden,
@@ -33787,6 +35113,18 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
+"nBA" = (
+/obj/structure/sink/greyscale{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "nBF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -33860,7 +35198,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland)
 "nDx" = (
@@ -33950,7 +35288,7 @@
 "nFA" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
+	icon_state = "straight"
 	},
 /obj/structure/fence/wooden{
 	dir = 4
@@ -34065,15 +35403,11 @@
 	light_color = "#d8b1b1";
 	pixel_y = 11
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nIp" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
-"nIz" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
 "nID" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sunset{
@@ -34099,9 +35433,9 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "nJr" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/chair/stool/retro/backed,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nJz" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/wasteland)
@@ -34122,6 +35456,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/closed/wall/f13/store,
+/area/f13/building)
+"nJQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "Vault1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "nJT" = (
 /turf/open/indestructible/ground/outside/road{
@@ -34328,11 +35670,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nOD" = (
-/obj/effect/decal/marking,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1";
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "nON" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34366,6 +35706,16 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
+"nPl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/bench{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "nPo" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34464,10 +35814,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"nQY" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "nRb" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
@@ -34545,6 +35891,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"nSv" = (
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "nSI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -34615,8 +35966,11 @@
 	},
 /area/f13/followers)
 "nTP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "nTV" = (
 /obj/structure/fence/corner,
@@ -34671,8 +36025,12 @@
 /turf/open/floor/wood/f13/stage_br,
 /area/f13/building)
 "nVi" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "nVn" = (
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -34710,6 +36068,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"nWb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "nWl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
@@ -35122,10 +36484,13 @@
 	},
 /area/f13/wasteland)
 "ofX" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right"
+/obj/machinery/smartfridge/bottlerack/lootshelf/diy,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "ofZ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
@@ -35141,6 +36506,15 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland)
+"ogo" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ogw" = (
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
@@ -35153,13 +36527,14 @@
 /obj/item/seeds/potato,
 /obj/item/seeds/soya,
 /obj/item/seeds/soya,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ogR" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
-	icon_state = "dirt";
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "ogZ" = (
@@ -35261,6 +36636,10 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oiA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oakbroken,
+/area/f13/building)
 "oiK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -35394,6 +36773,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/building)
+"olm" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "olG" = (
 /obj/machinery/light{
 	dir = 8;
@@ -35488,11 +36871,14 @@
 	},
 /area/f13/followers)
 "onh" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "onk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -35501,6 +36887,16 @@
 "onm" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/village)
+"onn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "onp" = (
 /obj/structure/wreck/trash/one_tire,
@@ -35788,14 +37184,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "osF" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/lootshelf/construction,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/area/f13/building)
+"oti" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/village)
 "otm" = (
 /obj/structure/sign/poster/contraband/atmosia_independence,
 /turf/closed/wall/f13/store/constructed,
@@ -35889,12 +37293,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ouJ" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "ouO" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants,
@@ -35910,18 +37312,16 @@
 /area/f13/wasteland)
 "ovg" = (
 /obj/machinery/autolathe/ammo,
+/obj/item/stack/sheet/metal,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ovt" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "ovF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -35967,6 +37367,12 @@
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"owR" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oxi" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -36130,11 +37536,10 @@
 	},
 /area/f13/wasteland)
 "oAe" = (
-/obj/machinery/power/smes,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/enclave)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building)
 "oAo" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -36145,13 +37550,10 @@
 	},
 /area/f13/building)
 "oAB" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/obj/structure/urinal,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "oAQ" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
@@ -36257,13 +37659,11 @@
 	},
 /area/f13/caves)
 "oDo" = (
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/door/unpowered/securedoor{
+	req_access_txt = "125"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oDG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36283,11 +37683,9 @@
 	},
 /area/f13/wasteland)
 "oES" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "oFp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -36312,13 +37710,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
 "oFK" = (
-/obj/structure/wreck/trash/engine{
-	desc = "Oh, you love the lake? Then name five brands of car batteries you’ve thrown into it.";
-	name = "Car battery";
-	pixel_x = 9
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oFX" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Bar";
@@ -36349,6 +37745,16 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
+"oGy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "oGB" = (
 /obj/structure/table,
 /obj/item/trash/f13/mre{
@@ -36364,7 +37770,7 @@
 "oGS" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
-	icon_state = "dirtcorner";
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
 "oGU" = (
@@ -36379,13 +37785,9 @@
 	},
 /area/f13/wasteland)
 "oGX" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/pinup_ride,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "oGZ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
@@ -36463,6 +37865,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"oIo" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "oIv" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36551,6 +37959,17 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"oKF" = (
+/obj/effect/decal/remains/human,
+/obj/item/screwdriver/nuke{
+	anchored = 1;
+	pixel_x = 12;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "oKW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -36592,10 +38011,12 @@
 	},
 /area/f13/building)
 "oMn" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oMp" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/road{
@@ -36603,15 +38024,12 @@
 	},
 /area/f13/wasteland)
 "oMC" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oMP" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -36628,25 +38046,16 @@
 	},
 /area/f13/building)
 "oNf" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "oNs" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
-"oNC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "oNE" = (
 /obj/structure/rack,
 /obj/item/clothing/head/nun_hood,
@@ -36661,11 +38070,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "oNR" = (
-/obj/structure/sign/poster/prewar/poster71{
-	pixel_x = 32
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oOa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36759,7 +38169,7 @@
 /area/f13/legion)
 "oPO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right";
+	icon_state = "horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
 "oPQ" = (
@@ -36836,6 +38246,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oSm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
 "oSp" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -36853,14 +38276,21 @@
 	},
 /area/f13/legion)
 "oSz" = (
-/obj/item/toy/beach_ball,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "oSA" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/armor/f13/slavelabor,
 /obj/item/clothing/shoes/f13/rag,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "oSC" = (
 /obj/structure/fence/wooden{
@@ -36971,6 +38401,23 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"oVB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/reagentgrinder,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
+"oVC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "oVH" = (
 /obj/structure/chair{
 	dir = 1
@@ -37116,6 +38563,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oZm" = (
+/obj/structure/car/rubbish2,
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
+"oZq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "oZv" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37145,12 +38607,15 @@
 	},
 /area/f13/village)
 "paa" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pad" = (
 /obj/structure/table/wood,
 /obj/item/documents{
@@ -37194,6 +38659,12 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"paU" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "paY" = (
 /obj/effect/decal/remains/human,
 /obj/structure/chair/stool{
@@ -37241,7 +38712,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pbx" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
 /area/f13/village)
 "pbM" = (
 /obj/structure/chair/wood/modern{
@@ -37253,21 +38734,18 @@
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
 "pbX" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/kudzu,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "pcb" = (
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -4;
-	pixel_y = 2;
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "125"
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "pck" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
@@ -37316,15 +38794,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pcV" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "pdl" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
@@ -37345,13 +38823,16 @@
 	},
 /area/f13/village)
 "pei" = (
+/obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pek" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -37418,11 +38899,19 @@
 	},
 /area/f13/wasteland)
 "pfd" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_3";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"pfi" = (
+/obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/building)
 "pfj" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
@@ -37586,7 +39075,7 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
-	icon_state = "outerbordercorner";
+	icon_state = "outerbordercorner"
 	},
 /area/f13/caves)
 "pia" = (
@@ -37719,7 +39208,7 @@
 "plm" = (
 /obj/structure/fence{
 	dir = 4;
-	icon_state = "straight";
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -37790,6 +39279,20 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"pmi" = (
+/obj/structure/kitchenspike,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "pmn" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
@@ -37834,6 +39337,14 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"pnM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "pnQ" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -37926,12 +39437,28 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ppL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "ppR" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"ppV" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/tunnel)
 "pqa" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -37956,10 +39483,7 @@
 	},
 /area/f13/followers)
 "pqw" = (
-/obj/structure/chair/stool/retro/backed,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "pqB" = (
 /obj/structure/bed/mattress{
@@ -38029,6 +39553,15 @@
 	icon_state = "dirt"
 	},
 /area/f13/legion)
+"prR" = (
+/obj/structure/table/snooker{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet9"
+	},
+/area/f13/village)
 "psf" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt{
@@ -38041,10 +39574,6 @@
 /obj/item/flag/khan,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"psD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
 "psK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -38056,7 +39585,7 @@
 "psR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 6;
-	icon_state = "outerpavement";
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "ptb" = (
@@ -38095,10 +39624,14 @@
 	},
 /area/f13/building)
 "ptI" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/effect/decal/remains/human,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ptP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -38145,7 +39678,7 @@
 "puY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
-	icon_state = "outerpavement";
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "pvf" = (
@@ -38160,10 +39693,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pvD" = (
-/obj/structure/chair/stool/retro/tan,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "pvL" = (
 /obj/structure/showcase/cyborg/old,
@@ -38232,10 +39763,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "pxw" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pxy" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -38259,7 +39795,7 @@
 /area/f13/building)
 "pye" = (
 /obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
+	icon_state = "tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -38272,7 +39808,7 @@
 "pyk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "pyr" = (
@@ -38318,13 +39854,18 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "pyU" = (
-/obj/effect/decal/remains{
-	icon_state = "remains";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pyZ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -38358,10 +39899,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
 "pzN" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left";
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pAm" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
@@ -38431,7 +39976,7 @@
 /area/f13/building)
 "pBX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2";
+	icon_state = "horizontaltopbordertop2"
 	},
 /area/f13/wasteland)
 "pCi" = (
@@ -38588,6 +40133,12 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
 /area/f13/caves)
+"pFx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/f13/village)
 "pFL" = (
 /obj/structure/table,
 /obj/item/crafting/lunchbox,
@@ -38596,7 +40147,7 @@
 /area/f13/village)
 "pFM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3";
+	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
 "pFN" = (
@@ -38626,10 +40177,18 @@
 	},
 /area/f13/city)
 "pGg" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pGq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
@@ -38710,6 +40269,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"pIc" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "pIf" = (
 /obj/structure/cross,
 /obj/effect/mob_spawn/human/corpse,
@@ -38773,11 +40336,17 @@
 	},
 /area/f13/wasteland)
 "pIS" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "pIT" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -38815,7 +40384,7 @@
 "pJQ" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
+	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
 "pJT" = (
@@ -38838,7 +40407,7 @@
 "pJY" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
-	icon_state = "horizontaltopborderbottom2left";
+	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
 "pKj" = (
@@ -38854,7 +40423,7 @@
 "pKq" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
-	icon_state = "horizontaltopborderbottom2right";
+	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
 "pKt" = (
@@ -38927,10 +40496,15 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "pLJ" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2left";
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/wasteland)
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 23;
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pLK" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -39027,7 +40601,7 @@
 /area/f13/clinic)
 "pOC" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2";
+	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
 "pOK" = (
@@ -39054,6 +40628,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"pPc" = (
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "pPG" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13{
@@ -39072,6 +40652,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood,
 /area/f13/village)
+"pQl" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	},
+/area/f13/building)
 "pQp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -39106,10 +40695,9 @@
 	},
 /area/f13/building)
 "pQX" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right";
-	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pRd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/ruins,
@@ -39122,7 +40710,7 @@
 /area/f13/building)
 "pRo" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2";
+	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
 "pRq" = (
@@ -39143,7 +40731,7 @@
 "pRy" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
-	icon_state = "horizontalinnermain2right";
+	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
 "pRQ" = (
@@ -39232,6 +40820,12 @@
 /obj/machinery/light,
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"pUj" = (
+/obj/machinery/power/smes,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/enclave)
 "pUl" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt{
@@ -39260,11 +40854,9 @@
 	},
 /area/f13/village)
 "pUB" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left";
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/prewar/poster79,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "pUQ" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -39296,10 +40888,14 @@
 	},
 /area/f13/wasteland)
 "pVb" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain3";
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/wasteland)
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pVQ" = (
 /obj/structure/table,
 /obj/structure/window/spawner,
@@ -39312,6 +40908,14 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pWn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland)
 "pWs" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -39323,7 +40927,7 @@
 /area/f13/wasteland)
 "pWt" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2right";
+	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
 "pWC" = (
@@ -39423,7 +41027,7 @@
 /area/f13/wasteland)
 "pYj" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2left";
+	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
 "pYn" = (
@@ -39509,21 +41113,27 @@
 "qaq" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2";
+	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland)
 "qax" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
-	pixel_x = -11;
-	pixel_y = 11
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qaS" = (
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/storage/fancy/rollingpapers,
+/obj/item/lighter,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "qbe" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -39827,6 +41437,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"qgw" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/door/poddoor{
+	id = "vaultelevator"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "qgM" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -39901,6 +41520,16 @@
 	icon_state = "hydrofloor"
 	},
 /area/f13/building)
+"qhP" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/closet/crate/solarpanel_small,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "qie" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/f13{
@@ -39913,12 +41542,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qin" = (
-/obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/farm)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qip" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -39926,6 +41557,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"qir" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "qiv" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/road{
@@ -40120,6 +41757,10 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"qmP" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "qnb" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -40200,6 +41841,16 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"qoC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "qoH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/cola/red,
@@ -40222,9 +41873,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qoN" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "qoP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/decan,
@@ -40256,6 +41909,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"qpr" = (
+/turf/closed/mineral/random/high_chance,
+/area/f13/tunnel)
 "qpM" = (
 /obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/indestructible/ground/outside/desert,
@@ -40366,6 +42022,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"qss" = (
+/obj/effect/decal/remains/human,
+/obj/item/stack/f13Cash/random/med,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "qst" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -40416,6 +42077,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"qtO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/village)
 "qtZ" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -40946,9 +42619,15 @@
 	},
 /area/f13/wasteland)
 "qER" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qEZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
@@ -40958,6 +42637,10 @@
 "qFQ" = (
 /turf/open/floor/wood/f13/old/ruinedstraighteast,
 /area/f13/wasteland)
+"qFR" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "qGk" = (
 /obj/machinery/light{
 	dir = 1;
@@ -41126,11 +42809,16 @@
 	},
 /area/f13/building)
 "qIS" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
+"qJv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/old{
+	icon_state = "housebase"
 	},
-/area/f13/enclave)
+/area/f13/village)
 "qJx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -41289,10 +42977,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "qMt" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/enclave)
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qMA" = (
 /obj/structure/table,
 /obj/machinery/light/small/broken{
@@ -41577,17 +43264,10 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"qRy" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
 "qRB" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/f13/wood,
+/obj/structure/reagent_dispensers/barrel/three,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/village)
 "qSe" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41818,8 +43498,9 @@
 	},
 /area/f13/building)
 "qXO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "qYa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41933,11 +43614,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "ram" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -42030,6 +43706,15 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"rcl" = (
+/obj/item/radio/intercom{
+	frequency = 1365;
+	name = "Vault Intercom";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "rcm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -42093,6 +43778,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/village)
+"rdT" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/enclave)
 "ree" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -42177,6 +43867,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/village)
+"rfB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/flour,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/village)
 "rfD" = (
 /obj/machinery/light{
@@ -42273,6 +43971,17 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rik" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "rit" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -42368,6 +44077,14 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"rkP" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rkR" = (
 /obj/structure/rack,
 /obj/item/clothing/head/nursehat,
@@ -42484,6 +44201,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/stage_r,
 /area/f13/building)
+"rnA" = (
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "rnD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -42581,6 +44302,15 @@
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rqf" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement"
+	},
+/area/f13/building)
 "rqs" = (
 /turf/open/floor/carpet,
 /area/f13/village)
@@ -42648,6 +44378,13 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"rsk" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "rss" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -42679,6 +44416,17 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"rto" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "rtR" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -42772,6 +44520,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rwt" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rwv" = (
 /obj/structure/kitchenspike,
 /obj/structure/decoration/hatch{
@@ -43003,6 +44758,19 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"rBM" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "rCx" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
@@ -43041,11 +44809,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/village)
 "rDi" = (
-/obj/structure/flora/tree/cactus,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "rDr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -43124,12 +44890,18 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rFc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
+/obj/structure/table/wood/settler,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "rFk" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/plating,
@@ -43222,6 +44994,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"rHu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "rHC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -43707,6 +45488,23 @@
 	icon_state = "plating"
 	},
 /area/f13/building)
+"rSt" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/item/reagent_containers/food/snacks/meat/slab/human,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "rSy" = (
 /obj/machinery/door/poddoor{
 	id = 42
@@ -43760,12 +45558,11 @@
 	},
 /area/f13/caves)
 "rTf" = (
-/obj/structure/closet,
-/obj/item/toy/poolnoodle/yellow,
-/obj/item/toy/poolnoodle,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "rTi" = (
 /obj/structure/sign/poster/contraband/pinup_couch,
 /turf/closed/wall/f13/wood,
@@ -43845,18 +45642,20 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "rVM" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/overlay/junk/sink{
+	pixel_y = 15
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "rVN" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/farm)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "rVQ" = (
 /obj/item/bodypart/l_arm,
 /obj/item/melee/onehanded/knife/throwing,
@@ -44067,6 +45866,10 @@
 /obj/item/soap/homemade,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"sas" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "sav" = (
 /obj/structure/fence/handrail{
 	dir = 1;
@@ -44132,6 +45935,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
+	},
+/area/f13/building)
+"sbd" = (
+/obj/structure/barricade/tentclothcorner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "sbf" = (
@@ -44264,10 +46074,6 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/village)
-"sdI" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
 "sdK" = (
 /obj/structure/rack,
@@ -44549,16 +46355,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "siS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/vermouth,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/area/f13/building)
 "siV" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -44791,11 +46591,16 @@
 /area/f13/wasteland)
 "snR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
 	},
-/area/f13/village)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "soh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44896,11 +46701,6 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
-"spG" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "spL" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -44926,6 +46726,13 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/caves)
+"sqr" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "sqx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -45129,6 +46936,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/clothing/under/f13/legskirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "svh" = (
@@ -45137,11 +46945,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
-"svp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
 "svA" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/road{
@@ -45351,6 +47154,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"szC" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	},
+/area/f13/building)
 "szG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -45371,12 +47180,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
 "sAe" = (
-/obj/structure/closet,
-/obj/item/toy/beach_ball,
-/obj/item/toy/poolnoodle/red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "sAk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -45606,6 +47416,23 @@
 /obj/structure/table/snooker,
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
+"sGH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "sGI" = (
 /turf/closed/wall/rust,
 /area/f13/caves)
@@ -45711,15 +47538,8 @@
 	},
 /area/f13/village)
 "sIc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "sIf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45978,13 +47798,22 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
 "sNC" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "sND" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -46021,6 +47850,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"sOz" = (
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/under/f13/classdress,
+/obj/item/clothing/mask/society,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet/anchored{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet12"
+	},
+/area/f13/village)
 "sOK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalleft"
@@ -46129,20 +47973,30 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"sQs" = (
+/obj/structure/simple_door/dirtyglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "sQu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/wood,
 /area/f13/village)
 "sQL" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "enclavebase";
-	name = "maintenance ladder"
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/enclave)
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "sQM" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -46150,10 +48004,15 @@
 	},
 /area/f13/wasteland)
 "sQW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/machinery/door/window{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "sQX" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -46230,11 +48089,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "sTn" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/area/f13/village)
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "sTv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -46425,7 +48292,7 @@
 /area/f13/building)
 "sWn" = (
 /obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore";
+	icon_state = "brokenstore"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood,
@@ -46677,9 +48544,19 @@
 	},
 /area/f13/wasteland)
 "tbX" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "tcg" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -46702,11 +48579,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "tcJ" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tcU" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -46741,9 +48616,15 @@
 	},
 /area/f13/village)
 "tdM" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tdO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46763,9 +48644,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ten" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/structure/flora/tree/cactus,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "teu" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -46831,8 +48720,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
 "tgR" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "tgZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47163,14 +49058,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "tmw" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/obj/item/kirbyplants,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tmA" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47212,20 +49102,13 @@
 	},
 /area/f13/building)
 "tnu" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tnK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -47473,10 +49356,12 @@
 /area/f13/building)
 "tsO" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/item/reagent_containers/food/drinks/bottle/vermouth,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "tsS" = (
 /obj/structure/table/wood/settler,
@@ -47696,6 +49581,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/dark,
 /area/f13/wasteland)
+"txd" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/village)
 "txh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47724,9 +49613,12 @@
 	},
 /area/f13/wasteland)
 "txC" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "txN" = (
 /obj/structure/closet/fridge/meat,
 /obj/effect/decal/cleanable/dirt,
@@ -47906,6 +49798,10 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
+"tBF" = (
+/mob/living/simple_animal/hostile/stalker,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "tBN" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -48022,9 +49918,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building)
 "tFP" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/red/white/side,
-/area/f13/village)
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "tFR" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -48088,15 +49984,16 @@
 	},
 /area/f13/wasteland)
 "tHN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/bedsheetbin/towel,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tIv" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -48123,10 +50020,15 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "tJl" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/village)
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tJm" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48212,12 +50114,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "tLE" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 4
+/obj/item/trash/f13/steak,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/area/f13/wasteland)
 "tLI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -48269,6 +50170,16 @@
 /obj/item/clothing/suit/armor/f13/kit,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
+/area/f13/village)
+"tMw" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/rust,
 /area/f13/village)
 "tMU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -48348,9 +50259,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "tOt" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/blue/white/side,
-/area/f13/village)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tOD" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -48414,7 +50332,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "tPD" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tPY" = (
@@ -48498,6 +50416,11 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"tRB" = (
+/obj/item/mine/shrapnel,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "tRD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -48537,12 +50460,10 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "tSf" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tSQ" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48564,6 +50485,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tTC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
+	},
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "tTK" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -48572,16 +50501,14 @@
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
 /area/f13/building)
 "tTV" = (
-/obj/effect/overlay/junk/toilet{
-	pixel_y = 12
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/eat,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "tUb" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
@@ -48600,8 +50527,12 @@
 	},
 /area/f13/building)
 "tUk" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "tUo" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48633,15 +50564,8 @@
 	},
 /area/f13/village)
 "tUO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/village)
 "tUQ" = (
 /obj/structure/reagent_dispensers/barrel/three,
@@ -48651,12 +50575,8 @@
 	},
 /area/f13/caves)
 "tUU" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood/house,
 /area/f13/village)
 "tVc" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -48706,6 +50626,16 @@
 /obj/item/stack/f13Cash/random/denarius/med,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"tWf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "tWp" = (
 /obj/structure/table,
 /obj/item/lighter,
@@ -48830,6 +50760,14 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland)
+"tYB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "tZg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -48843,18 +50781,14 @@
 	},
 /area/f13/building)
 "tZh" = (
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/area/f13/building)
 "tZr" = (
 /obj/structure/chair/wood/modern{
 	dir = 4
@@ -48913,6 +50847,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"tZM" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "enclavebase";
+	name = "maintenance ladder"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/f13/enclave)
 "tZN" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -49046,7 +50989,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "uco" = (
-/obj/item/clothing/head/cone,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "ucr" = (
@@ -49147,6 +51090,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"udJ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/village)
 "udP" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -49238,6 +51187,14 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ueY" = (
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "ufa" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -49600,6 +51557,15 @@
 "ukQ" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/wasteland)
+"ukY" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "ulf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -49607,6 +51573,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"uls" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "ult" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -50132,6 +52107,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uwR" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/tunnel)
 "uxf" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4
@@ -50154,6 +52132,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
+"uxR" = (
+/obj/structure/simple_door/dirtyglass,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "uyc" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "hospitalgarage2";
@@ -50177,6 +52159,14 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"uyo" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "uyp" = (
 /obj/structure/lamp_post/doubles/bent{
 	dir = 8
@@ -50237,8 +52227,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "uzN" = (
-/obj/structure/nest/mirelurk,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/table/snooker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
+	},
 /area/f13/village)
 "uzO" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -50257,11 +52250,12 @@
 	},
 /area/f13/wasteland)
 "uAp" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/area/f13/village)
+/area/f13/building)
 "uAv" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/wasteland)
@@ -50760,9 +52754,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "uIT" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/village)
 "uJa" = (
 /obj/machinery/hydroponics/soil,
@@ -50786,6 +52779,14 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
+"uKj" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "uKq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken,
@@ -50798,6 +52799,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
 	name = "tile"
+	},
+/area/f13/building)
+"uKC" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
 /area/f13/building)
 "uKQ" = (
@@ -50852,6 +52862,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"uLE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/redchess,
+/area/f13/village)
 "uLT" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -50936,9 +52954,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "uNW" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/glass/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "uOg" = (
 /obj/machinery/light/small{
@@ -51072,10 +53091,15 @@
 	},
 /area/f13/building)
 "uPK" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "uPP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -51295,14 +53319,31 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
 "uTA" = (
-/obj/machinery/icecream_vat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "uTE" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uTH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "damaged"
+	},
+/area/f13/village)
 "uTQ" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -51506,9 +53547,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
 "uYx" = (
-/obj/structure/sink/puddle,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/backpack,
+/obj/item/storage/backpack,
+/obj/item/storage/backpack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "uYz" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -51557,12 +53610,16 @@
 /turf/open/floor/wood,
 /area/f13/village)
 "uZg" = (
-/obj/structure/kitchenspike,
+/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "uZl" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -51612,12 +53669,18 @@
 	},
 /area/f13/building)
 "uZS" = (
-/obj/structure/chair/bench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/mob/living/simple_animal/hostile/handy{
+	name = "General Atomics Representative"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vad" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -51650,6 +53713,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vaZ" = (
+/obj/structure/table/snooker{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet1"
+	},
+/area/f13/village)
 "vbi" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -51801,10 +53873,16 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "veZ" = (
-/obj/effect/decal/remains/human,
-/obj/item/stack/f13Cash/random/med,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/safe,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vfc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -51863,8 +53941,12 @@
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
 "vfY" = (
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/item/trash/f13/dandyapples,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vga" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -52018,12 +54100,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
-"vjj" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
-/area/f13/village)
 "vjn" = (
 /obj/structure/sign/poster/ncr/democracy,
 /turf/closed/wall/r_wall/rust,
@@ -52130,6 +54206,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vlH" = (
+/obj/structure/fluff/railing{
+	color = "#968d87"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "vmB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -52150,11 +54233,15 @@
 	},
 /area/f13/wasteland)
 "vno" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "vns" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/store,
@@ -52192,7 +54279,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/f13{
-	icon_state = "darkredfull";
+	icon_state = "darkredfull"
 	},
 /area/f13/caves)
 "voc" = (
@@ -52283,14 +54370,15 @@
 	},
 /area/f13/ncr)
 "vpp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/area/f13/building)
 "vpw" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/f13/wood/house,
@@ -52344,6 +54432,10 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
+"vqN" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/village)
 "vqW" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/effect/decal/cleanable/dirt{
@@ -52490,12 +54582,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vvh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/item/stock_parts/cell,
+/obj/item/stock_parts/cell{
+	icon_state = "hpcell"
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "vvl" = (
 /obj/structure/simple_door/house{
 	icon_state = "interioropening"
@@ -52760,8 +54864,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vAu" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "vAJ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -52962,12 +55067,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vEw" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "vEG" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -53536,18 +55641,22 @@
 	},
 /area/f13/legion)
 "vQE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/village)
+/obj/structure/sign/poster/contraband/pinup_couch,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "vQS" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"vQW" = (
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "vQZ" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -53731,6 +55840,20 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/legion)
+"vWp" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "vWw" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/window/fulltile/house{
@@ -53993,23 +56116,19 @@
 	},
 /area/f13/building)
 "wcB" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_2";
+	pixel_x = 8;
+	pixel_y = 1
 	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wcO" = (
-/obj/effect/decal/remains/human,
-/obj/item/screwdriver/nuke{
-	anchored = 1;
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/enclave)
+/obj/structure/sign/poster/contraband/free_tonto,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "wcS" = (
 /obj/structure/rack,
 /obj/machinery/light/small/broken{
@@ -54150,6 +56269,30 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"wgt" = (
+/obj/item/candle/tribal_torch,
+/turf/open/indestructible/ground/outside/savannah/topcenter,
+/area/f13/wasteland)
+"whb" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/village)
 "why" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -54255,8 +56398,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wju" = (
-/obj/structure/closet,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "wjI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -54266,6 +56409,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"wjO" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	},
+/area/f13/wasteland)
 "wjP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -54461,6 +56610,11 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legion)
+"wor" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "woy" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -54668,6 +56822,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wsM" = (
+/obj/machinery/button/door{
+	id = "vaultelevator";
+	name = "Blast Door Exit";
+	pixel_y = -27
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/enclave)
 "wsR" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/decal/cleanable/dirt,
@@ -54816,6 +56983,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"wxa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/store,
+/area/f13/village)
 "wxc" = (
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt{
@@ -54824,9 +56996,11 @@
 	},
 /area/f13/legion)
 "wxi" = (
-/obj/structure/debris/v3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "wxr" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
@@ -54911,6 +57085,21 @@
 	name = "concrete wall"
 	},
 /area/f13/ncr)
+"wyt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/wicker{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/reagent_containers/pill/patch/bitterdrink,
+/obj/item/reagent_containers/pill/patch/bitterdrink,
+/turf/open/floor/wood/f13/oak,
+/area/f13/village)
 "wyI" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -55116,14 +57305,10 @@
 	},
 /area/f13/wasteland)
 "wDW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/village)
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wDX" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -55147,12 +57332,20 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "wEs" = (
-/obj/structure/nest/ghoul{
-	layer = 2.07;
-	max_mobs = 2
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/snacks/rawbrahminliver,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/area/f13/building)
 "wEO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
@@ -55219,6 +57412,15 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"wGn" = (
+/obj/effect/overlay/junk/toilet{
+	dir = 8
+	},
+/obj/item/clothing/under/f13/legskirt/tac,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "wGo" = (
 /obj/structure/chair,
 /turf/open/floor/carpet/black,
@@ -55472,11 +57674,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wLF" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/machinery/autolathe/constructionlathe,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "wLO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -55489,15 +57695,17 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "wLR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/item/clothing/head/helmet/f13/raider/eyebot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wLU" = (
 /obj/structure/closet,
 /obj/item/lighter,
@@ -55556,8 +57764,12 @@
 /area/f13/wasteland)
 "wMU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wMX" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/shovel,
@@ -55829,12 +58041,19 @@
 	},
 /area/f13/building)
 "wRI" = (
-/mob/living/simple_animal/hostile/stalkeryoung,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/head/welding/weldingfire,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "wSa" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/luchador/rudos,
@@ -55976,6 +58195,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
+"wUF" = (
+/obj/structure/stalkeregg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "wUL" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -56006,6 +58229,11 @@
 "wVn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland)
+"wVq" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop3";
 	},
 /area/f13/wasteland)
 "wVs" = (
@@ -56252,11 +58480,19 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "xab" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/stack/sheet/metal/ten,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "xae" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -56343,6 +58579,13 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland)
+"xch" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/f13/village)
 "xcm" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/barber{
@@ -56382,6 +58625,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"xdi" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
 "xdp" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -56411,10 +58658,17 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"xdF" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	},
+/area/f13/wasteland)
 "xdG" = (
-/obj/structure/stalkeregg,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xdP" = (
 /obj/structure/simple_door/metal/fence,
 /obj/structure/decoration/rag,
@@ -56442,11 +58696,9 @@
 	},
 /area/f13/wasteland)
 "xei" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
 /area/f13/village)
 "xeo" = (
 /obj/machinery/light{
@@ -56464,10 +58716,14 @@
 	},
 /area/f13/legion)
 "xeG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xeK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -56478,10 +58734,16 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "xeO" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/village)
 "xeQ" = (
 /obj/item/kirbyplants/random,
@@ -56873,9 +59135,12 @@
 /turf/open/indestructible/ground/outside/savannah/bottomright,
 /area/f13/building)
 "xny" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/building)
 "xnC" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 4;
@@ -57051,9 +59316,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xql" = (
-/obj/structure/decoration/clock/old/active,
-/turf/closed/wall/f13/wood/house,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "xqp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/shreds,
@@ -57307,6 +59578,34 @@
 /obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"xuU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/wooden{
+	pixel_y = 15
+	},
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet";
+	pixel_y = 15
+	},
+/obj/item/bedsheet/hos{
+	desc = "A comfortable red bedsheet.";
+	name = "Comfy Red Bedsheet"
+	},
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet4"
+	},
+/area/f13/village)
+"xuY" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "xvg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -57366,6 +59665,16 @@
 	icon_state = "remains"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/village)
+"xvM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/village)
 "xwk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -57552,13 +59861,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "xAB" = (
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "xAX" = (
 /obj/machinery/smartfridge/bottlerack,
 /obj/effect/decal/cleanable/dirt{
@@ -57665,6 +59972,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xDw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/village)
 "xDH" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -57678,16 +59994,40 @@
 /area/f13/building)
 "xDL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/closet/crate/bin,
+/obj/item/paper/crumpled,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xDP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
+"xEc" = (
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty. You hear some weird noises behind these vents...";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/enclave)
 "xEh" = (
 /obj/structure/table,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -57864,6 +60204,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"xGY" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "xHc" = (
 /obj/structure/fence{
 	dir = 4
@@ -57912,6 +60264,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"xHO" = (
+/obj/structure/table/snooker{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/village)
 "xHT" = (
 /obj/structure/railing/handrail{
 	dir = 8
@@ -57929,11 +60288,19 @@
 	},
 /area/f13/building)
 "xIh" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xIm" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -57965,6 +60332,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"xIv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/village)
 "xIJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -58200,11 +60578,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xOt" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/area/f13/village)
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "xOD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -58326,8 +60712,11 @@
 	},
 /area/f13/caves)
 "xSc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "xSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58350,18 +60739,23 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "xSs" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/enclave)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "xSC" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/tires/five,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "xSS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -58412,6 +60806,20 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xTM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = 32
+	},
+/obj/structure/dresser{
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/wood/f13/carpet{
+	icon_state = "torncarpet10"
+	},
+/area/f13/village)
 "xTQ" = (
 /obj/structure/bonfire/dense,
 /obj/item/stack/rods,
@@ -58447,8 +60855,16 @@
 	},
 /area/f13/bunker)
 "xVu" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/farm)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/village)
 "xVG" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -58457,11 +60873,19 @@
 	},
 /area/f13/building)
 "xVI" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
 	},
-/area/f13/village)
+/area/f13/building)
+"xVJ" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/building)
 "xVN" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall/f13/store,
@@ -58504,6 +60928,12 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
+"xWT" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "xXa" = (
@@ -58617,6 +61047,13 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/caves)
+"yax" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "yaz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -58766,10 +61203,16 @@
 	},
 /area/f13/village)
 "ydq" = (
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/closet/fridge/standard,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ydE" = (
 /obj/structure/chair{
 	dir = 4
@@ -58966,20 +61409,29 @@
 	},
 /area/f13/building)
 "yhB" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "yhH" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "yhL" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/overlay/junk/shower{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "yig" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -59063,15 +61515,27 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "yjE" = (
-/obj/structure/barricade/sandbags,
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerouter"
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 7
 	},
-/area/f13/wasteland)
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/obj/item/storage/box/cups{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "yjF" = (
 /obj/machinery/light{
 	dir = 8
@@ -59169,9 +61633,13 @@
 	},
 /area/f13/village)
 "ylQ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/machinery/vending/tool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "ylR" = (
 /obj/structure/fence{
 	dir = 4
@@ -59195,6 +61663,7 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+
 (1,1,1) = {"
 ktB
 ktB
@@ -59323,44 +61792,44 @@ ktB
 ktB
 ktB
 ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
-ktB
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 ktB
 ktB
 ktB
@@ -59595,8 +62064,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
 gbL
+gcK
 gcK
 gcK
 gcK
@@ -59727,7 +62196,7 @@ vcg
 cpK
 cpK
 cpK
-ajD
+pBX
 mQj
 oyb
 gmX
@@ -59841,6 +62310,9 @@ gcK
 gcK
 gcK
 gcK
+gkG
+cNE
+mOo
 gcK
 gcK
 gcK
@@ -59851,9 +62323,6 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -59974,7 +62443,7 @@ egW
 bkk
 amp
 mvv
-aBH
+dCL
 eZD
 aEv
 cpK
@@ -60096,22 +62565,22 @@ gcK
 gcK
 gcK
 gcK
+uwR
+xdi
+mwp
+mwp
+mwp
+qmP
+qpr
+gcK
+qmP
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
 gbL
 gcK
 gcK
@@ -60124,8 +62593,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+hCB
+rnA
 gcK
 gcK
 gcK
@@ -60354,6 +62823,14 @@ gcK
 gcK
 gcK
 gcK
+kyq
+mwp
+mwp
+mwp
+mwp
+mwp
+nWb
+mwp
 gcK
 gcK
 gcK
@@ -60366,29 +62843,21 @@ gcK
 gcK
 gcK
 gcK
+mwp
+mwp
+mwp
+mwp
 gcK
 gcK
-ktB
+gcK
+mwp
+mwp
+gcK
+gcK
+gcK
+gcK
 gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-jmq
-niD
-gcK
-gcK
-gcK
-gcK
-gcK
+gbL
 gcK
 gcK
 gcK
@@ -60612,35 +63081,35 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+wUF
+mwp
+mwp
+qss
 mwp
 mwp
 mwp
 mwp
+wUF
+gbL
+gbL
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
 mwp
+mnl
 mwp
+mwp
+mwp
+gcK
+gcK
+mwp
+mwp
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -60867,42 +63336,42 @@ gcK
 gcK
 gcK
 gcK
+gbL
+gbL
+gbL
+olm
+mwp
+tBF
+mwp
+mwp
+mwp
+olm
+tBF
+mwp
+mwp
+mwp
+mwp
+mwp
 gcK
+oKE
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
 gcK
 gcK
 gcK
 gbL
-ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-mwp
-mwp
-mwp
-mwp
-mwp
-gcK
-gcK
-mwp
-mwp
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
 gbL
 gbL
@@ -61002,7 +63471,7 @@ amp
 rYW
 aOH
 nTK
-hCg
+mcf
 eZD
 aEv
 cpK
@@ -61042,13 +63511,13 @@ gcK
 gcK
 gcK
 gcK
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 kGc
 unI
@@ -61125,39 +63594,39 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
 gbL
-gcK
-gcK
-gcK
-gcK
-gcK
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
+gbL
+wUF
+nWb
 mwp
 mwp
 mwp
 gcK
+gcK
+mwp
+mwp
+mwp
+olm
+mwp
+mwp
+mwp
+sas
+sas
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+mwp
+fcJ
+mwp
+mwp
+gcK
+gcK
+mwp
+mwp
+mwp
 gcK
 gcK
 gbL
@@ -61176,7 +63645,7 @@ gcK
 fyf
 fyf
 vpF
-doX
+dCX
 wDc
 fyf
 fyf
@@ -61299,13 +63768,13 @@ gcK
 gcK
 gcK
 gcK
-gjP
-aUV
-pJd
-siS
-gjs
-pJd
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 kGc
 unI
@@ -61384,18 +63853,10 @@ gcK
 gcK
 gcK
 gcK
+qmP
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
 gcK
 gcK
 gcK
@@ -61403,19 +63864,27 @@ gcK
 gcK
 mwp
 mwp
-mwp
-wEs
-mwp
+qFR
 mwp
 mwp
-uYx
+sas
+sas
+mwp
+mwp
+mwp
+mwp
+mwp
+mnl
+mwp
+mwp
+mwp
 mwp
 mwp
 gcK
 gcK
+gcK
 mwp
-mwp
-mwp
+gcK
 gcK
 gcK
 gcK
@@ -61432,9 +63901,9 @@ gcK
 gcK
 fyf
 sqA
-nlO
+oGS
 xGH
-doX
+dCX
 wDc
 fyf
 fyf
@@ -61556,13 +64025,13 @@ gcK
 gcK
 gcK
 gcK
-gjP
-fOs
-pJd
-vQE
-pvD
-pJd
-gjP
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 fyf
 sdo
 pBv
@@ -61578,7 +64047,7 @@ gcK
 gcK
 gcK
 cpK
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -61610,7 +64079,7 @@ mvv
 mvv
 mvv
 mvv
-doX
+dCX
 wDc
 fyf
 gcK
@@ -61644,18 +64113,17 @@ gcK
 gcK
 gcK
 gcK
+ahu
+ahu
+ahu
+ahu
 gcK
 gcK
+qmP
+mwp
+tBF
+wUF
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
 gcK
 gcK
 mwp
@@ -61664,15 +64132,16 @@ mwp
 mwp
 mwp
 mwp
-mwp
-mwp
-mwp
-mwp
-mwp
+gcK
 gcK
 gcK
 gcK
 mwp
+mwp
+gcK
+gcK
+mwp
+gcK
 gcK
 gcK
 gcK
@@ -61690,9 +64159,9 @@ gcK
 fyf
 fyf
 qOV
-daU
+iez
 sXB
-doX
+dCX
 wDc
 fyf
 fyf
@@ -61814,15 +64283,15 @@ gcK
 gcK
 gcK
 gjP
-hau
-fUs
-fPb
-gjs
-xIh
+gjP
+gjP
+gjP
+gjP
+gjP
 gjP
 fyf
 kGc
-jIB
+pFM
 qvQ
 czu
 ehN
@@ -61861,14 +64330,14 @@ hlo
 iWc
 gjP
 qOV
-daU
+iez
 mvv
 mvv
 mvv
 mvv
 mvv
 mvv
-doX
+dCX
 wDc
 gcK
 gcK
@@ -61900,36 +64369,36 @@ gcK
 gcK
 gcK
 gcK
+ahu
+tZM
+rdT
+lcd
+gYD
+ahu
+gcK
+gcK
+dLj
+iQF
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
+fhm
+qaS
+mwp
+cjH
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-gcK
-gcK
 gcK
 gcK
 mwp
-mwp
 gcK
-gcK
-mwp
 gcK
 gcK
 gcK
@@ -61946,18 +64415,18 @@ gcK
 fyf
 qOV
 cWG
-daU
-aBH
+iez
+dCL
 bni
 mfD
-hCg
+mcf
 fyf
 fyf
 nGq
 fyf
 fyf
 kGc
-ajD
+pBX
 qnS
 sgz
 hOl
@@ -62040,7 +64509,7 @@ lIh
 cpK
 cpK
 cpK
-ajD
+pBX
 qvQ
 dRA
 hgQ
@@ -62072,14 +64541,14 @@ gcK
 gcK
 gjP
 nzN
-pJd
+pqw
 tsO
 pvD
 pJd
-bEu
+gjP
 fyf
 kGc
-ofX
+oPO
 qvQ
 xgx
 ehN
@@ -62092,7 +64561,7 @@ gcK
 fyf
 kGc
 cpK
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -62157,6 +64626,16 @@ gcK
 gcK
 gcK
 gcK
+ahu
+ahu
+ahu
+ahu
+wsM
+ahu
+gcK
+ppV
+iQF
+kFf
 gcK
 gcK
 gcK
@@ -62166,26 +64645,16 @@ gcK
 gcK
 gcK
 gcK
-gbL
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
-iLD
-gPd
+gcK
+mrH
 mwp
-coQ
-gcK
-gcK
-gcK
 gcK
 gcK
 mwp
-gcK
-gcK
 mwp
 gcK
 gcK
@@ -62201,10 +64670,10 @@ gcK
 gcK
 gcK
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -62214,8 +64683,8 @@ thG
 fyf
 fyf
 kGc
-jIB
-lSD
+pFM
+pKq
 sgz
 hOl
 koD
@@ -62329,11 +64798,11 @@ gcK
 gcK
 gjP
 rVM
+pqw
+ccN
+sIc
 pJd
-pJd
-pJd
-pJd
-tmw
+gjP
 fyf
 kGc
 unI
@@ -62367,13 +64836,13 @@ thG
 fyf
 fyf
 fyf
-nlO
+oGS
 xGH
 mvv
 mvv
 mvv
-aBH
-hCg
+dCL
+mcf
 tBN
 gjP
 bGw
@@ -62414,6 +64883,16 @@ gcK
 gcK
 gcK
 gcK
+ahu
+kFc
+dFc
+uKj
+fBZ
+qgw
+bsz
+iQF
+tRB
+mwp
 gcK
 gcK
 gcK
@@ -62423,27 +64902,17 @@ gcK
 gcK
 gcK
 gcK
-ktB
-gbL
-gbL
-gbL
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-yhB
+mwp
 mwp
 gcK
 gcK
 mwp
+mnl
 mwp
 gcK
 gcK
@@ -62471,7 +64940,7 @@ thG
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 hOl
 ehN
@@ -62544,7 +65013,7 @@ aiH
 dYY
 aBT
 jIz
-doX
+dCX
 eZD
 aEv
 cpK
@@ -62586,11 +65055,11 @@ gcK
 gcK
 gjP
 eYa
-pJd
+bEu
 tUO
-pJd
+pvD
 jMN
-trG
+gjP
 fyf
 kGc
 unI
@@ -62631,7 +65100,7 @@ mvv
 mvv
 bpD
 qOV
-daU
+iez
 gjP
 yjA
 peu
@@ -62640,7 +65109,7 @@ nVn
 eYY
 gjP
 mvv
-doX
+dCX
 fyf
 gcK
 gcK
@@ -62667,25 +65136,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
 gbL
 gcK
 gcK
 gcK
+ahu
+hnX
+oIo
+dFc
+jRV
+ahu
+rcl
+iQF
+mwp
 gcK
 gcK
 gcK
@@ -62693,15 +65156,21 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+hsN
+mwp
 gcK
 gcK
 gcK
 mwp
 mwp
-gcK
-gcK
-mwp
-wEs
 mwp
 gcK
 gcK
@@ -62801,7 +65270,7 @@ aiH
 rZx
 uNR
 iNM
-aBH
+dCL
 eZD
 aEv
 cpK
@@ -62842,12 +65311,12 @@ gcK
 gcK
 gcK
 gjP
-pJd
+bbW
 pqw
 bUd
 sIc
-xIh
-gjP
+pJd
+giU
 fyf
 kGc
 unI
@@ -62926,35 +65395,35 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gbL
 gbL
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-fkU
+ahu
+eIH
+oKF
+oIo
+pUj
+ahu
+mVs
 mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63023,7 +65492,7 @@ sHp
 xGi
 kmT
 sHp
-aug
+ezo
 uqa
 rpu
 sHQ
@@ -63099,14 +65568,14 @@ gcK
 gcK
 gcK
 gjP
+bcF
 pJd
-pqw
-erB
-sNC
 pJd
-gjP
+pJd
+pJd
+gjs
 igz
-hgX
+psR
 unI
 qvQ
 czu
@@ -63143,8 +65612,8 @@ tBN
 mvv
 mvv
 mvv
-doX
-daU
+dCX
+iez
 mvv
 gjP
 cbk
@@ -63181,27 +65650,15 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gbL
-gbL
-gcK
 gbL
 gcK
 gcK
 gcK
 gcK
+ahu
+gTH
+xEc
+ahu
 gcK
 gcK
 gcK
@@ -63216,6 +65673,18 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+mwp
 mwp
 gcK
 gcK
@@ -63358,7 +65827,7 @@ gcK
 gjP
 pJd
 pJd
-elL
+pJd
 pJd
 pJd
 lyG
@@ -63451,10 +65920,10 @@ gcK
 gcK
 gcK
 gcK
+gcK
+gcK
+gcK
 gbL
-gbL
-gcK
-ktB
 gcK
 gcK
 gcK
@@ -63472,7 +65941,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+mwp
 mwp
 gcK
 gcK
@@ -63613,7 +66082,7 @@ gcK
 gcK
 gcK
 gjP
-gwJ
+bgq
 pJd
 wjl
 pJd
@@ -63708,11 +66177,11 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-ktB
 gbL
 gbL
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -63757,7 +66226,7 @@ fyf
 sqA
 kGc
 pBv
-dXy
+pOC
 hOl
 ehN
 koD
@@ -63914,7 +66383,7 @@ tBN
 mvv
 mvv
 mvv
-aBH
+dCL
 mfD
 xGH
 gjP
@@ -63964,12 +66433,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
 gbL
 gbL
-gcK
-gcK
+gbL
+gbL
+gbL
+gbL
 gcK
 gcK
 gcK
@@ -64013,8 +66482,8 @@ thG
 fyf
 fyf
 kGc
-ajD
-dXy
+pBX
+pOC
 hOl
 ehN
 koD
@@ -64042,7 +66511,7 @@ gcK
 gcK
 ktB
 uqa
-aug
+ezo
 sHp
 uqa
 cvu
@@ -64098,7 +66567,7 @@ cpK
 deW
 xQX
 dtO
-mHW
+pRo
 gmX
 koD
 xdt
@@ -64125,7 +66594,7 @@ gcK
 gcK
 gcK
 gcK
-ace
+fyf
 gjP
 gwJ
 dny
@@ -64164,16 +66633,16 @@ peu
 peu
 khc
 mvv
-doX
+dCX
 cWG
 cWG
-daU
+iez
 mvv
 mvv
 mvv
 bpD
 fyf
-nlO
+oGS
 gjP
 gjP
 eXa
@@ -64270,8 +66739,8 @@ thG
 fyf
 fyf
 kGc
-jIB
-dXy
+pFM
+pOC
 sgz
 hOl
 koD
@@ -64381,8 +66850,8 @@ gcK
 gcK
 gcK
 gcK
-ace
-ace
+fyf
+fyf
 gjP
 dyU
 pJd
@@ -64527,8 +66996,8 @@ thG
 fyf
 fyf
 kGc
-ofX
-dXy
+oPO
+pOC
 sgz
 hOl
 koD
@@ -64636,10 +67105,10 @@ wvV
 ayH
 gcK
 gcK
-ace
-ace
-ace
-ace
+fyf
+fyf
+fyf
+fyf
 gjP
 ufi
 vzw
@@ -64648,7 +67117,7 @@ wLw
 xLd
 gjP
 ptf
-gNA
+puY
 unI
 qvQ
 xgx
@@ -64678,7 +67147,7 @@ peu
 peu
 nSf
 mvv
-aBH
+dCL
 mfD
 mfD
 xGH
@@ -64785,7 +67254,7 @@ fyf
 fyf
 kGc
 unI
-dXy
+pOC
 sgz
 hOl
 koD
@@ -64894,9 +67363,9 @@ ayH
 gcK
 gcK
 gcK
-ace
-ace
-jMd
+fyf
+fyf
+pis
 gjP
 gjP
 qgl
@@ -65042,7 +67511,7 @@ fyf
 fyf
 kGc
 unI
-dXy
+pOC
 sgz
 ehN
 koD
@@ -65151,19 +67620,19 @@ ayH
 gcK
 gcK
 gcK
-ace
-ace
 fyf
-thG
-tdM
-tUk
+fyf
+fyf
+xHN
+mvv
+mvv
 nIm
-tUk
-thG
+pIn
+erB
 fyf
 fyf
 kGc
-ajD
+pBX
 qvQ
 czu
 ehN
@@ -65411,16 +67880,16 @@ gcK
 gcK
 fyf
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+ttW
+mvv
+mvv
+mvv
+erB
 fyf
 fyf
 sPC
-ajD
+pBX
 qvQ
 czu
 ehN
@@ -65556,7 +68025,7 @@ gcK
 fyf
 kGc
 unI
-dXy
+pOC
 hOl
 ehN
 koD
@@ -65668,16 +68137,16 @@ ayH
 gcK
 fyf
 fyf
-thG
+xHN
 jzC
-tUk
-tUk
-tUk
-thG
+mvv
+mvv
+mvv
+erB
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 czu
 ehN
@@ -65705,8 +68174,8 @@ gjP
 gjP
 uRJ
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 tBN
@@ -65813,7 +68282,7 @@ gcK
 fyf
 kGc
 pBv
-dXy
+pOC
 hOl
 ehN
 koD
@@ -65925,12 +68394,12 @@ ayH
 gcK
 fyf
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+mvv
+mvv
+mvv
+mvv
+erB
 fyf
 fyf
 kGc
@@ -66069,8 +68538,8 @@ gcK
 fyf
 fyf
 kGc
-ajD
-lSD
+pBX
+pKq
 ehN
 ehN
 koD
@@ -66182,12 +68651,12 @@ ayH
 gcK
 gcK
 fyf
-thG
+xHN
 ogw
-tUk
-tUk
-tUk
-thG
+mvv
+mvv
+mvv
+erB
 fyf
 fyf
 kGc
@@ -66219,7 +68688,7 @@ peu
 uRJ
 uRJ
 mvv
-doX
+dCX
 wDc
 sND
 fyf
@@ -66326,7 +68795,7 @@ gcK
 fyf
 fyf
 kGc
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -66439,12 +68908,12 @@ ayH
 ayH
 gcK
 fyf
-thG
-pbX
-tUk
-tUk
-pbX
-thG
+xHN
+xwW
+mvv
+mvv
+xwW
+erB
 fyf
 fyf
 kGc
@@ -66468,7 +68937,7 @@ ehN
 wwM
 dMW
 fyf
-nlO
+oGS
 vtb
 xGH
 mvv
@@ -66583,7 +69052,7 @@ gts
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -66696,12 +69165,12 @@ wvV
 ayH
 gcK
 fyf
-thG
-tUk
-tUk
-tUk
-tUk
-thG
+xHN
+mvv
+mvv
+mvv
+mvv
+erB
 fyf
 fyf
 kGc
@@ -66727,7 +69196,7 @@ dMW
 fyf
 fyf
 thG
-nlO
+oGS
 mfD
 mfD
 xGH
@@ -66737,11 +69206,11 @@ gjP
 bpD
 fyf
 fyf
-nlO
+oGS
 xGH
 lFX
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 lPT
@@ -66927,7 +69396,7 @@ pqO
 pqO
 rMa
 rMa
-mHW
+pRo
 ehN
 wGJ
 uru
@@ -66953,12 +69422,12 @@ wvV
 ayH
 gcK
 fyf
-vxC
-uxC
-uxC
-uxC
-uxC
-vxC
+aBH
+igc
+igc
+igc
+igc
+pLD
 fyf
 pis
 kGc
@@ -66987,11 +69456,11 @@ jgu
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -67182,12 +69651,12 @@ pqO
 pqO
 pqO
 pqO
-bJB
-bJB
-mHW
+pRy
+pRy
+pRo
 ehN
 oVl
-bJB
+pRy
 wGJ
 ehN
 gmX
@@ -67254,7 +69723,7 @@ fyf
 fyf
 tBN
 mvv
-doX
+dCX
 cWG
 cWG
 wDc
@@ -67354,7 +69823,7 @@ thG
 fyf
 atL
 kGc
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -67611,7 +70080,7 @@ thG
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -67766,7 +70235,7 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 oks
 mfD
 xGH
@@ -67867,7 +70336,7 @@ igz
 gts
 igz
 igz
-hgX
+psR
 unI
 qvQ
 ehN
@@ -67950,7 +70419,7 @@ unI
 mKp
 pqO
 pqO
-mHW
+pRo
 wGJ
 pqO
 pqO
@@ -68027,8 +70496,8 @@ fyf
 fyf
 fyf
 tBN
-aBH
-hCg
+dCL
+mcf
 fyf
 gcK
 gcK
@@ -68275,7 +70744,7 @@ hAC
 fyf
 qOV
 cWG
-daU
+iez
 bpD
 fyf
 hAC
@@ -68283,8 +70752,8 @@ fyf
 fyf
 fyf
 fyf
-nlO
-hCg
+oGS
+mcf
 fyf
 fyf
 gcK
@@ -68427,8 +70896,8 @@ yiU
 yiU
 tCY
 kGc
-ajD
-box
+pBX
+pJY
 hOl
 ehN
 bfu
@@ -68530,7 +70999,7 @@ fyf
 fyf
 fyf
 qOV
-daU
+iez
 wsJ
 pXo
 vbi
@@ -68684,8 +71153,8 @@ lEY
 mkK
 lkI
 kGc
-ajD
-dXy
+pBX
+pOC
 sgz
 hOl
 dKW
@@ -68693,7 +71162,7 @@ dMW
 uqa
 nhR
 sHp
-aug
+ezo
 vXh
 sHp
 sHp
@@ -68941,8 +71410,8 @@ uqa
 uqa
 uqa
 kGc
-ajD
-dXy
+pBX
+pOC
 sgz
 hOl
 dKW
@@ -68953,7 +71422,7 @@ rpu
 sHp
 rpu
 sHQ
-aug
+ezo
 uqa
 rpu
 uqa
@@ -68981,7 +71450,7 @@ pqO
 pqO
 pqO
 pqO
-mHW
+pRo
 gmX
 koD
 wvV
@@ -69017,8 +71486,8 @@ aBd
 pJd
 trG
 igz
-hgX
-ajD
+psR
+pBX
 qvQ
 czu
 ehN
@@ -69198,9 +71667,9 @@ gcK
 fyf
 xXi
 kGc
-ajD
-dXy
-gWo
+pBX
+pOC
+kin
 wNe
 sXu
 kOz
@@ -69275,7 +71744,7 @@ tUM
 kHj
 dkg
 cpK
-ofX
+oPO
 qvQ
 czu
 ehN
@@ -69410,7 +71879,7 @@ gts
 ptf
 ptf
 kwK
-ofX
+oPO
 bVy
 ehN
 ehN
@@ -69421,7 +71890,7 @@ bFJ
 bFJ
 bFJ
 uaf
-ajD
+pBX
 qvQ
 hOl
 ehN
@@ -69560,8 +72029,8 @@ tBN
 mvv
 mvv
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 sWR
 fyf
@@ -69678,7 +72147,7 @@ bFJ
 uaf
 bFJ
 uCW
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -69813,11 +72282,11 @@ fyf
 fyf
 fyf
 qOV
-daU
+iez
 mvv
-aBH
+dCL
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -70069,10 +72538,10 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 yaz
@@ -70226,8 +72695,8 @@ sHp
 xWu
 rpu
 kdJ
-ajD
-dXy
+pBX
+pOC
 pWN
 uPP
 fyf
@@ -70319,7 +72788,7 @@ gcK
 unI
 qvQ
 sgz
-gWo
+kin
 hzb
 jMC
 fyf
@@ -70483,8 +72952,8 @@ xWu
 sHp
 uqa
 kdJ
-ajD
-dXy
+pBX
+pOC
 sgz
 dop
 fyf
@@ -70522,7 +72991,7 @@ pqO
 pqO
 pqO
 pqO
-mHW
+pRo
 pqO
 pqO
 koD
@@ -70559,7 +73028,7 @@ kZc
 fRN
 gjP
 ptf
-gNA
+puY
 unI
 qvQ
 czu
@@ -70740,8 +73209,8 @@ kwN
 rpu
 uqa
 kdJ
-ajD
-dXy
+pBX
+pOC
 sgz
 pWN
 oCi
@@ -70997,8 +73466,8 @@ uqa
 uqa
 uqa
 kGc
-ajD
-dXy
+pBX
+pOC
 sgz
 sgz
 sBk
@@ -71287,7 +73756,7 @@ ehN
 dte
 ehN
 nKz
-mHW
+pRo
 vfc
 pqO
 vfc
@@ -71331,7 +73800,7 @@ fyf
 fyf
 pis
 kGc
-ajD
+pBX
 qvQ
 czu
 ehN
@@ -71456,7 +73925,7 @@ fyf
 uqa
 guY
 rpu
-aug
+ezo
 plt
 uqa
 coD
@@ -71768,7 +74237,7 @@ fyf
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 hOl
 hOl
@@ -72055,7 +74524,7 @@ eTx
 ehN
 ehN
 ehN
-mHW
+pRo
 ehN
 nKz
 ehN
@@ -72249,7 +74718,7 @@ lqc
 jnj
 jnj
 iLc
-dXy
+pOC
 hOl
 ehN
 sBk
@@ -72506,7 +74975,7 @@ iLc
 iLc
 iLc
 iLc
-dXy
+pOC
 fZW
 wNe
 wwM
@@ -72615,7 +75084,7 @@ igz
 igz
 igz
 igz
-hgX
+psR
 unI
 qvQ
 czu
@@ -72629,7 +75098,7 @@ gcK
 gcK
 gcK
 cpK
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -72819,7 +75288,7 @@ ktB
 (54,1,1) = {"
 ktB
 mvv
-doX
+dCX
 cWG
 cWG
 wDc
@@ -72832,7 +75301,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 unI
 qvQ
 dMR
@@ -72873,7 +75342,7 @@ cpK
 cpK
 cpK
 dkg
-ajD
+pBX
 qvQ
 czu
 ehN
@@ -72886,7 +75355,7 @@ dkg
 cpK
 cpK
 cpK
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -72992,11 +75461,11 @@ fyf
 fyf
 fyf
 vpF
-doX
+dCX
 wDc
 fyf
 uqa
-aug
+ezo
 rpu
 rpu
 uqa
@@ -73008,7 +75477,7 @@ uqa
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -73079,7 +75548,7 @@ xPu
 mvv
 tZB
 mvv
-doX
+dCX
 cWG
 wDc
 fyf
@@ -73143,7 +75612,7 @@ cpK
 hYN
 cpK
 gQZ
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -73248,9 +75717,9 @@ fyf
 hll
 fyf
 sqA
-nlO
+oGS
 xGH
-doX
+dCX
 cWG
 uqa
 uqa
@@ -73499,14 +75968,14 @@ fyf
 fyf
 vpF
 wDV
-hCg
+mcf
 sqA
 fyf
 fyf
 fyf
 fyf
 qOV
-daU
+iez
 mvv
 ofL
 mvv
@@ -73515,7 +75984,7 @@ rpu
 olW
 uqa
 vUF
-aug
+ezo
 rpu
 rpu
 uqa
@@ -73563,7 +76032,7 @@ gbL
 gcK
 uqa
 lPZ
-aug
+ezo
 sHp
 plt
 uqa
@@ -73754,7 +76223,7 @@ sYX
 lVG
 wDc
 fyf
-nlO
+oGS
 mkw
 fyf
 fyf
@@ -73762,8 +76231,8 @@ dKU
 fyf
 qOV
 cWG
-daU
-aBH
+iez
+dCL
 bni
 mfD
 mfD
@@ -74017,10 +76486,10 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -74112,7 +76581,7 @@ uXj
 qnz
 irP
 mvv
-doX
+dCX
 bVo
 fyf
 fyf
@@ -74265,8 +76734,8 @@ eQA
 lhc
 rVe
 sYX
-nlO
-hCg
+oGS
+mcf
 fyf
 fyf
 fyf
@@ -74484,7 +76953,7 @@ gcK
 ttW
 sph
 mvv
-doX
+dCX
 iIj
 qOY
 pHd
@@ -74542,15 +77011,15 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 sqA
 fyf
 fyf
 kGc
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -74595,7 +77064,7 @@ uqa
 uqa
 uqa
 uqa
-fsl
+pyk
 voF
 xWO
 bHy
@@ -74633,7 +77102,7 @@ fyf
 fyf
 nJW
 ptf
-gNA
+puY
 hJI
 cpK
 unI
@@ -74644,7 +77113,7 @@ hvF
 ehN
 ehN
 ehN
-hEX
+hOl
 ehN
 ehN
 uLq
@@ -74747,7 +77216,7 @@ peu
 bGw
 peu
 pJv
-doX
+dCX
 wDc
 evK
 jxH
@@ -74807,7 +77276,7 @@ sYX
 fyf
 fyf
 kGc
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -74884,7 +77353,7 @@ uXj
 qst
 hhd
 hdh
-doX
+dCX
 cWG
 cWG
 cWG
@@ -74942,7 +77411,7 @@ gcK
 cpK
 cpK
 nha
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -74962,7 +77431,7 @@ pcG
 fyf
 tBN
 mvv
-doX
+dCX
 klv
 wDc
 fyf
@@ -74998,7 +77467,7 @@ kbF
 mvv
 mvv
 mvv
-aBH
+dCL
 kje
 qOY
 peu
@@ -75064,7 +77533,7 @@ jvg
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -75261,8 +77730,8 @@ mVB
 mVB
 mVB
 vMH
-nlO
-hCg
+oGS
+mcf
 qOV
 wDc
 tBN
@@ -75306,8 +77775,8 @@ dMW
 fyf
 fyf
 fyf
-nlO
-hCg
+oGS
+mcf
 thG
 fyf
 fyf
@@ -75398,12 +77867,12 @@ uXj
 fSm
 qUZ
 ijC
-aBH
+dCL
 mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 kGc
 cpK
 dkg
@@ -75442,19 +77911,19 @@ gcK
 gcK
 ptf
 ptf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
+giZ
 cpK
 unI
 qvQ
@@ -75520,8 +77989,8 @@ cWG
 cWG
 hOM
 wDc
-nlO
-hCg
+oGS
+mcf
 tBN
 mvv
 bpD
@@ -75699,19 +78168,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+jiv
+mdv
+ofX
+oAo
+sAe
+uPK
+wLF
+xql
+xSC
+eZL
+qhP
+sqy
 lKG
 emn
 rMB
@@ -75733,9 +78202,9 @@ pcG
 fyf
 tBN
 mvv
-aBH
+dCL
 mfD
-hCg
+mcf
 fyf
 fyf
 mtL
@@ -75765,7 +78234,7 @@ fyf
 fyf
 tBN
 mvv
-aBH
+dCL
 fCS
 mfD
 xGH
@@ -75775,8 +78244,8 @@ mvv
 mvv
 mvv
 aKX
-aBH
-hCg
+dCL
+mcf
 hAC
 uey
 tBN
@@ -75832,7 +78301,7 @@ oeL
 rpu
 hFM
 tNh
-doX
+dCX
 wDc
 kGc
 unI
@@ -75956,19 +78425,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+jmq
+mfR
+onh
+pei
+pzN
+uTA
+onh
+vRZ
+vRZ
+tdM
+cku
+rBM
 cpK
 unI
 qvQ
@@ -76008,7 +78477,7 @@ fyf
 fyf
 tBN
 mvv
-aBH
+dCL
 mfD
 mfD
 mkw
@@ -76020,19 +78489,19 @@ dzE
 cWG
 cWG
 wbd
-daU
+iez
 mvv
 bpD
 fyf
 nis
-nlO
+oGS
 mfD
 mfD
 xGH
 mvv
-aBH
+dCL
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -76064,7 +78533,7 @@ sYX
 sYX
 sYX
 sYX
-hgX
+psR
 unI
 qvQ
 ehN
@@ -76168,7 +78637,7 @@ wMa
 qnz
 ppv
 mvv
-aBH
+dCL
 gKw
 fyf
 fyf
@@ -76213,19 +78682,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+jpB
+jpB
+osF
+pfd
+sNC
+uYx
+wLR
+vno
+xVI
+vpp
+mKU
+iah
 cpK
 unI
 qvQ
@@ -76263,9 +78732,9 @@ fyf
 fyf
 qOV
 cWG
-daU
-aBH
-hCg
+iez
+dCL
+mcf
 fyf
 uey
 qOV
@@ -76273,7 +78742,7 @@ cWG
 cWG
 cWG
 cWG
-daU
+iez
 mvv
 mvv
 mvv
@@ -76346,8 +78815,8 @@ rpu
 kas
 rMz
 tNh
-nlO
-hCg
+oGS
+mcf
 kGc
 pBv
 qvQ
@@ -76425,7 +78894,7 @@ hdr
 qst
 oPQ
 hTb
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -76470,19 +78939,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+mlf
+ouJ
+pxw
+sQL
+uZg
+wMU
+xDL
+ydq
+vpp
+giZ
+giZ
 cpK
 jnK
 qvQ
@@ -76502,7 +78971,7 @@ uRJ
 pcG
 nwT
 cWG
-daU
+iez
 mvv
 bpD
 fyf
@@ -76518,10 +78987,10 @@ gcK
 gcK
 fyf
 tOH
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 uey
 fyf
@@ -76536,13 +79005,13 @@ mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 bKy
 fyf
 siJ
 fyf
 fyf
-nlO
+oGS
 kkg
 bpD
 fyf
@@ -76551,8 +79020,8 @@ fyf
 fyf
 fyf
 tBN
-aBH
-hCg
+dCL
+mcf
 uey
 fyf
 hll
@@ -76591,7 +79060,7 @@ dMW
 fyf
 fyf
 vpF
-doX
+dCX
 wDc
 sYX
 uCO
@@ -76606,7 +79075,7 @@ sYX
 fyf
 fyf
 kGc
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -76679,9 +79148,9 @@ rCR
 xvi
 nJz
 vtg
-nlO
+oGS
 elF
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -76727,21 +79196,21 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+jxD
+mmT
+gdN
+pyU
+sQW
+uZS
+wMU
+xDP
+yhB
+onh
+hlp
+eOf
 cpK
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -76767,7 +79236,7 @@ fyf
 tBN
 mvv
 mvv
-doX
+dCX
 wDc
 qOV
 cWG
@@ -76808,7 +79277,7 @@ fyf
 fyf
 fyf
 pYn
-hCg
+mcf
 qOV
 wDc
 fyf
@@ -76847,9 +79316,9 @@ koD
 dMW
 fyf
 sqA
-nlO
+oGS
 xGH
-doX
+dCX
 tKZ
 qQX
 rpu
@@ -76863,7 +79332,7 @@ sYX
 fyf
 fyf
 kGc
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -76932,7 +79401,7 @@ ktB
 ktB
 cPg
 cnz
-daU
+iez
 xvi
 nJz
 igz
@@ -76946,7 +79415,7 @@ igz
 igz
 igz
 igz
-hgX
+psR
 cpK
 cpK
 unI
@@ -76984,19 +79453,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+gHP
+eOf
+gdN
+pzN
+sTn
+veZ
+wMU
+xIh
+yjE
+iwq
+fBQ
+giZ
 cpK
 unI
 qvQ
@@ -77018,20 +79487,20 @@ mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
 mfD
-hCg
-nlO
+mcf
+oGS
 aUL
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -77067,7 +79536,7 @@ fyf
 cqG
 uey
 tBN
-doX
+dCX
 wDc
 hLi
 hLi
@@ -77105,7 +79574,7 @@ dMW
 fyf
 fyf
 qOV
-daU
+iez
 mvv
 tKZ
 rpu
@@ -77120,7 +79589,7 @@ sYX
 wDc
 fyf
 kGc
-ofX
+oPO
 lrz
 ehN
 ehN
@@ -77241,19 +79710,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+mlf
+pGg
+tbX
+vno
+wRI
+xOt
+ylQ
+pfd
+akp
+rwt
 cpK
 axG
 qvQ
@@ -77314,8 +79783,8 @@ fyf
 fyf
 fyf
 fyf
-nlO
-hCg
+oGS
+mcf
 qTY
 fyf
 fyf
@@ -77361,8 +79830,8 @@ koD
 dMW
 qOV
 cWG
-daU
-aBH
+iez
+dCL
 bni
 sYX
 rof
@@ -77371,10 +79840,10 @@ spf
 sIJ
 uCO
 rpu
-aug
+ezo
 rpu
 sYX
-hCg
+mcf
 fyf
 kGc
 unI
@@ -77498,19 +79967,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+jCH
+mHW
+ovt
+onh
+tdM
+vpp
+vpp
+onh
+oZq
+jTR
+eej
+sqy
 cpK
 unI
 qvQ
@@ -77580,7 +80049,7 @@ fyf
 fyf
 hLi
 dzE
-daU
+iez
 mvv
 bpD
 fyf
@@ -77616,10 +80085,10 @@ kaM
 kaM
 koD
 dMW
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 sYX
 sYX
@@ -77755,19 +80224,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+jIB
+mHW
+oAe
+pIS
+tgR
+vvh
+xab
+xSs
+lam
+lUw
+rkP
+rwt
 cpK
 unI
 qvQ
@@ -77816,7 +80285,7 @@ lqO
 wPl
 fyf
 fyf
-nlO
+oGS
 mfD
 mkw
 thG
@@ -77836,7 +80305,7 @@ cWG
 wDc
 qOV
 fbH
-daU
+iez
 mvv
 mvv
 bpD
@@ -77890,7 +80359,7 @@ igz
 igz
 igz
 igz
-hgX
+psR
 unI
 qvQ
 ehN
@@ -78012,19 +80481,19 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-cpK
+giZ
+jMd
+mPT
+dVy
+giZ
+giZ
+giZ
+mlf
+ovt
+mlf
+mlf
+giZ
+giZ
 cFe
 unI
 qvQ
@@ -78087,11 +80556,11 @@ fyf
 fyf
 qTY
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
-nlO
+mcf
+oGS
 hYS
 mfD
 xGH
@@ -78269,10 +80738,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+giZ
+giZ
+giZ
+giZ
 gcK
 gcK
 gcK
@@ -78351,16 +80820,16 @@ fyf
 uey
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
 mfD
-hCg
+mcf
 kGc
 vCc
 qvQ
@@ -78440,7 +80909,7 @@ eAD
 eAD
 mvv
 mvv
-doX
+dCX
 wDc
 fyf
 fyf
@@ -78601,8 +81070,8 @@ fyf
 fyf
 qOV
 uLw
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -78620,7 +81089,7 @@ fyf
 fyf
 kGc
 vCc
-box
+pJY
 ehN
 ehN
 ehN
@@ -78785,7 +81254,7 @@ gcK
 gcK
 gcK
 gcK
-ajD
+pBX
 mQj
 xbX
 xbX
@@ -78856,9 +81325,9 @@ fyf
 fyf
 siJ
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 hAC
 fyf
 hLi
@@ -78946,7 +81415,7 @@ thG
 jxH
 fyf
 qOV
-daU
+iez
 eAD
 gFR
 gFR
@@ -79042,8 +81511,8 @@ wPl
 gcK
 gcK
 hBr
-jIB
-box
+pFM
+pJY
 tPy
 kaM
 wxX
@@ -79104,7 +81573,7 @@ fyf
 fyf
 fyf
 tBN
-doX
+dCX
 cWG
 wDc
 fyf
@@ -79299,9 +81768,9 @@ wPl
 hBr
 hBr
 hBr
-ajD
-dXy
-bJB
+pBX
+pOC
+pRy
 geM
 wGc
 fFG
@@ -79363,7 +81832,7 @@ fyf
 dAg
 xGH
 mvv
-doX
+dCX
 cWG
 cWG
 cWG
@@ -79416,7 +81885,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 sUX
 ptf
 ptf
@@ -79432,7 +81901,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 pBv
 qvQ
 ehN
@@ -79556,8 +82025,8 @@ wPl
 dAB
 dpg
 nEW
-ofX
-dXy
+oPO
+pOC
 pqO
 qbY
 wGc
@@ -79584,8 +82053,8 @@ fyf
 tBN
 bGM
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 qFk
@@ -79716,7 +82185,7 @@ fyf
 thG
 jxH
 fyf
-nlO
+oGS
 sdf
 mvv
 mvv
@@ -79725,8 +82194,8 @@ mvv
 mvv
 mvv
 eAD
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -79814,7 +82283,7 @@ fyf
 fyf
 kGc
 pBv
-dXy
+pOC
 pqO
 wGc
 wGc
@@ -79838,10 +82307,10 @@ fyf
 fyf
 fyf
 qOV
-daU
+iez
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -79979,10 +82448,10 @@ mvv
 mvv
 mvv
 mvv
-aBH
+dCL
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 lTs
@@ -80070,8 +82539,8 @@ jnX
 fyf
 fyf
 kGc
-ajD
-lSD
+pBX
+pKq
 pqO
 wGc
 hoR
@@ -80094,10 +82563,10 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 bQO
 mfD
-hCg
+mcf
 fyf
 fyf
 hAC
@@ -80231,12 +82700,12 @@ thG
 fyf
 mBd
 fyf
-nlO
+oGS
 rbf
 mfD
 nQe
 mfD
-hCg
+mcf
 uey
 nOv
 mBd
@@ -80327,7 +82796,7 @@ wPl
 fyf
 fyf
 kGc
-ofX
+oPO
 qvQ
 pqO
 wGc
@@ -80622,7 +83091,7 @@ fyf
 fyf
 qOV
 cWG
-daU
+iez
 mvv
 mvv
 mvv
@@ -80841,9 +83310,9 @@ wPl
 fyf
 fyf
 kGc
-jIB
-dXy
-mHW
+pFM
+pOC
+pRo
 wGc
 gMO
 cCf
@@ -80880,10 +83349,10 @@ fyf
 tBN
 mvv
 mvv
-aBH
+dCL
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 qTY
@@ -80925,8 +83394,8 @@ fyf
 fyf
 fyf
 fyf
-nlO
-hCg
+oGS
+mcf
 fyf
 giS
 fyf
@@ -80974,7 +83443,7 @@ fyf
 fyf
 fyf
 gSt
-hgX
+psR
 unI
 qvQ
 ehN
@@ -81012,7 +83481,7 @@ rpu
 xjA
 rpu
 rpu
-aug
+ezo
 kEI
 gcK
 gcK
@@ -81134,10 +83603,10 @@ thG
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -81475,7 +83944,7 @@ fRZ
 kGc
 dMW
 qOV
-daU
+iez
 uTE
 bpD
 pzm
@@ -81524,7 +83993,7 @@ rpu
 rpu
 rpu
 rpu
-aug
+ezo
 rpu
 hwG
 kEI
@@ -81662,11 +84131,11 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 xGH
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -81702,7 +84171,7 @@ fyf
 fyf
 qOV
 cWG
-daU
+iez
 mvv
 sqy
 lyg
@@ -81717,7 +84186,7 @@ kdt
 ptf
 ptf
 ptf
-gNA
+puY
 dMW
 fyf
 fyf
@@ -81733,8 +84202,8 @@ kGc
 dMW
 tBN
 mvv
-aBH
-hCg
+dCL
+mcf
 kGD
 rkZ
 leP
@@ -81774,7 +84243,7 @@ fyf
 fyf
 kEI
 wqG
-aug
+ezo
 rpu
 vnu
 rpu
@@ -81994,7 +84463,7 @@ bpD
 fyf
 sYX
 bPU
-aug
+ezo
 lFM
 sYX
 sYX
@@ -82034,7 +84503,7 @@ kEI
 kEI
 bCC
 rpu
-aug
+ezo
 rpu
 rpu
 rpu
@@ -82245,9 +84714,9 @@ gts
 gts
 kGc
 dMW
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 sYX
 rpu
@@ -82434,9 +84903,9 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 xTK
 fyf
@@ -82700,7 +85169,7 @@ fyf
 fyf
 fyf
 qOV
-daU
+iez
 cxL
 tBN
 gjP
@@ -82748,7 +85217,7 @@ qTY
 fyf
 bNK
 mfD
-hCg
+mcf
 qqu
 fyf
 fyf
@@ -82770,11 +85239,11 @@ rpu
 sYX
 rkZ
 vnz
-aug
+ezo
 rpu
 sYX
 uCW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -82993,7 +85462,7 @@ hdX
 lKe
 mvv
 mvv
-doX
+dCX
 wDc
 fyf
 fyf
@@ -83031,7 +85500,7 @@ oVo
 sYX
 sYX
 uaf
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -83196,7 +85665,7 @@ xbX
 xbX
 skF
 xbX
-gWo
+kin
 mmH
 fyf
 fyf
@@ -83216,13 +85685,13 @@ hAC
 tBN
 mvv
 bpD
-nlO
+oGS
 mfD
 mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -83251,7 +85720,7 @@ lMr
 vEs
 lKe
 mvv
-doX
+dCX
 oEd
 cWG
 wDc
@@ -83260,8 +85729,8 @@ fyf
 fyf
 qOV
 uLw
-aBH
-hCg
+dCL
+mcf
 fyf
 hAC
 sND
@@ -83288,7 +85757,7 @@ fyf
 hAC
 ilu
 trd
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -83384,7 +85853,7 @@ unI
 qvQ
 hOl
 sgz
-gWo
+kin
 wKo
 sgz
 hOl
@@ -83470,9 +85939,9 @@ vnc
 fyf
 hAC
 hAC
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -83511,13 +85980,13 @@ ofL
 mvv
 mvv
 mvv
-doX
+dCX
 wDc
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 hAC
 fyf
 fyf
@@ -83545,7 +86014,7 @@ fyf
 fyf
 hAC
 kdJ
-ajD
+pBX
 qnS
 hOl
 ehN
@@ -83640,7 +86109,7 @@ cpK
 unI
 qvQ
 sgz
-gWo
+kin
 ptd
 rlN
 sgz
@@ -83722,7 +86191,7 @@ ehN
 ehN
 bhC
 ehN
-gWo
+kin
 mmH
 fyf
 uey
@@ -83747,7 +86216,7 @@ fyf
 fyf
 fyf
 gts
-dNW
+hiT
 epE
 fRk
 aRl
@@ -83769,7 +86238,7 @@ mvv
 mvv
 iuD
 mvv
-doX
+dCX
 wDc
 upX
 fyf
@@ -83786,7 +86255,7 @@ urQ
 uuc
 uuc
 uvp
-doX
+dCX
 wDc
 fyf
 fyf
@@ -83802,8 +86271,8 @@ fyf
 fyf
 uey
 kdJ
-ajD
-dXy
+pBX
+pOC
 hOl
 hOl
 koD
@@ -83983,7 +86452,7 @@ ubd
 fyf
 fyf
 fyf
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -84036,7 +86505,7 @@ fyf
 fyf
 jCC
 cWG
-daU
+iez
 fTG
 mvv
 mvv
@@ -84059,7 +86528,7 @@ uey
 fyf
 hAC
 kdJ
-ajD
+pBX
 oqL
 txB
 sgz
@@ -84194,7 +86663,7 @@ sYX
 qnE
 qnE
 qnE
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -84267,7 +86736,7 @@ eOX
 aRl
 tQo
 fXh
-dNW
+hiT
 nTa
 fgG
 aRl
@@ -84288,7 +86757,7 @@ sWG
 gts
 mvv
 mvv
-doX
+dCX
 cWG
 cWG
 evk
@@ -84301,7 +86770,7 @@ mvv
 hNT
 srL
 mvv
-doX
+dCX
 wDc
 fyf
 fyf
@@ -84323,7 +86792,7 @@ sgz
 koD
 dMW
 xLY
-nlO
+oGS
 mfD
 mfD
 mfD
@@ -84451,7 +86920,7 @@ sYX
 mrq
 mrq
 mrq
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -84491,7 +86960,7 @@ rlN
 sgz
 ehN
 ehN
-dXy
+pOC
 vnc
 xTK
 fyf
@@ -84559,7 +87028,7 @@ cNc
 srL
 mvv
 mvv
-doX
+dCX
 wDc
 fyf
 fyf
@@ -84971,9 +87440,9 @@ ehN
 ehN
 koD
 unI
-dXy
+pOC
 tKo
-lZP
+qaq
 gmX
 gjP
 rNv
@@ -85076,8 +87545,8 @@ jeo
 uxv
 uqa
 uqa
-ajD
-dXy
+pBX
+pOC
 pWN
 plq
 uPP
@@ -85228,7 +87697,7 @@ ehN
 ehN
 koD
 unI
-dXy
+pOC
 wGJ
 wGJ
 gmX
@@ -85280,7 +87749,7 @@ fyf
 fyf
 fyf
 pYn
-hCg
+mcf
 qOV
 wDc
 fyf
@@ -85333,8 +87802,8 @@ jfG
 uxv
 uqh
 uqa
-ajD
-dXy
+pBX
+pOC
 sgz
 sgz
 pWN
@@ -85344,8 +87813,8 @@ rlN
 sgz
 sgz
 sBk
-ajD
-dXy
+pBX
+pOC
 sgz
 sgz
 koD
@@ -85355,7 +87824,7 @@ sYX
 sYX
 sYX
 fyf
-nlO
+oGS
 mfD
 mfD
 qwy
@@ -85363,7 +87832,7 @@ mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 xLY
 fyf
 fyf
@@ -85461,10 +87930,10 @@ gbL
 gbL
 gcK
 gcK
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 sYX
 rpu
 rpu
@@ -85479,7 +87948,7 @@ sYX
 mrq
 mrq
 mrq
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -85539,7 +88008,7 @@ fyf
 cqG
 uey
 tBN
-doX
+dCX
 wDc
 gts
 dCV
@@ -85590,8 +88059,8 @@ bTA
 uxv
 jVy
 jEd
-ajD
-lSD
+pBX
+pKq
 hOl
 hOl
 sgz
@@ -85601,8 +88070,8 @@ rkr
 edt
 fDz
 sBk
-ajD
-lSD
+pBX
+pKq
 hOl
 sgz
 koD
@@ -85629,13 +88098,13 @@ fyf
 fyf
 thG
 qOV
-daU
+iez
 vXv
 mvv
 mvv
-doX
+dCX
 cWG
-daU
+iez
 mvv
 sYX
 mvv
@@ -85736,14 +88205,14 @@ sYX
 qnE
 qnE
 qnE
-jIB
+pFM
 qvQ
 ehN
 ehN
 koD
 unI
 qvQ
-mHW
+pRo
 wGJ
 wGJ
 srw
@@ -85789,7 +88258,7 @@ pcG
 bFJ
 unI
 qvQ
-mHW
+pRo
 pfl
 fyf
 fyf
@@ -85847,7 +88316,7 @@ uxv
 uxv
 kFx
 uqa
-ajD
+pBX
 eMy
 tle
 hOl
@@ -85858,7 +88327,7 @@ hOl
 hOl
 ehN
 wwM
-ajD
+pBX
 qvQ
 hOl
 ehN
@@ -85896,7 +88365,7 @@ mvv
 qPQ
 tKZ
 fTG
-amc
+pye
 mvv
 tKZ
 fyf
@@ -85904,7 +88373,7 @@ fyf
 tVV
 lae
 tRc
-dXy
+pOC
 pWN
 uPP
 uey
@@ -85993,7 +88462,7 @@ qyR
 qnE
 qnE
 qnE
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -86002,7 +88471,7 @@ onk
 qvQ
 wGJ
 wGJ
-mHW
+pRo
 gjP
 gjP
 gjP
@@ -86046,13 +88515,13 @@ pcG
 bFJ
 unI
 qvQ
-mHW
+pRo
 pfl
 fyf
 fyf
 hLi
 dzE
-daU
+iez
 mvv
 bpD
 gts
@@ -86104,7 +88573,7 @@ cKU
 pRx
 uqa
 uqa
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -86154,14 +88623,14 @@ mvv
 tKZ
 mvv
 fTG
-hhC
+mhJ
 tKZ
 fyf
 fyf
 kdJ
 uaf
 unI
-dXy
+pOC
 sgz
 dop
 fyf
@@ -86303,12 +88772,12 @@ pcG
 dxM
 unI
 qnS
-mHW
+pRo
 pfl
 fyf
 qOV
 fbH
-daU
+iez
 mvv
 mvv
 bpD
@@ -86409,7 +88878,7 @@ mvv
 mvv
 mvv
 tKZ
-amc
+pye
 mvv
 mvv
 sYX
@@ -86418,7 +88887,7 @@ fyf
 kdJ
 uaf
 unI
-dXy
+pOC
 sgz
 pWN
 oCi
@@ -86511,8 +88980,8 @@ unI
 qvQ
 ehN
 ehN
-dFQ
-dFQ
+pYj
+pYj
 pqO
 pqO
 pqO
@@ -86560,10 +89029,10 @@ pcG
 gdY
 unI
 rQh
-mHW
+pRo
 pfl
 fyf
-nlO
+oGS
 hYS
 mfD
 xGH
@@ -86662,7 +89131,7 @@ mvv
 mvv
 mvv
 mvv
-hhC
+mhJ
 mvv
 mvv
 sYX
@@ -86675,7 +89144,7 @@ fyf
 kdJ
 uaf
 unI
-dXy
+pOC
 sgz
 sgz
 koD
@@ -86771,7 +89240,7 @@ ehN
 btW
 btW
 lQG
-mHW
+pRo
 wGJ
 gmX
 oUI
@@ -86817,15 +89286,15 @@ pcG
 uaf
 pBv
 qvQ
-mHW
+pRo
 pfl
 fyf
 uey
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 gts
 dCV
 tOF
@@ -86886,7 +89355,7 @@ ehN
 bse
 ehN
 koD
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -86925,14 +89394,14 @@ mvv
 ucA
 qPQ
 mvv
-amc
+pye
 alU
 fyf
 fyf
 kdJ
 uaf
 eYR
-lSD
+pKq
 hOl
 sgz
 bfu
@@ -87029,7 +89498,7 @@ geM
 muk
 qvQ
 wGJ
-mHW
+pRo
 gmX
 pcG
 pcG
@@ -87072,9 +89541,9 @@ rpv
 ygZ
 ygZ
 uaf
-ajD
+pBX
 mYs
-mHW
+pRo
 pfl
 fyf
 fyf
@@ -87132,7 +89601,7 @@ fgd
 voR
 voR
 eFC
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -87143,7 +89612,7 @@ fDz
 fDz
 fDz
 koD
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -87188,7 +89657,7 @@ fyf
 tVV
 lae
 uaf
-ajD
+pBX
 qvQ
 hOl
 hOl
@@ -87329,9 +89798,9 @@ qcw
 pWC
 pRd
 btL
-jIB
+pFM
 qvQ
-mHW
+pRo
 pfl
 hLi
 fyf
@@ -87389,7 +89858,7 @@ fgd
 voR
 hGe
 jEd
-ofX
+oPO
 eeh
 fDz
 fDz
@@ -87437,7 +89906,7 @@ mvv
 mvv
 ymi
 ucA
-hhC
+mhJ
 mvv
 qPQ
 alU
@@ -87445,7 +89914,7 @@ fyf
 kdJ
 wVn
 uaf
-jIB
+pFM
 qvQ
 qfm
 hOl
@@ -87543,7 +90012,7 @@ koD
 unI
 qvQ
 wGJ
-lZP
+qaq
 wGJ
 pcG
 uYz
@@ -87586,7 +90055,7 @@ wzr
 fmZ
 pRd
 cam
-ofX
+oPO
 qvQ
 ehN
 pfl
@@ -87624,7 +90093,7 @@ vUG
 rQx
 dCV
 uqa
-dNW
+hiT
 gts
 nJH
 uaf
@@ -87702,8 +90171,8 @@ fyf
 kdJ
 uCW
 uaf
-ofX
-box
+oPO
+pJY
 hOl
 hOl
 koD
@@ -87801,7 +90270,7 @@ unI
 qvQ
 tPy
 wGJ
-mHW
+pRo
 pcG
 wxI
 vAt
@@ -87830,7 +90299,7 @@ cvH
 rqs
 odJ
 gjP
-box
+pJY
 snB
 pfl
 nzJ
@@ -87960,7 +90429,7 @@ kdJ
 dkg
 uaf
 unI
-dXy
+pOC
 hOl
 hOl
 koD
@@ -88058,7 +90527,7 @@ unI
 qvQ
 wGJ
 wGJ
-mHW
+pRo
 pcG
 pcG
 pcG
@@ -88087,7 +90556,7 @@ rHS
 rqs
 eAh
 gjP
-dXy
+pOC
 snB
 pfl
 ydQ
@@ -88217,8 +90686,8 @@ ilu
 trd
 trd
 unI
-dXy
-gWo
+pOC
+kin
 wNe
 koD
 bFJ
@@ -88428,7 +90897,7 @@ hOl
 ehN
 ehN
 bfu
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -88469,7 +90938,7 @@ ixT
 rpu
 thM
 sYX
-doX
+dCX
 wDc
 hAC
 ilu
@@ -88685,7 +91154,7 @@ hOl
 ehN
 ehN
 wwM
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -88873,7 +91342,7 @@ bFJ
 bFJ
 jUe
 qvQ
-hEX
+hOl
 pWN
 uPP
 fyf
@@ -88942,7 +91411,7 @@ ehN
 ehN
 ehN
 koD
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -88984,7 +91453,7 @@ sDp
 uCO
 sYX
 mfD
-hCg
+mcf
 fyf
 hAC
 fyf
@@ -89114,7 +91583,7 @@ gdY
 gdY
 gdY
 gdY
-ofX
+oPO
 qvQ
 pTC
 pfl
@@ -89130,7 +91599,7 @@ bFJ
 nPg
 onk
 qvQ
-hEX
+hOl
 sgz
 pfl
 fyf
@@ -89260,7 +91729,7 @@ vqb
 cbr
 cbr
 prp
-hCg
+mcf
 gcK
 ktB
 "}
@@ -89386,7 +91855,7 @@ ybI
 ybI
 onk
 iLd
-hEX
+hOl
 sgz
 sgz
 pfl
@@ -89511,7 +91980,7 @@ fyf
 hAC
 nZr
 qOV
-daU
+iez
 kSZ
 cbr
 hRN
@@ -89591,7 +92060,7 @@ dkg
 bFJ
 dkg
 uaf
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -89611,14 +92080,14 @@ xbX
 hBN
 aJb
 aJb
-gWo
+kin
 mmH
 qTY
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 hCs
 wKo
@@ -89645,7 +92114,7 @@ xbX
 ehN
 sgz
 sgz
-gWo
+kin
 mmH
 fyf
 fyf
@@ -89897,11 +92366,11 @@ ehN
 lCv
 ehN
 dqX
-hEX
+hOl
 ehN
-hEX
+hOl
 sgz
-gWo
+kin
 mmH
 fyf
 fyf
@@ -90129,8 +92598,8 @@ vnc
 fyf
 qOV
 uLw
-aBH
-hCg
+dCL
+mcf
 fyf
 ulH
 cax
@@ -90156,7 +92625,7 @@ kaM
 kaM
 kaM
 kaM
-hEX
+hOl
 sgz
 pfl
 fyf
@@ -90286,8 +92755,8 @@ tqL
 mvv
 mvv
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 gcK
 ktB
@@ -90384,9 +92853,9 @@ fsm
 fsm
 fsm
 ubd
-nlO
+oGS
 mfD
-hCg
+mcf
 hAC
 fyf
 hLi
@@ -90414,7 +92883,7 @@ ees
 ees
 muk
 iLd
-hEX
+hOl
 pfl
 uey
 fyf
@@ -90619,7 +93088,7 @@ iek
 wmN
 iek
 thw
-fsl
+pyk
 voF
 lCv
 ehN
@@ -91056,9 +93525,9 @@ mvv
 mvv
 wsC
 mvv
-aBH
-hCg
-nlO
+dCL
+mcf
+oGS
 mfD
 gcK
 ktB
@@ -91312,7 +93781,7 @@ mvv
 mvv
 mvv
 mvv
-aBH
+dCL
 lmn
 fyf
 fyf
@@ -91441,7 +93910,7 @@ mLv
 mLv
 mgX
 uaf
-ajD
+pBX
 qvQ
 pfl
 fyf
@@ -91564,12 +94033,12 @@ fyf
 fyf
 fyf
 qOV
-daU
+iez
 pSC
 jPh
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -91669,7 +94138,7 @@ fyf
 trW
 fyf
 azz
-ajD
+pBX
 qvQ
 sgz
 neN
@@ -91698,7 +94167,7 @@ mLv
 mLv
 gMT
 uaf
-jIB
+pFM
 qvQ
 pfl
 fyf
@@ -91788,9 +94257,9 @@ sJM
 fyf
 fyf
 kGc
-ajD
+pBX
 qvQ
-gWo
+kin
 wNe
 koD
 adp
@@ -91824,7 +94293,7 @@ tBN
 mvv
 mvv
 mvv
-aBH
+dCL
 lmn
 fyf
 fyf
@@ -91926,7 +94395,7 @@ fyf
 fyf
 upX
 koD
-ofX
+oPO
 qvQ
 hOl
 sgz
@@ -92019,7 +94488,7 @@ voR
 iaP
 jXv
 dKW
-ajD
+pBX
 qvQ
 ehN
 fAt
@@ -92155,7 +94624,7 @@ mfq
 xcQ
 miS
 nYo
-ajD
+pBX
 eMy
 ehN
 ehN
@@ -92183,7 +94652,7 @@ rjD
 rjD
 cdt
 koD
-fsl
+pyk
 voF
 hOl
 hOl
@@ -92276,7 +94745,7 @@ voR
 cbS
 hfd
 dKW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -92471,7 +94940,7 @@ pcG
 bFJ
 unI
 qvQ
-mHW
+pRo
 pWN
 uPP
 fyf
@@ -92533,7 +95002,7 @@ nsz
 cbS
 prO
 dKW
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -92594,8 +95063,8 @@ fyf
 tBN
 mvv
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -92728,8 +95197,8 @@ bFJ
 bFJ
 unI
 qvQ
-mHW
-gWo
+pRo
+kin
 mmH
 fyf
 sqA
@@ -92954,7 +95423,7 @@ uRJ
 sSt
 vIb
 pcG
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -92970,7 +95439,7 @@ fbq
 boN
 fbq
 bNg
-daU
+iez
 pcG
 eQR
 mLv
@@ -92985,7 +95454,7 @@ dkg
 gdY
 unI
 qvQ
-hEX
+hOl
 pfl
 fyf
 rtR
@@ -93106,7 +95575,7 @@ qai
 mrQ
 wFW
 aFG
-kRe
+nJQ
 sGp
 bpD
 fyf
@@ -93183,7 +95652,7 @@ vIx
 vIx
 kTm
 mQD
-ajD
+pBX
 eMy
 fDz
 hOl
@@ -93211,7 +95680,7 @@ iWc
 uRJ
 vIb
 pcG
-jIB
+pFM
 qvQ
 ehN
 dte
@@ -93242,7 +95711,7 @@ dkg
 uaf
 pBv
 qvQ
-hEX
+hOl
 pfl
 fyf
 fyf
@@ -93362,10 +95831,10 @@ sGp
 uco
 kBV
 oDG
-kRe
+lei
 axr
 sGp
-hCg
+mcf
 fyf
 fyf
 hAC
@@ -93444,7 +95913,7 @@ pgD
 qvQ
 ehN
 sgz
-gWo
+kin
 wNe
 wKo
 hOl
@@ -93468,38 +95937,38 @@ nSK
 uRJ
 uRJ
 qiV
-ofX
+oPO
 qvQ
 ehN
 ehN
 koD
-thG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+dMW
+wPl
+wPl
+wPl
+wPl
+wPl
+fFu
 fyf
 tBN
 ofL
 mvv
-amc
+pye
 pcG
 iqy
-ces
-jCH
-bGG
-mLv
+bGV
+fyf
+hCW
+qJv
 acK
 trd
 xKx
 gCo
 xKx
 uaf
-ajD
+pBX
 qvQ
-hEX
+hOl
 pfl
 fyf
 fyf
@@ -93540,7 +96009,7 @@ dCV
 dCV
 gts
 nJW
-gNA
+puY
 usx
 iMm
 uxv
@@ -93620,7 +96089,7 @@ vxz
 oDG
 oDG
 kRe
-umX
+bWM
 sGp
 fyf
 fyf
@@ -93697,7 +96166,7 @@ uYP
 yaZ
 miS
 dkg
-ajD
+pBX
 eMy
 hOl
 sgz
@@ -93730,31 +96199,31 @@ qvQ
 ehN
 ins
 koD
-thG
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-tBN
-mvv
-mvv
-aBH
-bTk
-nGq
-nGq
-nGq
-hoz
+dMW
+wPl
+xRk
+xRk
+lrp
+xRk
+qOV
+cWG
+iez
+kLl
 pcG
 pcG
-yjE
-trd
-gCo
+pcG
+pcG
+pcG
+pcG
+auk
+eQN
+pcG
+wIK
+pWn
+flU
+bFJ
 uaf
-uaf
-jIB
+pFM
 qvQ
 ehN
 pfl
@@ -93838,7 +96307,7 @@ uCO
 sHp
 lrf
 nei
-aug
+ezo
 dcQ
 sHp
 sWF
@@ -93987,29 +96456,29 @@ qvQ
 ehN
 ehN
 koD
-thG
-uey
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-nlO
-mfD
-bni
-hCg
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-fyf
-kdJ
-xKx
-uaf
+dMW
+wPl
+gRR
+mIk
+gLn
+udJ
+iez
+mvv
+mvv
+mvv
+ygZ
+hNs
+drF
+uLE
+tYB
+pcG
+pcG
+pcG
+pIc
+iuJ
+bFJ
+hkP
+bFJ
 uaf
 nZJ
 qvQ
@@ -94018,8 +96487,8 @@ pWN
 uPP
 fyf
 bRd
-aBH
-hCg
+dCL
+mcf
 gts
 dCV
 giZ
@@ -94211,7 +96680,7 @@ vkF
 vSd
 odV
 dkg
-ajD
+pBX
 eMy
 edt
 sgz
@@ -94244,29 +96713,29 @@ qvQ
 rbi
 ehN
 koD
-gjP
-gjP
-cPn
-cPn
-gjP
-gjP
-gjP
-gjP
-gjP
-fyf
-fyf
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-ijg
-ijg
-gjP
+dMW
+wPl
+luZ
+ifv
+gLn
+txd
+mvv
+mvv
+mvv
+mvv
+onn
+mWY
+cXu
+rfB
+dgE
+pcG
+rHu
+kaC
+oVB
+pIc
+bFJ
+jgs
+bFJ
 cam
 unI
 qvQ
@@ -94332,7 +96801,7 @@ nzb
 gMx
 usx
 sBk
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -94351,15 +96820,15 @@ cpK
 sYX
 iTJ
 lDR
-aug
+ezo
 pHi
 dcQ
 rAi
 tkm
 sYX
 kGc
-ajD
-dXy
+pBX
+pOC
 pWN
 plq
 oCi
@@ -94468,7 +96937,7 @@ uYP
 yeF
 wOv
 dkg
-ajD
+pBX
 qvQ
 ehN
 sgz
@@ -94496,34 +96965,34 @@ pcG
 pcG
 pcG
 nkp
-ajD
+pBX
 qvQ
 ehN
 ehN
 koD
-gjP
-jel
-bMg
+dMW
+wPl
+udJ
 qRB
-lqO
-cbk
-uRJ
-mPT
-gjP
-fyf
-fyf
-srw
-bMg
-lly
-gvh
-pIV
-dvp
-aUV
-cbk
-isy
-lly
-uRJ
-gjP
+gLn
+hTt
+xGH
+mvv
+mvv
+mvv
+ygZ
+rik
+iOe
+pnM
+wxa
+pcG
+xIv
+cRJ
+itB
+qir
+bFJ
+bFJ
+bFJ
 bFJ
 unI
 qvQ
@@ -94531,8 +97000,8 @@ ehN
 wGJ
 pfl
 fyf
-nlO
-hCg
+oGS
+mcf
 fyf
 gts
 dCV
@@ -94589,7 +97058,7 @@ hCC
 nzb
 usx
 wwM
-ajD
+pBX
 qvQ
 ehN
 dte
@@ -94615,8 +97084,8 @@ uCO
 uCO
 sYX
 kGc
-ajD
-dXy
+pBX
+pOC
 sgz
 hOl
 sBk
@@ -94725,7 +97194,7 @@ wkx
 cGV
 wOv
 wOv
-ajD
+pBX
 eMy
 ehN
 hOl
@@ -94753,36 +97222,36 @@ upX
 fyf
 fyf
 koD
-jIB
+pFM
 qvQ
 ehN
 ehN
 bfu
-gjP
-uRJ
-uRJ
-mvJ
-uRJ
-jnX
-wyI
-lqO
-gjP
-fyf
-qOV
-srw
-bMg
-lly
-uRJ
-uRJ
-uRJ
-uRJ
-cbk
+dMW
+wPl
+udJ
+hTt
+xRk
+xRk
+fsR
+hko
+mvv
+mvv
+mtr
+xVu
+xVu
+ppL
+mPF
+aAd
+xvM
+dDx
+jfO
 ctm
-wyI
-uRJ
-gjP
+xWT
+bFJ
+bFJ
 bKv
-fsl
+pyk
 voF
 wGJ
 wGJ
@@ -94846,7 +97315,7 @@ usx
 usx
 usx
 koD
-ajD
+pBX
 qvQ
 jyC
 ehN
@@ -94872,8 +97341,8 @@ rEB
 tsB
 ung
 kGc
-ofX
-lSD
+oPO
+pKq
 hOl
 ehN
 sBk
@@ -94982,7 +97451,7 @@ wkx
 wkx
 iAz
 wOv
-ofX
+oPO
 qvQ
 ehN
 vMU
@@ -95015,34 +97484,34 @@ voF
 ehN
 ehN
 wwM
-gjP
-uRJ
-uRJ
-uRJ
-uRJ
-cbk
-cbk
-cbk
-gjP
-qOV
-gjP
-gjP
-gjP
-gjP
-cbk
-cbk
-cbk
-jnX
-cbk
-cbk
-cbk
-jnX
-gjP
+dMW
+wPl
+wPl
+wPl
+wPl
+wPl
+gKD
+mvv
+mvv
+mvv
+mKM
+cDm
+lJk
+anH
+mPF
+tMw
+xvM
+dDx
+ltA
+pcG
+pIc
+pcG
+pIc
 bFJ
 unI
 voF
 wGJ
-mHW
+pRo
 pfl
 fyf
 fyf
@@ -95083,7 +97552,7 @@ fyf
 fyf
 fyf
 nJW
-gNA
+puY
 unI
 btW
 btW
@@ -95094,16 +97563,16 @@ qoS
 qoS
 qoS
 wGJ
-mHW
-mHW
+pRo
+pRo
 wGJ
 wGJ
-mHW
-mHW
-mHW
+pRo
+pRo
+pRo
 fEb
 dKW
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -95272,34 +97741,34 @@ qvQ
 ehN
 ehN
 koD
+dMW
+ijg
 gjP
-wyI
-jdE
-uRJ
-uRJ
-jnX
-uRJ
-uRJ
-srw
-daU
-soY
+xei
+ijg
+ijg
+iZV
+avx
+vqN
+mvv
+ygZ
 rVN
-rVN
+kOI
 xVu
-tlr
-cCf
-cbk
-uRJ
-uRJ
-uRJ
-uRJ
-uRJ
-srw
+mPF
+mxt
+xvM
+gOx
+nBA
+pcG
+oGy
+xGY
+pIc
 bFJ
 bwE
 qvQ
-mHW
-mHW
+pRo
+pRo
 pfl
 uey
 fyf
@@ -95529,34 +97998,34 @@ qvQ
 ehN
 hOl
 koD
+dMW
 gjP
-cbk
-dJg
-cbk
-cbk
-cbk
-uRJ
-uRJ
-oiu
+dnk
+tTC
+eAT
+qXO
+uIT
+uIT
+gjP
 mvv
-soY
-fbq
-fbq
+onn
+dkG
+tWf
 xVu
-tTV
-oGX
-jnX
-uRJ
-aqv
-uRJ
-uRJ
-uRJ
-oiu
+ygZ
+iOB
+rSt
+gdA
+uls
+vQW
+aoV
+pmi
+pIc
 bFJ
 unI
-dXy
-mHW
-gWo
+pOC
+pRo
+kin
 mmH
 fyf
 fyf
@@ -95781,34 +98250,34 @@ bFJ
 bFJ
 bFJ
 dkg
-ajD
+pBX
 qvQ
 ehN
 sgz
 koD
-gjP
-nQY
-ppn
+dMW
+xei
+oSm
 fjR
-uRJ
-cbk
-uRJ
-uRJ
-srw
-amc
-soY
-fbq
-fbq
+xuU
+qOz
+nPl
+nTP
+gjP
+mvv
+ygZ
+jAh
+rto
 xVu
-gjP
-gjP
-gjP
-uRJ
-jTq
-bMg
-uRJ
-hVN
-gjP
+cgf
+pcG
+whb
+oVC
+dDX
+pcG
+lNE
+vWp
+pcG
 wfe
 eSX
 grp
@@ -95874,7 +98343,7 @@ khY
 xIa
 imO
 dKW
-ajD
+pBX
 qvQ
 lCv
 lCv
@@ -96043,29 +98512,29 @@ grp
 wKo
 sgz
 koD
+dMW
 gjP
-mfR
-uRJ
-uRJ
-kwA
-cbk
-adN
+qOz
+qOz
+qOz
+qOz
+nPl
 uIT
-gjP
-xGH
-soY
-fbq
-boN
-fbq
-hCp
-fbq
-jnX
-uRJ
-uRJ
-mTy
-wyI
-ipE
-gjP
+drR
+mvv
+pcG
+pcG
+pcG
+pcG
+pcG
+pcG
+ygZ
+ueY
+pcG
+pcG
+pcG
+pcG
+pcG
 fyf
 fyf
 fyf
@@ -96131,7 +98600,7 @@ jUg
 xIa
 djV
 sBk
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -96156,8 +98625,8 @@ sYX
 sYX
 sYX
 sYX
-hgX
-ajD
+psR
+pBX
 qvQ
 dte
 ehN
@@ -96298,33 +98767,33 @@ jMC
 fyf
 fyf
 ukl
-gWo
+kin
 hzb
+obr
 gjP
+alD
+ibz
+edu
+qXO
+kIp
+nTP
 gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-gjP
-nlO
-qin
-wxr
-wxr
-wxr
-wxr
-wxr
-gjP
-gjP
-xql
-ijg
-ijg
-gjP
-gjP
+mvv
+mvv
+iqX
+mvv
+mvv
+mvv
+mvv
+hko
+mvv
+bpD
+fyf
+thG
+byq
 tFR
 tFR
+fyf
 tFR
 fyf
 fyf
@@ -96557,28 +99026,28 @@ fyf
 ukl
 pfl
 fyf
+nSv
+xei
+nqT
+uTH
+sGH
+qOz
+nnB
+nTP
+gjP
+hxO
+mvv
+hxO
+owR
+mvv
+mvv
+mvv
+mvv
+mvv
+bpD
 fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-hAC
-fyf
-fyf
-nlO
-mfD
-mfD
-mfD
-mfD
-mfD
-hCg
-fyf
-fyf
-fyf
-fyf
-fyf
+thG
+byq
 fyf
 fyf
 fyf
@@ -96813,29 +99282,29 @@ fyf
 fyf
 ukl
 pfl
-fyf
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
-fyf
+hLi
+hLi
+gjP
+qOz
+qOz
+qOz
+qOz
+auR
+oti
+mdB
+hxO
+hJg
+hxO
+tcJ
+mvv
+gjP
+rsk
+gjP
+sQs
+gjP
+sqr
+ijg
+wPl
 fyf
 dDr
 fyf
@@ -96940,7 +99409,7 @@ whD
 wVs
 wVs
 wVs
-aug
+ezo
 aYT
 cLW
 spj
@@ -97044,7 +99513,7 @@ eme
 ssm
 ilu
 trd
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -97070,30 +99539,30 @@ noK
 nJT
 rkr
 pfl
-fyf
-pcG
-qXO
+hLi
+dDC
+gjP
 agA
 atk
 aHN
 qXO
-lqh
-vEw
-qXO
-rTf
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-tFR
-tFR
-tFR
-yeJ
-fLx
+uIT
+sbX
+ijg
+hxO
+mvv
+hxO
+mvv
+hko
+yhL
+wju
+wyt
+nTP
+xDw
+wju
+gRZ
+wPl
+fyf
 fyf
 fyf
 fyf
@@ -97140,7 +99609,7 @@ fyf
 uey
 hAC
 nJW
-gNA
+puY
 unI
 nAk
 wGJ
@@ -97328,29 +99797,29 @@ qvQ
 sgz
 pfl
 hAC
-pcG
-psD
+fyf
+xei
 pbx
-pbx
-psD
-fnB
-psD
-psD
-qXO
-sAe
-pcG
-uNW
+kEk
+bDK
+qOz
+qoC
+gad
+uxR
+mvv
+mvv
+mvv
 ptI
-awO
+mvv
 uNW
 wju
-nIz
-pcG
-pcG
-pcG
-pcG
-cam
-uaf
+nTP
+nTP
+oti
+wju
+xch
+wPl
+tVV
 ssm
 fyf
 fyf
@@ -97557,7 +100026,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 vCc
 qvQ
 ehN
@@ -97580,34 +100049,34 @@ lgt
 cCf
 cCf
 sow
-ofX
+oPO
 qvQ
 sgz
 pfl
 fyf
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
+trW
+gjP
+qOz
+qOz
+qOz
+qOz
+eKd
 lag
-qXO
-ihA
-tFP
+tUU
+mfD
+mfD
 vfY
-vfY
+mvv
+mvv
 xSc
-xSc
-xSc
-vfY
+wju
+uIT
 nVi
-nTP
-rak
-pcG
-pcG
-pcG
+sbX
+wju
+bLP
+wPl
+kGc
 eqo
 noK
 nJT
@@ -97842,29 +100311,29 @@ qvQ
 sgz
 pWN
 oCi
-pcG
-vjj
+ssm
+gjP
 aUa
-aUa
-aUa
-aUa
-aUa
-lag
+avf
+aHN
 qXO
-kNf
-pcG
-vpp
-ebC
-tUU
+nTP
+uIT
+gjP
+pEv
+upX
+tBN
+mvv
+mvv
 tUU
 fdO
-aFV
-pcG
-pzL
 nTP
-icB
-hEh
-pcG
+fwJ
+lag
+dIC
+tUU
+wPl
+kGc
 bFJ
 unI
 iiC
@@ -97933,7 +100402,7 @@ sBk
 vCc
 qvQ
 hOl
-gWo
+kin
 wKo
 hOl
 hOl
@@ -98049,7 +100518,7 @@ tBN
 mvv
 mvv
 mvv
-doX
+dCX
 cWG
 gcK
 gcK
@@ -98071,7 +100540,7 @@ xDv
 cnj
 gts
 igz
-hgX
+psR
 unI
 qvQ
 ehN
@@ -98099,32 +100568,32 @@ qvQ
 hOl
 sgz
 koD
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
-lag
-qXO
-sQW
-pcG
+oZm
+xei
+xTM
+noU
+bDK
+qOz
+nPl
+nTP
+gjP
+fyf
+trW
 wcB
-tSf
-xSC
+mvv
+mvv
 yhL
-yhL
+wju
 xeO
-pcG
+eLf
 mOP
-svp
-pzL
-rFc
-blt
+wju
+mOe
+wPl
+kGc
 gdY
 pBv
-dXy
+pOC
 sgz
 ehN
 koD
@@ -98189,7 +100658,7 @@ mvv
 sBk
 vCc
 qvQ
-gWo
+kin
 mmH
 rlN
 sgz
@@ -98210,10 +100679,10 @@ nWy
 bVB
 qMX
 qvQ
-bJB
+pRy
 ubg
 wGJ
-gWo
+kin
 wKo
 wGJ
 ehN
@@ -98351,37 +100820,37 @@ cCf
 cCf
 cCf
 pcG
-ajD
+pBX
 qvQ
 ehN
 uit
-iYF
-pcG
-vjj
-aUa
-aUa
-aUa
-aUa
-aUa
-lag
-qXO
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
+koD
+dMW
+gjP
+qOz
+qOz
+qOz
+qOz
+nPl
 nTP
-spG
+drR
+uey
+fyf
+tBN
+mvv
+mvv
+uNW
+wju
+xDw
+xDw
 nTP
-hEh
-blt
+wju
+kEe
+wPl
+doh
 uaf
-ajD
-lSD
+pBX
+pKq
 ehN
 ehN
 koD
@@ -98415,7 +100884,7 @@ kQJ
 fyf
 uey
 qOV
-daU
+iez
 mvv
 mvv
 bpD
@@ -98586,7 +101055,7 @@ ujC
 cKs
 glZ
 cpK
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -98608,36 +101077,36 @@ cCf
 qos
 cCf
 xMw
-jIB
+pFM
 qvQ
 ehN
 hOl
 wwM
-pcG
-xei
-aUa
-aUa
-aUa
-aUa
-aUa
-pbx
-qER
-pcG
-tHN
-kBd
-pcG
-uAp
-qRy
-oNC
+dMW
+gjP
+sOz
+rYE
+ibz
+qXO
+dyS
+dyS
+gjP
+fyf
+qTY
+tBN
+mvv
+mvv
+xSc
+wju
 mKr
-pcG
-nTP
-sdI
-nTP
-qoN
-pcG
+jxB
+uyo
+wju
+bLP
+wPl
+doh
 uaf
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -98673,7 +101142,7 @@ lgN
 fyf
 tBN
 pyZ
-hCg
+mcf
 sih
 tFR
 qvN
@@ -98682,13 +101151,13 @@ mvB
 lFX
 mvv
 mvv
-doX
+dCX
 cWG
 cWG
 cWG
 fbH
 cWG
-daU
+iez
 vvV
 xSS
 tQt
@@ -98722,13 +101191,13 @@ fyy
 mIF
 lda
 pLf
-ajD
+pBX
 qvQ
 ubg
 dQW
 wGJ
-apk
-apk
+pWt
+pWt
 wGJ
 ehN
 koD
@@ -98842,8 +101311,8 @@ lLh
 gUF
 gts
 ptf
-gNA
-jIB
+puY
+pFM
 qvQ
 ehN
 ehN
@@ -98865,36 +101334,36 @@ hxy
 lXH
 cCf
 frC
-ofX
+oPO
 qvQ
 ehN
 hOl
 koD
-pcG
+dMW
 xei
-aUa
-aUa
-aUa
-aUa
-aUa
+iFa
+aKk
+xuU
+qOz
+mmS
 bkc
-ihA
-sTn
-xDL
-tJl
+gjP
+trW
+iGM
+tBN
 ntz
-pJd
-aku
-pei
-aku
-leq
-txC
-spG
-pzL
-pzL
+mvv
+ijg
+gjP
+ijg
+gjP
+gjP
+ijg
+ijg
+wPl
 doh
 cam
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -98928,19 +101397,19 @@ cbr
 kTy
 fyf
 qOV
-daU
+iez
 bpD
 fyf
 fyf
 fyf
 qOV
 cWG
-iez
+ltK
 mvv
 xwW
 mvv
 mvv
-dCL
+ajD
 mfD
 xGH
 mvv
@@ -99073,7 +101542,7 @@ gcK
 gcK
 gcK
 gcK
-nlO
+oGS
 mfD
 mfD
 mfD
@@ -99100,7 +101569,7 @@ gts
 gts
 gts
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -99127,29 +101596,29 @@ qvQ
 ehN
 ehN
 koD
-pcG
-xei
-aUa
-aUa
-aUa
-aUa
-aUa
-bkc
-ihA
-pcG
-xDL
-xOt
-pcG
-iTC
-kwL
-hVW
-xVI
-pcG
-bgq
+dMW
+gjP
+qOz
+qOz
+qFk
+qOz
+qtO
+xDw
+pFx
+uey
+aIr
+tBN
+mvv
+mvv
+mvv
+mvv
+koD
+cam
+dkg
 jeI
-nTP
-qoN
-pcG
+ttq
+wPl
+agR
 bFJ
 unI
 qvQ
@@ -99183,14 +101652,14 @@ hzs
 jVE
 cbr
 kTP
-daU
+iez
 mvv
 mvv
-doX
+dCX
 wDc
 qLa
-ouu
-jNJ
+erp
+cVe
 jNJ
 jNJ
 hGf
@@ -99200,7 +101669,7 @@ mvv
 bpD
 pis
 tBN
-dCL
+ajD
 mfD
 xGH
 vDP
@@ -99384,29 +101853,29 @@ qvQ
 ehN
 ehN
 koD
-pcG
-psD
-psD
+dMW
+ijg
+lWN
 axw
-pbx
-psD
-psD
-psD
-ihA
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-sdI
-spG
 nTP
-hEh
-blt
+uIT
+afI
+lhM
+gjP
+hAC
+iGD
+tBN
+mvv
+mvv
+kbF
+mvv
+koD
+wPl
+wPl
+byq
+wPl
+wPl
+bFJ
 bFJ
 unI
 qvQ
@@ -99436,17 +101905,17 @@ srw
 aSd
 cbr
 cbr
-cbr
-wOp
-cbr
-cbr
-lBS
+mvv
+rjH
+mvv
+pPc
+mvv
 mvv
 mvv
 npG
-hCg
+mcf
 nsK
-uVG
+nYa
 qrB
 tXb
 tPD
@@ -99454,9 +101923,9 @@ pKt
 mvv
 wsC
 mvv
-dCX
+wjO
 sSQ
-daU
+iez
 bpD
 bxx
 ujQ
@@ -99641,29 +102110,29 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-pcG
-pcG
-pcG
-pcG
-qXO
-qXO
-qXO
-ihA
-tbX
-pcG
+dMW
+vjR
+mKV
+aFY
+nTP
+xHO
+cxJ
+nTP
+gjP
+fyf
+fyf
 tLE
 dJn
-tLE
-dJn
-dJn
-jpB
-pcG
-xDP
-pzL
-svp
-rFc
-blt
+uTE
+mvv
+mvv
+koD
+wPl
+dkg
+dkg
+qGZ
+trd
+dkg
 bFJ
 unI
 qvQ
@@ -99693,8 +102162,8 @@ gjP
 tXS
 kUA
 cbr
-wOp
-cbr
+rjH
+mvv
 kWW
 kVv
 mvv
@@ -99711,10 +102180,10 @@ iGZ
 pAC
 mvv
 mvv
-dCL
+ajD
 toy
 twa
-hCg
+mcf
 fyf
 tBN
 mvv
@@ -99898,29 +102367,29 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-uZS
-aku
+dMW
+auk
+dBr
 aFY
-pcG
+dyS
 uzN
 ngr
-qXO
-ihA
+gad
+cLm
 ten
-pcG
-eQq
+fyf
+tBN
 tcJ
-enp
-enp
-enp
-ejp
-pcG
-pzL
-pzL
+mvv
+mvv
+mvv
+koD
+wPl
+uaf
+qGZ
 hoe
-hEh
-pcG
+kdJ
+dkg
 gdY
 neP
 qvQ
@@ -99950,9 +102419,9 @@ srw
 tXS
 hRN
 cbr
-cbr
-koZ
-cbr
+mvv
+bGM
+mvv
 gDn
 mvv
 mvv
@@ -99967,8 +102436,8 @@ tQM
 pKt
 mvv
 odZ
-aBH
-hCg
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -100071,7 +102540,7 @@ gcK
 fyf
 tBN
 mvv
-aBH
+dCL
 cbM
 crg
 mvv
@@ -100108,7 +102577,7 @@ ktB
 mcN
 mvv
 mvv
-doX
+dCX
 tbg
 gcK
 gcK
@@ -100155,32 +102624,32 @@ qvQ
 ehN
 ehN
 bdN
-pcG
-uZS
-snR
-aku
-bbW
-ihA
-ihA
-qXO
-qXO
-ihA
-tOt
-tgR
-wMU
-wMU
-wMU
-tgR
-tgR
-nVi
-nTP
-qoN
-pcG
-pcG
-pcG
+dMW
+fyf
+auk
+dBr
+sbX
+prR
+vaZ
+dyS
+gjP
+eEc
+trW
+tBN
+mvv
+mvv
+mvv
+mvv
+koD
+wPl
+dkg
+nPX
+tVV
+lae
+dkg
 uaf
 pBv
-box
+pJY
 ehN
 acg
 ehN
@@ -100207,11 +102676,11 @@ srw
 tXS
 kiH
 cbr
-cbr
-cbr
+mvv
+mvv
 lbJ
 gDs
-mvv
+aLd
 mvv
 pIn
 bpD
@@ -100223,7 +102692,7 @@ ruw
 ruw
 fAM
 mvv
-aBH
+dCL
 pUl
 fyf
 fyf
@@ -100344,7 +102813,7 @@ fyf
 tBN
 mvv
 mvv
-doX
+dCX
 cWG
 wDc
 aSS
@@ -100407,37 +102876,37 @@ dxf
 ozA
 ozA
 pcG
-ajD
+pBX
 qvQ
 ehN
 ehN
 koD
-pcG
-uZS
-wDW
-jxD
-pcG
-ihA
-onh
-gsB
-onh
-ihA
-pcG
-ira
+dMW
+fyf
+fyf
+auk
+ijg
+gjP
+gjP
+ijg
+gjP
+dCX
+cWG
+iez
 hko
-fas
-hko
-jiv
-guU
-pcG
-pcG
-pcG
-pcG
-mmT
-kgn
+mvv
+mvv
+mvv
+koD
+uaf
+uaf
+eme
+lae
+bFJ
+dkg
 rVv
 sbt
-lSD
+pKq
 ehN
 ehN
 ehN
@@ -100464,11 +102933,11 @@ gjP
 bkF
 cDL
 cbr
-wOp
-wOp
+rjH
+rjH
 cbr
 mZn
-mvv
+jIz
 mvv
 mvv
 lBY
@@ -100476,11 +102945,11 @@ qTY
 tBN
 pBM
 mvv
-dCL
+ajD
 xGH
-aBH
+dCL
 mfD
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -100642,7 +103111,7 @@ uLk
 mke
 gts
 jRX
-fsl
+pyk
 voF
 ehN
 ehN
@@ -100664,36 +103133,36 @@ pcG
 pcG
 pcG
 pcG
-jIB
+pFM
 qvQ
 ehN
 ehN
 bfu
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-pcG
-rVv
-rVv
-rVv
-rVv
-rVv
+jkJ
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+iez
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
+koD
 uaf
-jIB
+uaf
+uaf
+bFJ
+bFJ
+cam
+uaf
+pFM
 qvQ
 ehN
 ehN
@@ -100724,8 +103193,8 @@ dZS
 dZS
 cbr
 cbr
-cbr
-mvv
+dUO
+jIz
 mvv
 mvv
 bpD
@@ -100739,10 +103208,10 @@ bpD
 fyf
 fyf
 fyf
-ouu
-jNJ
-jNJ
-hGf
+erp
+ubl
+ubl
+rWe
 fyf
 tBN
 qSl
@@ -100838,9 +103307,9 @@ ajW
 afs
 afs
 aOE
-doX
+dCX
 cWG
-daU
+iez
 mvv
 bBJ
 owo
@@ -100876,7 +103345,7 @@ cWG
 cWG
 cWG
 cWG
-daU
+iez
 mvv
 mvv
 mvv
@@ -100942,7 +103411,7 @@ ybI
 ybI
 ybI
 ybI
-dkP
+fLc
 hLv
 sTa
 hkW
@@ -100981,13 +103450,13 @@ btv
 btv
 btv
 mlD
-rpu
-pBM
+aVJ
+wgt
 mvv
 mvv
-doX
+dCX
 cWG
-daU
+iez
 bGM
 mvv
 bpD
@@ -100996,10 +103465,10 @@ bpD
 bGO
 hAC
 fyf
-pKt
+tXS
 tvl
 rfr
-iGZ
+hEf
 fyf
 tBN
 vqx
@@ -101241,7 +103710,7 @@ xGi
 lAW
 mvv
 miA
-dCL
+ajD
 mfD
 mfD
 xGH
@@ -101253,10 +103722,10 @@ bpD
 uey
 fyf
 fyf
-pKt
+tXS
 kNm
 hRN
-pKt
+asz
 fyf
 tBN
 wQS
@@ -101352,7 +103821,7 @@ afs
 afs
 afs
 aOE
-aBH
+dCL
 mfD
 mfD
 mfD
@@ -101369,21 +103838,21 @@ jix
 uqa
 cWG
 cWG
-daU
+iez
 oXD
 mvv
 oXD
 mvv
-doX
+dCX
 cWG
 qQo
 cWG
 cWG
-daU
-aBH
+iez
+dCL
 xGH
 mvv
-aBH
+dCL
 mfD
 mfD
 mfD
@@ -101503,17 +103972,17 @@ xTK
 qOf
 tBN
 mvv
-aBH
-hCg
+dCL
+mcf
 sij
 bpD
 fyf
 sqA
 qsu
-pKt
+tXS
 rrj
 wTy
-pKt
+asz
 fyf
 tBN
 xOr
@@ -101670,7 +104139,7 @@ geS
 sbf
 gts
 jRX
-fsl
+pyk
 voF
 ehN
 ehN
@@ -101746,7 +104215,7 @@ gjP
 uRJ
 gfY
 gmR
-oGS
+xdF
 hPJ
 fct
 jNX
@@ -101758,19 +104227,19 @@ jNJ
 hGf
 wDc
 vAe
-nlO
+oGS
 mfD
-hCg
+mcf
 fyf
 tBN
 bpD
 fyf
 fyf
 fyf
-deJ
+hEd
 ruw
-ruw
-fAM
+pQl
+aNR
 fyf
 tBN
 iuD
@@ -102013,7 +104482,7 @@ pKt
 lsT
 tPD
 pKt
-doX
+dCX
 cWG
 cWG
 cWG
@@ -102145,7 +104614,7 @@ jVO
 mvv
 jVO
 mvv
-aBH
+dCL
 qCb
 qCb
 mfD
@@ -102165,7 +104634,7 @@ fyf
 thG
 mvv
 mvv
-doX
+dCX
 cWG
 cWG
 cWG
@@ -102274,7 +104743,7 @@ mvv
 lEG
 mvv
 mvv
-doX
+dCX
 cWG
 poX
 bpD
@@ -102283,10 +104752,10 @@ tBN
 bpD
 rwj
 mvv
-doX
+dCX
 cWG
 cWG
-iez
+ltK
 mvv
 mvv
 fyV
@@ -102299,7 +104768,7 @@ qst
 pcH
 mvv
 dKW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -102324,10 +104793,10 @@ rtZ
 rtZ
 cpK
 cpK
-vAu
-uTA
-vno
-wLR
+gcK
+gcK
+gcK
+gcK
 sYX
 sYX
 sYX
@@ -102527,19 +104996,19 @@ pKt
 bWe
 vqb
 pKt
-mfD
+dCL
 mfD
 mfD
 mfD
 mfD
 mfD
 xGH
-dCX
+wjO
 wDc
 tBN
 bpD
 tBN
-dCL
+ajD
 mfD
 mfD
 tBc
@@ -102556,7 +105025,7 @@ mGP
 mvv
 mvv
 dKW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -102581,12 +105050,12 @@ kEh
 kEh
 kEh
 kEh
-vAu
-uZg
-vvh
-wRI
-xeG
-ydq
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -102664,7 +105133,7 @@ fyf
 jZk
 nxY
 fyf
-nlO
+oGS
 sYX
 lvy
 lOV
@@ -102749,8 +105218,8 @@ vRZ
 dHN
 vRZ
 rwd
-ajD
-box
+pBX
+pJY
 ehN
 ehN
 ehN
@@ -102780,11 +105249,11 @@ mGP
 aip
 kMn
 qSl
-deJ
-ruw
-ruw
-fAM
-fyf
+jhy
+uxf
+uxf
+sbd
+mcf
 fyf
 sqA
 fyf
@@ -102792,15 +105261,15 @@ jcp
 fyf
 tBN
 mvv
-ppv
-mvv
-doX
-daU
+ulN
+iez
+dCX
+iez
 bpD
 fyf
 uey
 fyf
-oGS
+xdF
 xGH
 txb
 edV
@@ -102838,24 +105307,24 @@ gts
 gts
 gts
 gts
-vAu
-vAu
-wxi
-mwp
-mwp
-mwp
-xny
-fNs
-gcK
-xny
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gbL
 gcK
 gcK
@@ -102916,7 +105385,7 @@ mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 bKy
 fyf
@@ -102954,7 +105423,7 @@ vYv
 vYv
 vYv
 bWh
-hgX
+psR
 unI
 qvQ
 ehN
@@ -103006,8 +105475,8 @@ iWV
 dHN
 vRZ
 rwd
-jIB
-lSD
+pFM
+pKq
 ehN
 ehN
 geM
@@ -103036,8 +105505,8 @@ mvv
 mvv
 jmn
 tAe
-aBH
-fyf
+dCL
+mcf
 fyf
 fyf
 fyf
@@ -103047,13 +105516,13 @@ uey
 fyf
 qOV
 cWG
-daU
+iez
 cqt
 wsC
 mvv
-aBH
+dCL
 mfD
-hCg
+mcf
 pis
 fyf
 fyf
@@ -103097,14 +105566,14 @@ fAr
 gts
 gcK
 gcK
-mwp
-mwp
-mwp
-mwp
-mwp
-mwp
-ylQ
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -103293,7 +105762,7 @@ mvv
 mvv
 mvv
 kTZ
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -103302,8 +105771,8 @@ ayR
 fyf
 fyf
 qOV
-daU
-dCL
+iez
+ajD
 mfD
 mfD
 xGH
@@ -103315,7 +105784,7 @@ fyf
 qOV
 vly
 cWG
-daU
+iez
 mvv
 mvv
 viN
@@ -103327,7 +105796,7 @@ mvv
 hhy
 mvv
 sBk
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -103355,21 +105824,21 @@ gts
 gcK
 gcK
 gcK
-xdG
-mwp
-mwp
-veZ
-mwp
-mwp
-mwp
-mwp
-xdG
-gbL
-gbL
-gbL
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gbL
@@ -103468,7 +105937,7 @@ rUJ
 rkR
 vYv
 bWh
-gNA
+puY
 pBv
 qvQ
 ehN
@@ -103546,10 +106015,10 @@ eme
 lae
 dMW
 thG
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 fyf
 fyf
 sYX
@@ -103558,19 +106027,19 @@ tFR
 fyf
 bGO
 qOV
-iez
+ltK
 mvv
 ozK
 fyf
 uuj
 tBN
 mvv
-bpD
-rDi
+dCX
+hOM
 cWG
 cWG
-daU
-aBH
+iez
+dCL
 mfD
 xGH
 iuD
@@ -103584,7 +106053,7 @@ mvv
 mvv
 mvv
 dKW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -103610,22 +106079,22 @@ rpe
 rob
 gts
 gcK
-gbL
-gbL
-gbL
-aVn
-mwp
-mdv
-mwp
-mwp
-mwp
-aVn
-mdv
-mwp
-mwp
-gbL
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -103726,7 +106195,7 @@ sgr
 vYv
 eAi
 kGc
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -103813,14 +106282,14 @@ jvg
 bad
 kPO
 uCO
-cWG
-daU
-mvv
-aBH
-hCg
+wUL
+xVJ
+cbr
+fGx
+cQC
 uey
 fyf
-iHk
+moH
 mvv
 mvv
 mvv
@@ -103829,19 +106298,19 @@ mvv
 mvv
 bpD
 fyf
-nlO
+oGS
 mfD
 xGH
 mvv
-jaa
-jaa
-jaa
-jaa
+mvv
+mvv
+mvv
+mvv
 mvv
 mvv
 fZD
 dKW
-ajD
+pBX
 qvQ
 rbi
 ehN
@@ -103868,21 +106337,21 @@ gts
 gts
 gcK
 gcK
-gbL
-gbL
-xdG
-ylQ
-mwp
-mwp
-mwp
 gcK
 gcK
-mwp
-mwp
-mwp
-aVn
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -103983,7 +106452,7 @@ pZq
 vYv
 bWh
 kGc
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -104069,19 +106538,19 @@ sYX
 sYX
 jWd
 dhC
-mvv
-dCL
-mfD
-mfD
-hCg
-fyf
+cbr
+kum
+mnh
+mnh
+xKi
+fsV
 pvp
-ouu
+erp
+cVe
 jNJ
 jNJ
-jNJ
-hGf
-wjS
+ukY
+yax
 sXB
 mvv
 bpD
@@ -104089,12 +106558,12 @@ fyf
 fyf
 fyf
 tBN
-bpD
-fyf
-fyf
-fyf
-qOV
-qax
+dCL
+mfD
+mfD
+mfD
+xGH
+scP
 jIR
 mvv
 dKW
@@ -104127,7 +106596,6 @@ gcK
 gcK
 gcK
 gcK
-xny
 gcK
 gcK
 gcK
@@ -104136,11 +106604,12 @@ gcK
 gcK
 gcK
 gcK
-mwp
-mwp
-dcS
-gbL
-gbL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gbL
@@ -104226,13 +106695,13 @@ fyf
 fyf
 tBN
 mvv
-doX
+dCX
 cWG
 cWG
 cWG
-daU
+iez
 mvv
-aBH
+dCL
 gts
 bWh
 gts
@@ -104240,7 +106709,7 @@ gts
 bWh
 gts
 kGc
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -104292,7 +106761,7 @@ tvJ
 vRZ
 rwd
 unI
-box
+pJY
 ehN
 ehN
 koD
@@ -104320,37 +106789,37 @@ thG
 fyf
 sYX
 dhC
-gCU
+wGn
 uCO
 uCO
 uCO
 jWz
-mvv
-mvv
-mcf
-sih
+cbr
+cbr
+szC
+wor
+fsV
+fsV
+hiJ
 fyf
-fyf
-qTY
-fyf
-uVG
+qJy
 jFc
 suQ
 cbr
-pKt
-nlO
+asz
+oGS
 xGH
 ouu
-jNJ
-jNJ
-hGf
+uKC
+ubl
+rWe
 fyf
 tBN
-dCX
+wjO
 cWG
-wDc
-fyf
-hfw
+cWG
+cWG
+iez
 scP
 mvv
 pgM
@@ -104387,16 +106856,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-xSs
-xSs
-xSs
 gcK
 gcK
-xny
-mwp
-mdv
-xdG
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104497,8 +106966,8 @@ plm
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 ehN
 ehN
 koD
@@ -104549,7 +107018,7 @@ vRZ
 vRZ
 rwd
 pBv
-dXy
+pOC
 sgz
 ehN
 koD
@@ -104585,24 +107054,24 @@ uCO
 sDp
 uCO
 sYX
-fyf
-tFR
+fsV
+ddR
 sYX
 sYX
 fyf
-kSZ
+qBa
 mjf
 cbr
 uNL
-pKt
+asz
 fyf
-fyf
+tBN
 pKt
 fAn
 oOd
-pKt
+asz
 fyf
-bRF
+wjS
 ouu
 jNJ
 jNJ
@@ -104612,7 +107081,7 @@ mvv
 erJ
 mvv
 dKW
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -104643,16 +107112,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-sQL
-qMt
-qIS
-cIR
-xSs
 gcK
 gcK
-hNC
-gDL
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -104754,8 +107223,8 @@ plm
 fyf
 atL
 kGc
-pxw
-kYI
+unI
+qvQ
 ehN
 ehN
 koD
@@ -104805,8 +107274,8 @@ gts
 gts
 gts
 gts
-ajD
-dXy
+pBX
+pOC
 sgz
 ehN
 koD
@@ -104847,19 +107316,19 @@ rpu
 odb
 kGD
 fyf
-uVG
+qJy
 cbr
 hRN
 pqB
-pKt
+asz
 fyf
-fyf
+tBN
 pKt
 hRN
 lsT
-iGZ
+hEf
 fyf
-fyf
+tBN
 pKt
 sao
 cbr
@@ -104869,7 +107338,7 @@ mvv
 mvv
 mvv
 sBk
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -104892,7 +107361,7 @@ qoH
 gts
 eeh
 lTB
-nOD
+voq
 hOl
 gcK
 gcK
@@ -104900,16 +107369,16 @@ gcK
 gcK
 gcK
 gcK
-xSs
-xSs
-xSs
-xSs
-hGm
-xSs
 gcK
-gtU
-gDL
-iAU
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105011,8 +107480,8 @@ plm
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 ehN
 ehN
 koD
@@ -105062,8 +107531,8 @@ tFU
 tFU
 tFU
 mcN
-jIB
-dXy
+pFM
+pOC
 sgz
 ehN
 bfu
@@ -105096,11 +107565,11 @@ rkZ
 rpu
 sDp
 kas
-aug
+ezo
 sDp
 rpu
 rpu
-aug
+ezo
 cHN
 sYX
 fyf
@@ -105108,15 +107577,15 @@ tTK
 vqb
 wTy
 oOd
-pKt
+asz
 fyf
-tdv
+sij
 pKt
 tWd
 vej
-pKt
+asz
 fyf
-uey
+tBN
 pKt
 hRN
 lsT
@@ -105150,23 +107619,23 @@ gts
 qvQ
 hOl
 sgz
-hEX
+hOl
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-xSs
-ngw
-nes
-lXu
-cRc
-ega
-giU
-gDL
-imR
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105222,7 +107691,7 @@ mfD
 fcI
 fsN
 djI
-gtn
+sKH
 gSx
 hoH
 hxt
@@ -105260,16 +107729,16 @@ fyf
 fyf
 tBN
 mvv
-doX
+dCX
 cWG
 cWG
-fmR
-fmR
-fmR
-fmR
+igz
+igz
+igz
+igz
 psR
-pxw
-kYI
+unI
+qvQ
 ehN
 ehN
 koD
@@ -105320,7 +107789,7 @@ xHo
 tFU
 mcN
 uyM
-lSD
+pKq
 ehN
 ehN
 oKA
@@ -105350,7 +107819,7 @@ sYX
 rpu
 rpu
 rMz
-aug
+ezo
 uCO
 uOr
 xGi
@@ -105361,19 +107830,19 @@ rpu
 jOH
 jvg
 fyf
-uVG
+qJy
 duF
 iQP
 sXx
-iGZ
+hEf
 fyf
-fyf
-deJ
-ruw
-ruw
-fAM
+oGS
+ogo
+uxf
+uxf
+aNR
 ayR
-fyf
+tBN
 pKt
 aQq
 vqb
@@ -105410,19 +107879,19 @@ dqf
 sgz
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
-xSs
-mlf
-ccN
-nes
-dmg
-xSs
-jay
-gDL
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105479,12 +107948,12 @@ fyf
 fyf
 lsF
 vqj
-gun
+wWN
 vXh
 dEc
 hzm
 qdS
-iHk
+tBN
 mvv
 uqa
 jNJ
@@ -105525,8 +107994,8 @@ cpK
 cpK
 cpK
 cpK
-pxw
-kYI
+unI
+qvQ
 ehN
 ehN
 koD
@@ -105576,7 +108045,7 @@ vrJ
 keT
 tFU
 mcN
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -105620,21 +108089,21 @@ sYX
 fyf
 mZl
 oSA
-vqb
-fAn
-pKt
+xuY
+daX
+kId
 fyf
 fyf
 fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-deJ
-ruw
-ruw
-fAM
+gSt
+psR
+kwB
+kzZ
+kzZ
+jyr
 jaa
 jaa
 jaa
@@ -105669,16 +108138,16 @@ gcK
 gcK
 gcK
 gcK
-gbL
 gcK
-xSs
-iXC
-wcO
-ccN
-oAe
-xSs
-hIi
-mwp
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105736,12 +108205,12 @@ cWG
 cWG
 ftg
 fRR
-gun
+wWN
 dEc
 hqs
 hDJ
 gxW
-iHk
+tBN
 egy
 tKZ
 jOq
@@ -105782,8 +108251,8 @@ ptf
 ptf
 ptf
 puY
-pxw
-kYI
+unI
+qvQ
 pRo
 ehN
 koD
@@ -105833,7 +108302,7 @@ tFU
 tFU
 tFU
 mcN
-jIB
+pFM
 qvQ
 lCv
 lCv
@@ -105865,7 +108334,7 @@ igz
 igz
 igz
 igz
-hgX
+psR
 cpK
 cpK
 jkJ
@@ -105875,18 +108344,18 @@ igz
 igz
 igz
 igz
-deJ
-ruw
-ruw
-ruw
-fAM
+hco
+rqf
+rqf
+aRN
+pfi
 fyf
 fyf
 lob
 fyf
 fyf
-fyf
-rkr
+tVV
+lae
 dkg
 dkg
 uaf
@@ -105924,15 +108393,15 @@ kin
 wNe
 gcK
 gcK
-gbL
 gcK
 gcK
 gcK
 gcK
-xSs
-goj
-bcF
-xSs
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -105998,7 +108467,7 @@ dEc
 rpu
 hJv
 ims
-iHk
+tBN
 lZX
 jfD
 ezZ
@@ -106039,8 +108508,8 @@ fyf
 fyf
 tNX
 kGc
-pxw
-kYI
+unI
+qvQ
 pRy
 ehN
 fLc
@@ -106135,14 +108604,14 @@ ybI
 ybI
 ybI
 ybI
-pfl
+rRR
 fyf
 fyf
 ayR
 fyf
 fyf
 fyf
-fyf
+wIK
 jps
 jps
 sTa
@@ -106255,7 +108724,7 @@ gTs
 dEc
 hJB
 gxW
-iHk
+tBN
 uVG
 jha
 ezZ
@@ -106296,8 +108765,8 @@ hAC
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 tUb
@@ -106432,8 +108901,8 @@ xbX
 xbX
 xbX
 xbX
-hEX
-hEX
+hOl
+hOl
 pfl
 fyf
 gcK
@@ -106554,7 +109023,7 @@ ppm
 fyf
 kGc
 pBv
-kYI
+qvQ
 xyk
 ehN
 ehN
@@ -106658,8 +109127,8 @@ fyf
 qTY
 hCs
 wKo
-snB
-ehN
+hOl
+hOl
 ehN
 ehN
 ehN
@@ -106690,7 +109159,7 @@ ehN
 ehN
 ehN
 dte
-cVX
+uit
 gcK
 gcK
 gcK
@@ -106811,7 +109280,7 @@ fyf
 fyf
 kGc
 oPO
-kYI
+qvQ
 pqO
 ehN
 kaM
@@ -106915,7 +109384,7 @@ fyf
 fyf
 fyf
 ukl
-vMU
+hOl
 vMU
 kaM
 kaM
@@ -106945,7 +109414,7 @@ kaM
 kaM
 kaM
 kaM
-gWo
+kin
 wNe
 wKo
 gcK
@@ -107068,8 +109537,8 @@ psu
 fyf
 jRX
 pyk
-pIS
-pUB
+voF
+ubg
 ehN
 bMz
 ees
@@ -107324,9 +109793,9 @@ mTd
 iWr
 fyf
 kGc
-pxw
-kYI
-pVb
+unI
+qvQ
+tPy
 ehN
 koD
 lDA
@@ -107412,24 +109881,24 @@ ptf
 ptf
 ptf
 ptf
-eCM
 ptf
 ptf
 ptf
 ptf
 ptf
-gNA
+ptf
+puY
 wVn
-pWN
+eme
+plq
 plq
 uPP
 fyf
 fyf
-fyf
 mKI
 rkr
-pRy
-pKq
+kDu
+koD
 gts
 rlf
 hXC
@@ -107581,7 +110050,7 @@ pgL
 wDc
 fyf
 kGc
-pyU
+rxa
 pJQ
 pWt
 ehN
@@ -107677,15 +110146,15 @@ fyf
 fyf
 kGc
 uCW
-pFM
-gWo
+wVq
+pOC
+kin
 mmH
-xaE
 cax
 rkr
 cdp
-mHW
-ehN
+pRo
+pTC
 koD
 gts
 uKY
@@ -107826,10 +110295,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
 ktB
 gcK
 gcK
@@ -107838,8 +110307,8 @@ pon
 bpD
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 fLc
@@ -107934,7 +110403,7 @@ fyf
 fyf
 kGc
 uCW
-ajD
+pBX
 pWN
 plq
 plq
@@ -108078,24 +110547,24 @@ mvv
 fzN
 gcK
 mTd
-oES
+eQq
 gcK
 gcK
 gcK
-gcK
-gcK
+kgn
+dfR
 gcK
 gcK
 gcK
 jHQ
-tZh
+gcK
 tii
 pfK
 iHu
 bpD
 fyf
 kGc
-pzN
+pBv
 pJY
 pqO
 ehN
@@ -108189,13 +110658,13 @@ gcK
 gcK
 gSt
 igz
-hgX
+psR
 cpK
 unI
 qvQ
 ehN
 tPy
-mHW
+pRo
 ehN
 rbi
 ehN
@@ -108305,8 +110774,8 @@ gxW
 eXn
 rXN
 fCM
-bQr
-gxh
+gVp
+ofL
 odZ
 mvv
 mvv
@@ -108336,16 +110805,16 @@ mvv
 mvv
 odZ
 mvv
-ayd
-gcK
-gcK
-mTd
-mTd
-mvv
 mvv
 mvv
 lFX
-pcV
+paa
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 fzN
 bGM
 mvv
@@ -108403,7 +110872,7 @@ edI
 tLZ
 hVr
 ehN
-mHW
+pRo
 sgz
 hOl
 ehN
@@ -108595,14 +111064,14 @@ mvv
 mvv
 mvv
 mvv
-mvv
-fzN
+lFX
+koZ
 mvv
 mvv
 odZ
 mvv
-lFX
-tnu
+mvv
+mvv
 mvv
 mvv
 mvv
@@ -108610,7 +111079,7 @@ bpD
 fyf
 kGc
 pFM
-kYI
+qvQ
 pqO
 ehN
 ehN
@@ -108828,7 +111297,7 @@ rXN
 rXN
 fdV
 jnN
-aBH
+dCL
 mfD
 xGH
 hxO
@@ -108853,13 +111322,13 @@ mvv
 mvv
 mvv
 mvv
-mvv
+kwA
 mvv
 bGM
 mvv
 mvv
 mvv
-pcb
+mvv
 mvv
 mvv
 mvv
@@ -108867,7 +111336,7 @@ bpD
 fyf
 kGc
 oPO
-pLJ
+qnS
 pYj
 ehN
 geM
@@ -108918,7 +111387,7 @@ tFU
 tFU
 ees
 muk
-dXy
+pOC
 hOl
 ehN
 wwM
@@ -109105,25 +111574,25 @@ gcK
 gcK
 mTd
 mTd
-gcK
-bGM
-mvv
-oNR
-odZ
-mvv
-mvv
-mvv
 mvv
 bGM
-lFX
-gnk
+mvv
+mvv
+hNC
+kwL
+mvv
+mvv
+mvv
+bGM
+mvv
+mvv
 mvv
 mvv
 mvv
 bpD
 fyf
 kGc
-pxw
+unI
 pOC
 pRo
 ehN
@@ -109174,8 +111643,8 @@ hva
 utA
 tFU
 cpK
-ajD
-dXy
+pBX
+pOC
 ehN
 ehN
 koD
@@ -109342,7 +111811,7 @@ iqZ
 iqZ
 mAi
 ifc
-doX
+dCX
 cWG
 iez
 hxO
@@ -109360,27 +111829,27 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-ayd
-paa
-gcK
-uPK
+bJB
+bJB
+bJB
+fas
 mvv
-mvv
+gNA
 lFX
-pcV
+paa
+mvv
+mvv
+mvv
+mvv
+mvv
+mvv
 iwR
 mvv
 iHu
 bpD
 fyf
 kGc
-pxw
+unI
 pOC
 pRo
 ehN
@@ -109431,8 +111900,8 @@ uxE
 uxE
 hZj
 cpK
-ajD
-lSD
+pBX
+pKq
 ehN
 ehN
 koD
@@ -109610,35 +112079,35 @@ cfD
 mBg
 xYS
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
+ktB
 gcK
+cQs
+coQ
+coQ
+bJB
+gnk
+gPd
+hVW
+kBd
+mTy
+bRF
+bJB
+uqa
+vAu
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-oKE
-jHQ
 waA
 gcK
 hNo
 bpD
 fyf
 kGc
-pxw
-pQX
+unI
+rQh
 pRo
 ehN
 koD
@@ -109688,7 +112157,7 @@ uxE
 abf
 kMM
 bFJ
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -109867,26 +112336,26 @@ may
 qvX
 xYS
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+cQs
+cIR
+ydO
+fkU
+wLC
+gWo
+imR
+kYI
+rTQ
+nan
+rTQ
+tmw
+vEw
 gcK
 ktB
 gcK
@@ -109894,8 +112363,8 @@ ayd
 ulI
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pRy
 ehN
 koD
@@ -110125,25 +112594,25 @@ mcp
 uXj
 uXj
 uXj
-uXj
+cwO
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+cQs
+cRc
+ydO
+fmR
+wLC
+gWo
+ipE
+wLC
+rTQ
+sYX
+pLJ
+tnu
+vQE
 gcK
 ktB
 gcK
@@ -110151,8 +112620,8 @@ gcK
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -110373,7 +112842,7 @@ jtc
 xwW
 mvv
 stD
-bQr
+gVp
 mvv
 mvv
 qvX
@@ -110382,34 +112851,34 @@ uXj
 uXj
 uXj
 uXj
-lRJ
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+aug
 gcK
 gcK
 gcK
 ktB
+gcK
+bQr
+cVX
+ydO
+fnB
+rTQ
+hau
+ydO
+leq
+rTQ
+oAB
+pQX
+txC
+wcO
+gcK
 gcK
 gcK
 mTd
 nHQ
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -110639,34 +113108,34 @@ uXj
 uXj
 uXj
 uXj
-uXj
+qnz
 gcK
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+bRF
+bJB
+doX
+kih
+uCO
+hfw
+uCO
+lBS
+mTy
+taV
+pUB
+tFP
+wxi
+sYX
 gcK
 gcK
 gcK
 fyf
 eHt
 kGc
-pxw
-pLJ
+unI
+qnS
 pqO
 ehN
 koD
@@ -110899,30 +113368,30 @@ uXj
 uXj
 tQt
 tQt
-tQt
-osF
-ouJ
-ouJ
-oDo
-mTd
-mTd
+oFp
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+dFQ
+fnP
+goj
+hgX
+ira
+lSD
+nes
+uCO
+pVb
+tHN
+ydO
+taV
 gcK
 gcK
 gcK
 fyf
 hAC
 kGc
-pxw
+unI
 pOC
 pYj
 ehN
@@ -111157,29 +113626,29 @@ mBh
 mBh
 mBh
 mBh
-uXj
-uXj
-jxS
-uXj
-tQt
-oFp
-ayd
+aVn
+bnz
+bnz
+daU
+dNW
+fsl
+gsB
+hhC
+gGz
+mMu
+gGz
+uCO
+qax
+tJl
+wLC
+sYX
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-fyf
+tNX
 giS
 kGc
-pxw
+unI
 pOC
 pRo
 ehN
@@ -111407,7 +113876,7 @@ mvv
 ttW
 mvv
 mss
-aBH
+dCL
 stD
 noo
 stD
@@ -111417,26 +113886,26 @@ okS
 uXj
 uXj
 jxS
-uXj
-uXj
-uXj
+qnz
+dXy
+fLx
 oMn
-mTd
+hoz
+iAU
+oNs
+oNs
+oDo
+rTQ
+wLC
+wLC
+xdG
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
-gcK
-fyf
+ptP
 tNX
 kGc
-pxw
+unI
 pOC
 pRo
 ehN
@@ -111566,10 +114035,10 @@ fyf
 fyf
 fyf
 fyf
-nlO
+oGS
 mfD
 mfD
-hCg
+mcf
 xGS
 xXm
 hom
@@ -111663,8 +114132,8 @@ mvv
 mvv
 mvv
 mvv
-dCL
-hCg
+ajD
+mcf
 stD
 stD
 stD
@@ -111673,27 +114142,27 @@ oav
 bEr
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-tQt
-cwO
-ayd
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
+jxS
+qnz
+ebC
+fNq
+gtn
+uCO
+iHk
+oNs
+mMu
+oES
+qin
+tOt
+rTQ
+cQs
 gcK
 gcK
 gcK
 fyf
 fyf
 kGc
-pxw
+unI
 pKq
 pRo
 lCv
@@ -111916,11 +114385,11 @@ mfD
 oCS
 mvv
 mvv
-bQr
+gVp
 odZ
 mvv
-aBH
-hCg
+dCL
+mcf
 fyf
 stD
 stD
@@ -111931,27 +114400,27 @@ nId
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-cwO
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+qnz
+ega
+fNs
+gtU
+hCg
+iLD
+mMu
+ngw
+oGX
+qoN
+uCO
+mTy
+cQC
 gcK
 gcK
 gcK
 knD
 fyf
 kGc
-pxw
-pLJ
+unI
+qnS
 pqO
 ehN
 koD
@@ -112017,8 +114486,8 @@ eRT
 iQs
 rBs
 eeO
-aRl
-aSc
+vlH
+hAw
 vBw
 daB
 etB
@@ -112080,7 +114549,7 @@ fyf
 fyf
 qOV
 uLw
-aBH
+dCL
 jcB
 qod
 fyf
@@ -112188,26 +114657,26 @@ uiy
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-wLF
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+qnz
+ega
+fOs
+oMC
+hCp
+oNs
+mMu
+niD
+oNR
+qER
+tSf
+ydO
+uqa
 gcK
 gcK
 gcK
 wET
 fyf
 kGc
-pxw
+unI
 pOC
 pqO
 ehN
@@ -112258,7 +114727,7 @@ ehN
 atI
 pnA
 cFe
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -112274,8 +114743,8 @@ xVT
 aRl
 aRl
 aRl
-csQ
-ryT
+oiA
+aRl
 aRl
 cYL
 eDy
@@ -112335,9 +114804,9 @@ dMW
 fyf
 siJ
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 hAC
 fyf
 imv
@@ -112445,26 +114914,26 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-jxS
-xab
+qnz
+ejp
+oFK
+gun
+hEh
+aRl
+gGz
+vZr
 oSz
-gcK
-gcK
-gcK
-gcK
-ktB
+qIS
+tSf
+wLC
+ftg
 gcK
 gcK
 gcK
 fyf
 fyf
 kGc
-pxw
+unI
 pOC
 qaq
 ehN
@@ -112702,28 +115171,28 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-uXj
-jxS
+qnz
+elL
+fPb
+guU
+hEX
+iTC
 xAB
-mTd
-gcK
-gcK
-gcK
-gcK
-ktB
+vZr
+oNR
+qMt
+tSf
+wDW
+ffL
 gcK
 gcK
 wET
 fyf
 fyf
 kGc
-pxw
+unI
 pKq
-pVb
+tPy
 ehN
 koD
 dMW
@@ -112863,7 +115332,7 @@ vAe
 wqz
 tBN
 mvv
-doX
+dCX
 dQd
 cWG
 cWG
@@ -112959,27 +115428,27 @@ uXj
 uXj
 uXj
 uXj
-uXj
-uXj
-uXj
-uXj
-jSN
+qnz
+ejp
+fNs
+gxh
+hCg
 oNs
-ayd
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+aRl
+nlO
+pbX
+rDi
+tTV
+mTy
+xeG
 gcK
 gcK
 hAC
 fyf
 bKy
 kGc
-pxw
-kYI
+unI
+qvQ
 pWt
 ehN
 koD
@@ -113108,7 +115577,7 @@ xQh
 xQh
 xQh
 xQh
-gWo
+kin
 mmH
 fyf
 qOV
@@ -113118,7 +115587,7 @@ cWG
 cWG
 cWG
 wqJ
-daU
+iez
 mvv
 mvv
 mvv
@@ -113208,9 +115677,7 @@ gcK
 gcK
 gcK
 gcK
-aip
-uXj
-nJr
+amc
 uXj
 uXj
 uXj
@@ -113218,25 +115685,27 @@ uXj
 uXj
 uXj
 uXj
-uXj
+qnz
+enp
+fUs
 oMC
-mTd
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+hGm
+mMu
+aRl
+nJr
+pcb
+rFc
+tUk
+heY
+cQC
 gcK
 gcK
 wPz
 uey
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -113368,7 +115837,7 @@ sgz
 vnc
 fyf
 fyf
-nlO
+oGS
 iXE
 mvv
 mvv
@@ -113401,7 +115870,7 @@ vJm
 tQV
 xNm
 hom
-bnz
+iDN
 mvv
 bpD
 xys
@@ -113465,36 +115934,36 @@ gcK
 gcK
 gcK
 gcK
-ieV
-jSN
+apk
+awO
 nLj
 uXj
 uXj
 uXj
 uXj
 uXj
-uXj
-uXj
+qnz
+ejp
 oFK
-lGH
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
+gDL
+hCp
+aRl
+lXu
+nJr
+pcb
+rTf
+tZh
+siS
+cQC
 gcK
 gcK
 fyf
 fXX
 fyf
 kGc
-pxw
-kYI
-pUB
+unI
+qvQ
+ubg
 ehN
 koD
 dMW
@@ -113660,7 +116129,7 @@ xXm
 xys
 tBN
 mvv
-doX
+dCX
 hom
 xXm
 gBA
@@ -113727,31 +116196,31 @@ gcK
 gcK
 ieV
 qzI
-jSN
-ovt
 uXj
 uXj
 uXj
-uXj
+qnz
+bRF
+bJB
 oNf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
+gCh
+iXC
+mMu
+nJr
+pcV
+siS
+heY
+rTf
+xny
 gcK
 gcK
 hAC
 fyf
 fyf
 kGc
-pxw
-kYI
-pVb
+unI
+qvQ
+tPy
 ehN
 koD
 dMW
@@ -113822,12 +116291,12 @@ acJ
 xrO
 sYX
 giZ
-nlO
+oGS
 mfD
 mfD
 mfD
 mfD
-hCg
+mcf
 fyf
 qTY
 fyf
@@ -113984,30 +116453,30 @@ gcK
 gcK
 gcK
 gcK
-gcK
-ayd
-oAB
-jxS
+ieV
+box
 uXj
+qnz
+gcK
+gcK
+gcK
+hIi
+jay
+lZP
 nJr
-oNf
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-ktB
-gcK
-gcK
+pcb
+snR
+uAp
+wEs
+uqa
 gcK
 gcK
 fyf
-pfd
+paU
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pWt
 ehN
 koD
@@ -114174,7 +116643,7 @@ hom
 hom
 tBN
 mvv
-aBH
+dCL
 hom
 xXm
 xNm
@@ -114242,29 +116711,29 @@ gcK
 gcK
 gcK
 gcK
-gcK
-mTd
-nLj
-jSN
-qzI
-lGH
+ayd
+bTk
+dcS
 gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-ktB
-gcK
-gcK
+jel
+cQC
+nOD
+hrU
+cQC
+uqa
+uqa
+uqa
 gcK
 dDC
 fyf
 uey
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -114322,7 +116791,7 @@ ldy
 ttq
 oHK
 emn
-dXy
+pOC
 hOl
 ehN
 ehN
@@ -114500,9 +116969,9 @@ gcK
 gcK
 gcK
 gcK
+ieV
+dmg
 gcK
-mTd
-mTd
 gcK
 gcK
 gcK
@@ -114520,8 +116989,8 @@ fyf
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -114579,7 +117048,7 @@ fLc
 ybI
 giZ
 onk
-dXy
+pOC
 sgz
 hOl
 hOl
@@ -114758,7 +117227,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+mTd
 gcK
 gcK
 gcK
@@ -114777,8 +117246,8 @@ fyf
 iGM
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -114850,11 +117319,11 @@ acJ
 xrO
 tKZ
 giZ
-nlO
+oGS
 mfD
 mfD
 mnh
-hCg
+mcf
 fyf
 fyf
 fyf
@@ -114907,7 +117376,7 @@ fyf
 fyf
 qod
 qOV
-daU
+iez
 bpD
 fyf
 fyf
@@ -115034,8 +117503,8 @@ qTY
 fyf
 fyf
 kGc
-pxw
-pLJ
+unI
+qnS
 pqO
 ehN
 koD
@@ -115079,13 +117548,13 @@ iaL
 sQX
 sQX
 ubg
-mHW
+pRo
 ubg
 iaL
 iaL
 wFh
 koD
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -115280,8 +117749,8 @@ gcK
 gcK
 gcK
 gcK
-ktB
 gcK
+ktB
 gcK
 gcK
 gcK
@@ -115291,7 +117760,7 @@ hAC
 xTK
 fyf
 kGc
-pxw
+unI
 pOC
 pqO
 ehN
@@ -115335,14 +117804,14 @@ jyC
 ehN
 sQX
 ubg
-mHW
-mHW
+pRo
+pRo
 ehN
 ehN
 ehN
 gmX
 koD
-jIB
+pFM
 qvQ
 ehN
 ehN
@@ -115452,10 +117921,10 @@ xkl
 wjS
 mvv
 bpD
-nlO
+oGS
 xGH
 mvv
-aBH
+dCL
 qip
 tBN
 mvv
@@ -115548,7 +118017,7 @@ fyf
 fyf
 fyf
 kGc
-pxw
+unI
 pOC
 pqO
 ehN
@@ -115591,15 +118060,15 @@ qvQ
 ehN
 ehN
 sQX
-mHW
-mHW
-bJB
+pRo
+pRo
+pRy
 ehN
 ehN
 wGI
 gmX
 koD
-ofX
+oPO
 qvQ
 ehN
 ehN
@@ -115677,9 +118146,9 @@ fyf
 uCd
 fyf
 fyf
-nlO
+oGS
 mfD
-hCg
+mcf
 gcK
 gcK
 hom
@@ -115694,27 +118163,27 @@ mvv
 mvv
 mvv
 mvv
-doX
+dCX
 qQo
 cWG
 mXe
 cWG
 cWG
 qQo
-daU
+iez
 jTJ
 jzY
 hKd
 udF
-daU
+iez
 mvv
-doX
+dCX
 cWG
-daU
+iez
 mvv
-doX
+dCX
 cWG
-daU
+iez
 mvv
 bpD
 hom
@@ -115805,7 +118274,7 @@ fyf
 fyf
 fyf
 kGc
-pxw
+unI
 pOC
 pqO
 ehN
@@ -115848,8 +118317,8 @@ eeh
 iaL
 iaL
 sQX
-apk
-bJB
+pWt
+pRy
 kLy
 ehN
 iaL
@@ -115863,7 +118332,7 @@ ehN
 koD
 aeZ
 giZ
-doX
+dCX
 wDc
 fyf
 fyf
@@ -116062,7 +118531,7 @@ fyf
 qTY
 fyf
 kGc
-pxw
+unI
 pKq
 pqO
 ehN
@@ -116121,7 +118590,7 @@ koD
 gEA
 giZ
 mvv
-doX
+dCX
 cWG
 wDc
 cax
@@ -116221,7 +118690,7 @@ xvi
 nJz
 mvv
 mvv
-aBH
+dCL
 mfD
 mfD
 hga
@@ -116319,8 +118788,8 @@ fyf
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -116471,7 +118940,7 @@ xUA
 dDL
 jIz
 mvv
-aBH
+dCL
 mfD
 bJo
 pjA
@@ -116572,12 +119041,12 @@ fyf
 uey
 iGM
 fyf
-pfd
+trW
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -116792,7 +119261,7 @@ fyf
 fyf
 fyf
 fyf
-pfd
+trW
 fyf
 fyf
 fyf
@@ -116833,8 +119302,8 @@ fyf
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -116992,7 +119461,7 @@ xYS
 uXj
 gpo
 mvv
-aBH
+dCL
 hom
 vGw
 xsj
@@ -117071,7 +119540,7 @@ fyf
 fyf
 fyf
 fyf
-pfd
+trW
 fyf
 fyf
 fyf
@@ -117080,7 +119549,7 @@ fyf
 fyf
 fyf
 fyf
-pfd
+trW
 fyf
 fyf
 fyf
@@ -117090,8 +119559,8 @@ fyf
 fyf
 fyf
 kGc
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -117141,7 +119610,7 @@ kaM
 kaM
 huu
 qEb
-ajD
+pBX
 qvQ
 ehN
 ehN
@@ -117290,7 +119759,7 @@ gcK
 gcK
 gcK
 gcK
-bQr
+gVp
 mvv
 uXj
 uXj
@@ -117298,57 +119767,57 @@ uXj
 mvv
 odZ
 eWh
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
-fmR
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
+igz
 psR
-pxw
-kYI
+unI
+qvQ
 pqO
 ehN
 koD
@@ -117556,55 +120025,55 @@ mvv
 mvv
 mcN
 mcN
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-fNq
-pGg
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+ybI
+yce
 pqO
 pqO
 ehN
@@ -117706,7 +120175,7 @@ kEh
 bEw
 fyf
 gSt
-hgX
+psR
 cpK
 uCW
 uCW
@@ -117809,58 +120278,58 @@ odZ
 uXj
 uXj
 uXj
-bQr
+gVp
 mvv
 eZI
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
-fnP
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
+xbX
 pqO
 pqO
 pqO
@@ -118277,7 +120746,7 @@ xYS
 uXj
 gpo
 mvv
-doX
+dCX
 mpu
 hom
 wte
@@ -118375,7 +120844,7 @@ ehN
 ehN
 hOl
 sgz
-gWo
+kin
 wKo
 hOl
 hOl
@@ -118631,7 +121100,7 @@ hOl
 ehN
 ehN
 hOl
-gWo
+kin
 ptd
 rlN
 sgz
@@ -118698,7 +121167,7 @@ ehN
 ehN
 hOl
 sgz
-gWo
+kin
 wKo
 sgz
 sgz
@@ -118791,7 +121260,7 @@ xYS
 uXj
 lGd
 mvv
-aBH
+dCL
 cXS
 hom
 ecO
@@ -118954,7 +121423,7 @@ ehN
 ehN
 hOl
 sgz
-gWo
+kin
 ptd
 rlN
 sgz
@@ -119041,12 +121510,12 @@ jEp
 czT
 vSL
 mvv
-doX
+dCX
 cWG
 cWG
 qga
 uAv
-daU
+iez
 mvv
 hgM
 wXo
@@ -119555,7 +122024,7 @@ ubm
 hom
 mvv
 mvv
-aBH
+dCL
 mfD
 mfD
 vvn
@@ -119812,7 +122281,7 @@ sbx
 xys
 mvv
 mvv
-doX
+dCX
 cWG
 uVy
 arN
@@ -120333,7 +122802,7 @@ hom
 hom
 hom
 mvv
-doX
+dCX
 cWG
 cWG
 cWG
@@ -120646,7 +123115,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 cpK
 cpK
 cpK
@@ -120720,7 +123189,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 bFJ
 bFJ
 sUX
@@ -120802,7 +123271,7 @@ ptf
 ptf
 ptf
 ptf
-gNA
+puY
 unI
 qvQ
 ehN
@@ -122219,7 +124688,7 @@ fyf
 tBN
 iXt
 mvv
-aBH
+dCL
 gcK
 gcK
 gcK


### PR DESCRIPTION
## Screenshots
![grafik](https://user-images.githubusercontent.com/69112131/165850682-e4c2b80e-6d99-4f5f-b58a-3a261642f357.png)
![grafik](https://user-images.githubusercontent.com/69112131/165850895-6636ad51-83b5-404d-a9a9-e8ac1350fd74.png)


## About The Pull Request
Adds a little bar to the Khan Khamp to sell drugs in.Re-adds dungeons that were previously removed and adds three new additional places for the second Z-level. Also fixes the blending and second Z-Level on the map PR that added tents.

## Why It's Good For The Game
Fun little expansion on RP for the Khans and a bit more to do for avid dungeon crawlers.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
add: overgrown vault bunker / raider bunker
add: Khan bar
/:cl:
