### PR TITLE
Fixes rockets + Nerfs mechs further

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -9,7 +9,7 @@
 	icon_state = "durand"
 	step_in = 4
 	dir_in = 1 //Facing North.
-	max_integrity = 600
+	max_integrity = 400
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30, "energy" = 30, "bomb" = 35, "bio" = 0, "rad" = 75, "fire" = 100, "acid" = 100)
 	max_temperature = 30000
 	infra_luminosity = 8

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -8,7 +8,7 @@
 	desc = "A retrofit of the orginal 'Durand' exosuit designed for extended combat operations, the shield projector has been replaced with a smoke-screen dispenser and a sophisticated sensor suite."
 	icon_state = "marauder"
 	step_in = 5
-	max_integrity = 700
+	max_integrity = 500
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 0, "rad" = 75, "fire" = 100, "acid" = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -99,7 +99,7 @@
 	var/attack_knockdown = 0 // For how much time it will knockdown a target in melee
 
 	var/exit_delay = 40 //Time to exit mech
-	var/destruction_sleep_duration = 20 //Time that mech pilot is put to sleep for if mech is destroyed
+	var/destruction_sleep_duration = 50 //Time that mech pilot is put to sleep for if mech is destroyed
 	var/enter_delay = 40 //Time taken to enter the mech
 
 	var/is_currently_ejecting = FALSE //Mech cannot use equiptment when true, set to true if pilot is trying to exit mech

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -91,7 +91,7 @@
 
 /obj/item/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
 	..()
-	explosion(target, 0, 1, 2, 4)
+	explosion(target, 0, 0, 2, 4)
 	new /obj/effect/temp_visual/explosion(get_turf(target))
 	return BULLET_ACT_HIT
 
@@ -99,7 +99,7 @@
 	name ="\improper high yield HE missile"
 	desc = "Boom plus."
 	icon_state = "missile"
-	damage = 35
+	damage = 15
 	ricochets_max = 0 //it's a MISSILE
 
 /obj/item/projectile/bullet/a84mm_he_big/on_hit(atom/target, blocked=0)


### PR DESCRIPTION
Someone snuck in a buff to LHE rockets that made them actually good.

They're not supposed to be good. 1,2,4 is not okay. Reverts this change and puts it back to its usual.

Reduces mecha health significantly, considering their immense armor. These are not meant to be printable power armor, nor are they meant to win raids. They're meant to be gimmick items you can build _if you want._ They're pretty cheap to construct en masse, more or less, so it's annoying to see them being used legitimately as weapons. At best, they're meant for base defense or smashing walls. 

600 HP and 50% bullet protection was ridiculous.