### PR TITLE
Adds anti_armour_damage values for high-end bullets

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -957,6 +957,8 @@
 	return TRUE
 
 /obj/mecha/container_resist(mob/living/user)
+	if(occupant)
+		occupant.SetSleeping(destruction_sleep_duration*2)
 	go_out()
 
 /obj/mecha/Exited(atom/movable/M, atom/newloc)

--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -42,7 +42,7 @@
 		return FALSE
 	var/mob/living/carbon/human/H = locate(/mob/living/carbon/human) in range(radius, get_turf(src))
 	var/obj/mecha/M = locate(/obj/mecha) in range(radius, get_turf(src))
-	if(!H?.client && !M)
+	if(!H?.client && !M?.occupant)
 		return FALSE
 	toggle_fire(FALSE)
 	addtimer(CALLBACK(src, .proc/toggle_fire), spawn_time)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -9,7 +9,14 @@
 	hitsound_wall = "ricochet"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 	sharpness = SHARP_POINTY
+	var/anti_armour_damage = 0
 
 /obj/item/projectile/bullet/smite
 	name = "divine retribution"
 	damage = 10
+
+/obj/item/projectile/bullet/on_hit(atom/target)
+	if(ismecha(target))
+		var/obj/mecha/M = target
+		M.take_damage(anti_armour_damage)
+	return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -338,11 +338,13 @@ Uranium, Contaminated
 	damage = 0
 	wound_bonus = 18
 	bare_wound_bonus = -24
+	anti_armour_damage = 30
 
 /obj/item/projectile/bullet/c4570/explosive
 	damage = -15
 	pixels_per_second = TILES_TO_PIXELS(500)
 	name = ".45-70 explosive bullet"
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/c4570/explosive/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -354,6 +356,7 @@ Uranium, Contaminated
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	var/acid_type = /datum/reagent/toxin/acid/fluacid
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/c4570/acid/Initialize()
 	. = ..()
@@ -451,6 +454,7 @@ Uranium, Contaminated
 	damage = 0
 	armour_penetration = 0.8 //rare AP pistol ammo
 	var/piercing = FALSE
+	anti_armour_damage = 30
 
 
 ////////////////

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -338,7 +338,7 @@ Uranium, Contaminated
 	damage = 0
 	wound_bonus = 18
 	bare_wound_bonus = -24
-	anti_armour_damage = 30
+	anti_armour_damage = 20
 
 /obj/item/projectile/bullet/c4570/explosive
 	damage = -15
@@ -376,6 +376,7 @@ Uranium, Contaminated
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	pixels_per_second = TILES_TO_PIXELS(500)
+	anti_armour_damage = 15
 
 /obj/item/projectile/bullet/c4570/knockback/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -143,11 +143,13 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 0
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
+	anti_armour_damage = 40
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = -10
 	var/fire_stacks = 4
 	zone_accuracy_factor = 100
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/a50MG/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -158,6 +160,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a50MG/explosive
 	damage = -20
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/a50MG/explosive/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -169,11 +172,13 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	stamina = 80
 	armour_penetration = 0
 	sharpness = SHARP_NONE
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/a50MG/penetrator
 	name = ".50 penetrator round"
 	damage = -10
 	movement_type = FLYING | UNSTOPPABLE
+	anti_armour_damage = 60
 
 /obj/item/projectile/bullet/a50MG/uraniumtipped
 	name = "12.7mm uranium-tipped bullet"
@@ -185,6 +190,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	name = "12.7mm contaminated bullet"
 	damage = -10
 	var/smoke_radius = 1
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/a50MG/contam/Initialize()
 	. = ..()
@@ -326,6 +332,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 0
 	armour_penetration = 0.9 //if only one bullet has built in AP, its this one
 	pixels_per_second = TILES_TO_PIXELS(100)
+	anti_armour_damage = 40
 
 
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town
@@ -340,6 +347,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	ricochet_decay_chance = 11
 	ricochet_chance = 100
 	var/collats = 3
+	anti_armour_damage = 0
 
 /obj/item/projectile/bullet/c2mm/blender/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)
 	if(isliving(target) && collats)

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -143,7 +143,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 0
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
-	anti_armour_damage = 40
+	anti_armour_damage = 30
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = -10
@@ -178,7 +178,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	name = ".50 penetrator round"
 	damage = -10
 	movement_type = FLYING | UNSTOPPABLE
-	anti_armour_damage = 60
+	anti_armour_damage = 50
 
 /obj/item/projectile/bullet/a50MG/uraniumtipped
 	name = "12.7mm uranium-tipped bullet"
@@ -332,7 +332,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 0
 	armour_penetration = 0.9 //if only one bullet has built in AP, its this one
 	pixels_per_second = TILES_TO_PIXELS(100)
-	anti_armour_damage = 40
+	anti_armour_damage = 30
 
 
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -20,9 +20,6 @@
 	..()
 	explosion(target, -1, 1, 3, 1, 0, flame_range = 4)
 
-	if(ismecha(target))
-		var/obj/mecha/M = target
-		M.take_damage(anti_armour_damage)
 	if(issilicon(target))
 		var/mob/living/silicon/S = target
 		S.take_overall_damage(anti_armour_damage*0.75, anti_armour_damage*0.25)

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -13,8 +13,8 @@
 	desc = "USE A WEEL GUN"
 	icon_state= "84mm-hedp"
 	damage = 0
-	var/anti_armour_damage = 200
 	ricochets_max = 0
+	anti_armour_damage = 200
 
 /obj/item/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request

This PR moves the anti_armour_damage var to bullets, and adds it to .45-70, AMR, needler and Gauss rounds.
Also makes mob_spawners not spawn mobs if there's an empty mecha nearby, now it checks for an occupant.

## Why It's Good For The Game

Mechas are a bit too tanky against high-end anti-armour weapons so this makes those weapons more desirable when dealing with mechas.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

:cl:
tweak: mob spawners don't care about empty mechas, buffs high-end weapons against mechas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
