### PR TITLE
removes the deathclaw gauntlet from legendary claws

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -89,12 +89,6 @@
 	melee_damage_upper = 55
 	armour_penetration = 0.5
 
-/mob/living/simple_animal/hostile/deathclaw/legendary/death(gibbed)
-	var/turf/T = get_turf(src)
-	if(prob(60))
-		new /obj/item/melee/unarmed/deathclawgauntlet(T)
-	. = ..()
-
 /mob/living/simple_animal/hostile/deathclaw/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72014488/165867336-2d9eda25-1e4d-4b58-9ab3-63bdc80d77a2.png)

more seriously, deathclaws shouldn't drop this shit