### PR TITLE
Fixes EMP not working on PA + ESD ammo + Radio bug

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -393,7 +393,7 @@
 			to_chat(user, "<span class='notice'>The radio can no longer be modified or attached!</span>")
 	else
 		return ..()
-
+/*
 /obj/item/radio/emp_act(severity)
 	. = ..()
 	if (. & EMP_PROTECT_SELF)
@@ -406,7 +406,7 @@
 		for (var/ch_name in channels)
 			channels[ch_name] = 0
 		on = FALSE
-
+*/
 ///////////////////////////////
 //////////Borg Radios//////////
 ///////////////////////////////

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -296,33 +296,29 @@
 		return
 	if(!powered)
 		return
-	if(emped == 0)
-		if(ismob(loc))
+	if(!emped)
+		if(isliving(loc))
 			var/mob/living/L = loc
+			var/induced_slowdown = 0
 			if(severity >= 41) //heavy emp
-				slowdown += 4
-				to_chat(loc, "<span class='boldwarning'>Warning: severe electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
-				emped = 1
-				if(istype(L))
-					L.update_equipment_speed_mods()
-				spawn(50) //5 seconds of being really slow
-					to_chat(loc, "<span class='notice'>Power armor systems restored.</span>")
-					slowdown -= 4
-					emped = 0
-					if(istype(L))
-						L.update_equipment_speed_mods()
+				induced_slowdown = 4
+				to_chat(L, "<span class='boldwarning'>Warning: severe electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
 			else
-				slowdown +=2
-				to_chat(loc, "<span class='warning'>Warning: light electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
-				emped = 1
-				if(istype(L))
-					L.update_equipment_speed_mods()
-				spawn(50) //5 seconds of being slow
-					to_chat(loc, "<span class='notice'>Power armor systems restored.</span>")
-					slowdown -= 2
-					emped = 0
-					if(istype(L))
-						L.update_equipment_speed_mods()
+				induced_slowdown = 2
+				to_chat(L, "<span class='warning'>Warning: light electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
+			emped = TRUE
+			slowdown += induced_slowdown
+			L.update_equipment_speed_mods()
+			addtimer(CALLBACK(src, .proc/end_emp_effect, induced_slowdown), 50)
+	return
+
+/obj/item/clothing/suit/armor/f13/power_armor/proc/end_emp_effect(slowdown_induced)
+	emped = FALSE
+	slowdown -= slowdown_induced // Even if armor is dropped it'll fix slowdown
+	if(isliving(loc))
+		var/mob/living/L = loc
+		to_chat(L, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
+		L.update_equipment_speed_mods()
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45b
 	name = "salvaged T-45b power armor"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -264,6 +264,7 @@
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	var/requires_training = TRUE
 	var/powered = TRUE
+	var/emped = 0
 
 /obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, mob/equipper, slot, disable_warning = 1)
 	var/mob/living/carbon/human/H = user
@@ -295,23 +296,33 @@
 		return
 	if(!powered)
 		return
-	if(isliving(loc) && prob(severity*1.5))
-		var/time_slowed = severity / 10 SECONDS
-		var/mob/living/L = loc
-		to_chat(L, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
-		slowdown += 1.2
-		if(istype(L))
-			L.update_equipment_speed_mods()
-		addtimer(CALLBACK(src, .proc/end_emp_effect), time_slowed)
-
-/obj/item/clothing/suit/armor/f13/power_armor/proc/end_emp_effect()
-	if(isliving(loc))
-		var/mob/living/L = loc
-		slowdown -= 1.2
-		to_chat(L, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
-		if(istype(L))
-			L.update_equipment_speed_mods()
-	return TRUE
+	if(emped == 0)
+		if(ismob(loc))
+			var/mob/living/L = loc
+			if(severity >= 41) //heavy emp
+				slowdown += 4
+				to_chat(loc, "<span class='boldwarning'>Warning: severe electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
+				emped = 1
+				if(istype(L))
+					L.update_equipment_speed_mods()
+				spawn(50) //5 seconds of being really slow
+					to_chat(loc, "<span class='notice'>Power armor systems restored.</span>")
+					slowdown -= 4
+					emped = 0
+					if(istype(L))
+						L.update_equipment_speed_mods()
+			else
+				slowdown +=2
+				to_chat(loc, "<span class='warning'>Warning: light electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
+				emped = 1
+				if(istype(L))
+					L.update_equipment_speed_mods()
+				spawn(50) //5 seconds of being slow
+					to_chat(loc, "<span class='notice'>Power armor systems restored.</span>")
+					slowdown -= 2
+					emped = 0
+					if(istype(L))
+						L.update_equipment_speed_mods()
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45b
 	name = "salvaged T-45b power armor"

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion/weak
+	projectile_type = /obj/item/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/f13weapons/pulsegunfire.ogg'
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -49,18 +49,13 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c22/shock
 	name = ".22lr shock bullet"
-	damage = -8 //about -50% damage
+	damage = -4 //about -25% damage
 	wound_bonus = 0
 	sharpness = SHARP_NONE
-	var/energy_damage = 5
 
 /obj/item/projectile/bullet/c22/shock/on_hit(atom/target, blocked = FALSE)
 	..()
-	target.emp_act(5)//5 severity is very, very low
-	if(blocked != 100 && isliving(target))
-		var/mob/living/L = target
-		L.electrocute_act(energy_damage, "shock bullet", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) //this might be spammy todo: check
-		//if it is, use O.take_damage(energy_damage, BURN, "energy", FALSE)
+	target.emp_act(15)//5 severity is very, very low
 
 /////////////////
 // .38 SPECIAL //

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -264,14 +264,10 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	name = "4.73mm shock bullet"
 	wound_bonus = 0
 	sharpness = SHARP_NONE
-	var/energy_damage = 4
 
 /obj/item/projectile/bullet/a473/shock/on_hit(atom/target, blocked = FALSE)
 	..()
-	target.emp_act(5)//5 severity is very, very low
-	if(blocked != 100 && isliving(target))
-		var/mob/living/L = target
-		L.electrocute_act(energy_damage, "shock bullet", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)
+	target.emp_act(15)//5 severity is very, very low
 
 /obj/item/projectile/bullet/a473/hv
 	name = "4.73mm highvelocity bullet"
@@ -299,15 +295,10 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = -6 //about -30% damage
 	wound_bonus = 0
 	sharpness = SHARP_NONE
-	var/energy_damage = 5
 
 /obj/item/projectile/bullet/m5mm/shock/on_hit(atom/target, blocked = FALSE)
 	..()
-	target.emp_act(5)//5 severity is very, very low
-	if(blocked != 100 && isliving(target))
-		var/mob/living/L = target
-		L.electrocute_act(energy_damage, "shock bullet", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) //this might be spammy todo: check
-		//if it is, use O.take_damage(energy_damage, BURN, "energy", FALSE)
+	target.emp_act(15)//5 severity is very, very low
 
 //////////////////////////
 // 5 MM minigun special //


### PR DESCRIPTION
EMP just no longer disables headsets. It wasn't a liked mechanic and previously EMPs were bugged and permanently broke headsets due to someone changing the EMP code.

PA EMP code was reworked (made worse) because previously, the percentage based chance in regards to EMP and EMP severity and so forth basically resulted in PA, paradoxically, protecting you against EMPs and never being affected by pulse grenades, etc.

Now, EMP respects severity and applies slowdown. Heavy EMP (pulse grenade close blast radius) will slow you down significantly, where the pulse rifle will only slow you down somewhat, as will ESD ammo.

In the future, if you want to make PA more or less vulnerable to a different kind of EMP, simply add another if check for an EMP's given severity. For instance, ESD has a severity of 15, so fi you wanted PA to be slowed down less by ESD than the pulse rifle, you would add a check for 15 severity EMP.

ESD also no longer does 5 burn across your whole body anymore. It's just EMP ammo.