### PR TITLE
EMPs kill simple mob robots

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -71,6 +71,13 @@
 		visible_message(span_danger("\The [Proj] bounces off \the [src]'s armor plating!"))
 		return FALSE
 
+/mob/living/simple_animal/hostile/securitron/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	var/emp_damage = round((maxHealth * 0.1) * (severity * 0.1)) // 10% of max HP * 10% of severity(Usually around 20-40)
+	adjustBruteLoss(emp_damage)
+
 /mob/living/simple_animal/hostile/securitron/proc/do_death_beep()
 	playsound(src, 'sound/machines/triple_beep.ogg', 75, TRUE)
 	visible_message(span_warning("You hear an ominous beep coming from [src]!"), span_warning("You hear an ominous beep!"))

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -49,6 +49,13 @@
 	..()
 	name = "ED-[rand(1,99)]"
 
+/mob/living/simple_animal/hostile/eyebot/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	var/emp_damage = round((maxHealth * 0.1) * (severity * 0.1)) // 10% of max HP * 10% of severity(Usually around 20-40)
+	adjustBruteLoss(emp_damage)
+
 /mob/living/simple_animal/hostile/eyebot/playable
 	ranged = FALSE
 	health = 200
@@ -108,11 +115,18 @@
 	attack_sound = 'sound/voice/liveagain.ogg'
 	butcher_results = list(/obj/effect/gibspawner/robot = 1)
 	blood_volume = 0
-	
+
 /mob/living/simple_animal/pet/dog/eyebot/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/wuv, "beeps happily!", EMOTE_AUDIBLE)
 	AddElement(/datum/element/mob_holder, held_icon)
+
+/mob/living/simple_animal/pet/dog/eyebot/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	var/emp_damage = round((maxHealth * 0.1) * (severity * 0.1)) // 10% of max HP * 10% of severity(Usually around 20-40)
+	adjustBruteLoss(emp_damage)
 
 /mob/living/simple_animal/pet/dog/eyebot/playable
 	health = 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Adds emp_act to 2 simple mob types. They receive damage based on their max health and the severity of EMP.

## Why It's Good For The Game

So, I was observing today and witnessed poor wastelander trying to use ion gun on an assaultron. Obviously it didn't work, which is sad, and wastie died. This PR fixes it.
Jokes aside, it both makes sesnse and isn't too strong, just an option to use EMPs against robots.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
