### PR TITLE
Fixes the "Nothing" tile underneath doors

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -3906,7 +3906,7 @@
 	obj_integrity = 400;
 	req_access_txt = "123"
 	},
-/turf/open/space/basic,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
 "oR" = (
 /obj/structure/tires/five,
@@ -3981,7 +3981,7 @@
 	obj_integrity = 400;
 	req_access_txt = "123"
 	},
-/turf/open/space/basic,
+/turf/open/indestructible/ground/outside/woodalt,
 /area/f13/wasteland)
 "pf" = (
 /obj/structure/chair/wood{
@@ -5478,6 +5478,7 @@
 	color = "#363636"
 	},
 /obj/structure/table,
+/obj/item/book/granter/trait/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "uT" = (
@@ -10311,6 +10312,10 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"ON" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "OO" = (
 /obj/structure/barricade/wooden,
 /obj/structure/fence/wooden{
@@ -10475,12 +10480,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
 "Pq" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/space/basic,
-/area/f13/raiders)
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -11872,6 +11877,11 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
+"Vg" = (
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "Vh" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -12012,7 +12022,7 @@
 	},
 /area/f13/caves)
 "VF" = (
-/obj/machinery/smartfridge/bottlerack/drug_storage,
+/obj/machinery/smartfridge/bottlerack/alchemy_rack,
 /turf/open/floor/carpet/black,
 /area/f13/wasteland)
 "VH" = (
@@ -12021,8 +12031,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "VJ" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/black,
 /area/f13/wasteland)
 "VL" = (
@@ -58536,7 +58548,7 @@ Pb
 XS
 nX
 Pn
-Pq
+nX
 rb
 PL
 PL
@@ -59114,7 +59126,7 @@ Gk
 JA
 Ty
 Yg
-Ty
+Pq
 al
 zx
 Gk
@@ -59371,7 +59383,7 @@ HG
 al
 Ub
 YO
-Ub
+ON
 al
 Dp
 sT
@@ -64643,7 +64655,7 @@ gv
 sU
 qG
 OC
-VJ
+vY
 Jk
 kC
 kC
@@ -64887,20 +64899,20 @@ Xs
 of
 lP
 Ks
-OC
+VJ
 IP
 IP
 vY
-vY
+Vg
 sU
-OC
+VJ
 IP
 vY
-vY
+Vg
 sU
-OC
+VJ
 rz
-vY
+Vg
 Jk
 kC
 kC

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -831,6 +831,7 @@
 /area/f13/wasteland)
 "apm" = (
 /obj/structure/table/reinforced,
+/obj/item/healthanalyzer,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
 "apw" = (
@@ -2978,6 +2979,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/bodypart/r_leg/robot,
+/obj/item/bodypart/l_leg/robot,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "bjT" = (
@@ -3608,6 +3611,7 @@
 /obj/structure/table/wood,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bvr" = (
@@ -4430,7 +4434,7 @@
 	},
 /area/f13/wasteland)
 "bMP" = (
-/obj/machinery/autolathe,
+/obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bNg" = (
@@ -5536,10 +5540,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cna" = (
-/obj/structure/simple_door/metal/fence{
-	door_type = "fence_wood";
-	icon_state = "fence_wood"
-	},
+/obj/machinery/door/unpowered/secure_legion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cng" = (
@@ -7670,12 +7671,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "dhK" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/campfire/stove,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "dhQ" = (
 /obj/structure/displaycase,
 /obj/item/clothing/gloves/ring/silver,
@@ -9042,9 +9040,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dHX" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "dIj" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -10406,9 +10406,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ekT" = (
-/obj/structure/decoration/rag,
-/obj/structure/campfire/stove,
-/turf/closed/wall/f13/wood/house,
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/wood,
 /area/f13/raiders)
 "ekW" = (
 /obj/structure/toilet{
@@ -10785,10 +10784,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "erY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/pusher,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "esc" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11548,12 +11547,9 @@
 	},
 /area/f13/wasteland)
 "eHQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/gallow,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "eIA" = (
 /obj/item/kitchen/knife,
 /obj/structure/dresser,
@@ -13223,6 +13219,7 @@
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
+/obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "fqg" = (
@@ -18247,6 +18244,7 @@
 /obj/structure/chair/f13chair1{
 	dir = 8
 	},
+/obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hgJ" = (
@@ -18393,9 +18391,9 @@
 	},
 /area/f13/building)
 "hiN" = (
-/obj/structure/closet/crate/grave,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "hiT" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -18699,6 +18697,9 @@
 /area/f13/wasteland)
 "hnU" = (
 /obj/structure/rack/shelf_metal,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "hoe" = (
@@ -21006,6 +21007,7 @@
 /area/f13/wasteland)
 "ifc" = (
 /obj/structure/chair/sofa/left,
+/obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
 "ifq" = (
@@ -21884,6 +21886,7 @@
 /area/f13/building)
 "izg" = (
 /obj/item/flashlight/lantern,
+/obj/item/mining_scanner,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "izn" = (
@@ -24139,6 +24142,7 @@
 /area/f13/wasteland)
 "jnN" = (
 /obj/structure/chair/sofa/right,
+/obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "jnW" = (
@@ -25496,9 +25500,11 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "jSw" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jSx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -25932,7 +25938,7 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "kag" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "kai" = (
@@ -26158,6 +26164,7 @@
 /obj/structure/chair/f13foldupchair{
 	dir = 4
 	},
+/obj/effect/landmark/start/f13/pusher,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "keR" = (
@@ -26594,6 +26601,11 @@
 	color = "#363636"
 	},
 /obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/raiders)
 "kmA" = (
@@ -27200,9 +27212,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kAJ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "kAT" = (
@@ -27553,6 +27566,7 @@
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/raiders)
 "kHC" = (
@@ -29776,7 +29790,7 @@
 	},
 /area/f13/wasteland)
 "lCw" = (
-/obj/machinery/workbench,
+/obj/machinery/autolathe,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "lDq" = (
@@ -32176,7 +32190,24 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mwZ" = (
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "mxl" = (
@@ -34196,6 +34227,14 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
+"nku" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "nkz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -34542,8 +34581,8 @@
 /turf/open/water,
 /area/f13/caves)
 "nrN" = (
-/obj/structure/closet/crate/grave,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/door/unpowered/secure_legion,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nrS" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -37395,12 +37434,18 @@
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/building)
 "oCS" = (
-/obj/effect/landmark/start/f13/pusher,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 50
 	},
-/area/f13/wasteland)
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "oCW" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38717,6 +38762,7 @@
 /obj/item/grenade/frag,
 /obj/item/grenade/frag,
 /obj/structure/table,
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "pgl" = (
@@ -39471,10 +39517,13 @@
 	},
 /area/f13/building)
 "pvY" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pwc" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -40002,7 +40051,6 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pIy" = (
@@ -43196,6 +43244,8 @@
 /area/f13/building)
 "qYW" = (
 /obj/machinery/smartfridge/bottlerack/gardentool/primitive,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "qZc" = (
@@ -46399,7 +46449,6 @@
 /area/f13/building)
 "sta" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /obj/structure/table,
 /obj/machinery/workbench/bottler,
 /turf/open/floor/f13/wood,
@@ -47600,10 +47649,13 @@
 	},
 /area/f13/building)
 "sSm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack/alchemy_rack,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/closet/crate/trashcart,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "sSo" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/floor/f13/wood,
@@ -48307,9 +48359,7 @@
 /area/f13/wasteland)
 "thK" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood/f13/oak,
 /area/f13/caves)
 "thM" = (
@@ -49794,9 +49844,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "tOD" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/campfollower,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "tOF" = (
@@ -52367,19 +52417,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland)
-"uNV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "uNW" = (
 /obj/structure/window/fulltile/ruins,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -56002,6 +56039,7 @@
 	name = "gate"
 	},
 /obj/structure/decoration/rag,
+/obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirt"
@@ -56134,6 +56172,7 @@
 /area/f13/wasteland)
 "wue" = (
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/secure_legion,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "wuk" = (
@@ -56254,6 +56293,7 @@
 /area/f13/village)
 "wxc" = (
 /obj/structure/decoration/rag,
+/obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
@@ -57852,7 +57892,7 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
 /obj/item/reagent_containers/blood/radaway,
-/obj/item/book/granter/trait/lowsurgery,
+/obj/item/book/granter/trait/midsurgery,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/village)
 "xdt" = (
@@ -72662,9 +72702,9 @@ lpu
 wvV
 wvV
 ayH
-hiN
 mLc
-nrN
+eHQ
+fyf
 fyf
 wZe
 fyf
@@ -73176,9 +73216,9 @@ wvV
 ayH
 ayH
 mLc
-hiN
+mLc
+wZe
 fyf
-nrN
 fyf
 wZe
 fyf
@@ -73690,9 +73730,9 @@ wvV
 ayH
 gcK
 mLc
-nrN
 fyf
-nrN
+wZe
+fyf
 fyf
 wZe
 fyf
@@ -104999,42 +105039,42 @@ ktB
 "}
 (173,1,1) = {"
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -106563,7 +106603,7 @@ mvv
 amy
 hxt
 hMz
-hMz
+dHX
 qOn
 hnU
 gSx
@@ -108650,7 +108690,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -108884,9 +108924,9 @@ mvv
 mvv
 mvv
 mvv
-dhK
+fzN
 mvv
-jSw
+mvv
 egW
 vfU
 iqZ
@@ -108908,7 +108948,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -109131,7 +109171,7 @@ iCH
 qdS
 lPT
 aLd
-jSw
+mvv
 stD
 stD
 mvv
@@ -109165,8 +109205,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -109381,8 +109421,8 @@ gcK
 ktB
 gcK
 gcK
-ekT
-hMz
+cQs
+dhK
 hMz
 ebx
 eBu
@@ -109423,7 +109463,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -109645,7 +109685,7 @@ edF
 qdS
 eUD
 fdV
-dHX
+jIz
 gVp
 ofL
 mvv
@@ -110429,7 +110469,7 @@ jnN
 dCL
 mfD
 xGH
-hxO
+erY
 stD
 clL
 aLd
@@ -110686,7 +110726,7 @@ xay
 bpD
 vhB
 tBN
-hxO
+erY
 mvv
 vDb
 jIz
@@ -110943,7 +110983,7 @@ ifc
 wjO
 cWG
 ltK
-hxO
+erY
 mvv
 cdL
 fLf
@@ -112225,10 +112265,10 @@ jft
 ezZ
 uOu
 jEb
-jSw
+mvv
 mvv
 stD
-jSw
+mvv
 mvv
 mvv
 lFm
@@ -112994,9 +113034,9 @@ jiT
 gOD
 ezZ
 iKG
-iSi
+ekT
 eFA
-jSw
+mvv
 stD
 kGe
 mvv
@@ -113257,9 +113297,9 @@ fff
 mvv
 mvv
 stD
-mvv
-mvv
-mvv
+qTe
+qTe
+qTe
 mvv
 dCL
 mcf
@@ -113511,7 +113551,7 @@ dEc
 iEp
 jDk
 mfD
-oCS
+xGH
 mvv
 mvv
 gVp
@@ -116104,7 +116144,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -116361,7 +116401,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -116618,7 +116658,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ktB
 gcK
 gcK
 gcK
@@ -116866,16 +116906,16 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
+ktB
 gcK
 gcK
 gcK
@@ -120355,11 +120395,11 @@ ehN
 ehN
 koD
 dMW
-nrN
+fyf
 mLc
-hiN
 mLc
-hiN
+mLc
+mLc
 mLc
 gcK
 gcK
@@ -120612,12 +120652,12 @@ ehN
 ehN
 koD
 dMW
-nrN
+fyf
 mLc
-hiN
+rja
 mLc
-hiN
 mLc
+rja
 gcK
 gbL
 gcK
@@ -120634,8 +120674,8 @@ hom
 wXo
 hom
 xXP
-jEp
-jEp
+nku
+nku
 czT
 vSL
 mvv
@@ -121672,9 +121712,9 @@ mvv
 rsh
 uXj
 uXj
-gpo
-mvv
-hgM
+lPT
+nrN
+pvY
 hom
 hom
 hom
@@ -122446,7 +122486,7 @@ xgl
 sQf
 xNm
 mvv
-goK
+sSm
 gxi
 mvv
 oVb
@@ -122702,7 +122742,7 @@ hom
 lCw
 xNm
 xNm
-pvY
+xNm
 hom
 hom
 hom
@@ -122959,7 +122999,7 @@ hom
 bMP
 xXm
 xNm
-sSm
+xNm
 wXo
 xLu
 leX
@@ -123213,7 +123253,7 @@ kIs
 gCL
 ggK
 hom
-hom
+hiN
 cfp
 xNm
 xNm
@@ -123469,10 +123509,10 @@ duF
 kIs
 ggK
 ggK
-gcK
-hom
-eHQ
-uNV
+mTd
+hiN
+xXm
+xXm
 xNm
 ueJ
 xNm
@@ -123726,10 +123766,10 @@ jdA
 kIs
 ggK
 ggK
-gcK
+mTd
 hom
 kAJ
-xih
+oCS
 xNm
 mkF
 vfn
@@ -124242,8 +124282,8 @@ ggK
 ggK
 gcK
 hom
-xNm
-erY
+jSw
+xih
 xNm
 hom
 hbW
@@ -124499,7 +124539,7 @@ ggK
 unp
 gcK
 hom
-lZz
+xNm
 xNm
 xNm
 hom
@@ -124756,7 +124796,7 @@ ggK
 ggK
 gcK
 hom
-xNm
+lZz
 xNm
 xNm
 cwD

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1704,6 +1704,12 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"bat" = (
+/mob/living/simple_animal/hostile/giantantqueen,
+/obj/item/disk/plantgene,
+/obj/item/disk/plantgene,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bau" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -2694,6 +2700,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"byp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/mob/living/simple_animal/hostile/raider/ranged/biker,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "byI" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt{
@@ -8111,6 +8127,7 @@
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/blood/radaway,
 /obj/item/reagent_containers/blood/radaway,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
@@ -9466,7 +9483,7 @@
 /area/f13/den)
 "eVC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "eVI" = (
@@ -11044,9 +11061,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fOy" = (
-/obj/structure/window/fulltile/store,
-/turf/open/space/basic,
-/area/f13/brotherhood/armory)
+/mob/living/simple_animal/hostile/raider/ranged/boss,
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "fOZ" = (
 /obj/structure/simple_door/metal/iron,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -20097,7 +20114,7 @@
 "lnk" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lnr" = (
@@ -28455,13 +28472,14 @@
 "qCm" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/caves)
 "qCE" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qDc" = (
@@ -29352,6 +29370,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
+"rdT" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "reg" = (
 /obj/structure/lattice{
 	layer = 3
@@ -35263,6 +35285,13 @@
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"uEd" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/item/circuitboard/machine/plantgenes,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uEe" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
@@ -38010,6 +38039,11 @@
 /obj/structure/timeddoor,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"wqt" = (
+/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
+/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wqw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -61012,8 +61046,8 @@ ajV
 enc
 bxT
 bxT
-rrZ
-npt
+vEd
+byp
 kGo
 mDq
 vPg
@@ -61524,7 +61558,7 @@ vPg
 ydu
 xLj
 ocG
-rrZ
+fOy
 npt
 ydu
 iMA
@@ -62297,7 +62331,7 @@ mWH
 mWH
 bxT
 eaj
-cDP
+rdT
 rUZ
 cDP
 mDq
@@ -80416,7 +80450,7 @@ aoj
 aoj
 tjA
 xNt
-jbG
+bat
 fTe
 aoj
 aoj
@@ -81185,7 +81219,7 @@ aoj
 aoj
 aoj
 aoj
-piQ
+uEd
 hLM
 yfy
 xVz
@@ -81445,7 +81479,7 @@ aoj
 aoj
 aoj
 dfM
-aMr
+wqt
 aoj
 vPg
 aoj
@@ -82464,7 +82498,7 @@ aoj
 aoj
 aoj
 aoj
-xVz
+hLM
 aoj
 aoj
 vPg
@@ -105382,7 +105416,7 @@ kDV
 gak
 tNL
 nDS
-fOy
+dMF
 pNR
 nDS
 nDS


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/69112131/167689868-57dd599a-a816-41dd-9efc-e461208627c9.png)


## About The Pull Request
Fixes the other PR that had left "space/nothing" tiles underneath doors and adds more light to the rooms as well as the Khan armoury. Adds seeds to the farming area of the legion and also places a door at the mines.

## Why It's Good For The Game
You can now enter the rooms added by that other PR

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
add: Wooden flooring beneath doors in legion camp
/:cl:

