### PR TITLE
Mechs are overtuned.

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -1,6 +1,5 @@
 /obj/mecha/combat
 	force = 30
-	attack_knockdown = 10
 	internal_damage_threshold = 50
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 15, "energy" = 20, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -9,12 +9,11 @@
 	icon_state = "durand"
 	step_in = 4
 	dir_in = 1 //Facing North.
-	max_integrity = 800
+	max_integrity = 600
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 75, "fire" = 100, "acid" = 100)
 	max_temperature = 30000
 	infra_luminosity = 8
-	force = 35
-	attack_knockdown = 15
+	force = 30
 	canstrafe = TRUE
 	step_energy_drain = 40
 	internal_damage_threshold = 20

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -23,7 +23,7 @@
 	name = "\improper Dark Gygax"
 	desc = "A lightweight exosuit, painted in a dark scheme. This model appears to have some modifications."
 	icon_state = "darkgygax"
-	max_integrity = 550
+	max_integrity = 500
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 60, "energy" = 40, "bomb" = 35, "bio" = 0, "rad" = 100, "fire" = 100, "acid" = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 100

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -8,7 +8,7 @@
 	desc = "A retrofit of the orginal 'Durand' exosuit designed for extended combat operations, the shield projector has been replaced with a smoke-screen dispenser and a sophisticated sensor suite."
 	icon_state = "marauder"
 	step_in = 5
-	max_integrity = 900
+	max_integrity = 700
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 75, "fire" = 100, "acid" = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
@@ -17,8 +17,7 @@
 	add_req_access = 0
 	internal_damage_threshold = 10
 	step_energy_drain = 60
-	force = 50 // Just don't go near that thing, or do, it can't strafe.
-	attack_knockdown = 20
+	force = 40 // Just don't go near that thing, or do, it can't strafe.
 	canstrafe = FALSE
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)


### PR DESCRIPTION
Reduced mech health. 
Removes Attack knockdown - Stun based combat isn't fun who knew?
Reduces melee damage back down to acceptable levels.

Since Mechs are printable power armor that only requires research and Mats this was bound to happen eventually. 