### PR TITLE
Nerf stimpak mood event

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -10,12 +10,12 @@
 /datum/mood_event/used_drugs //for NCR, BOS, Enclave
 	description = "<span class='boldwarning'>I'm nothing but a filthy junkie...</span>\n"
 	mood_change = -12
-	timeout = 15 MINUTES
+	timeout = 2 MINUTES
 
 /datum/mood_event/betrayed_caesar //for Legion, obviously
 	description = "<span class='boldwarning'>I have betrayed the will of Caesar and defiled my body!</span>\n"
 	mood_change = -25
-	timeout = 30 MINUTES
+	timeout = 5 MINUTES
 
 /datum/mood_event/jet_euphoria
 	description = "<span class='nicegreen'>I feel like i'm flying...</span>\n"

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -21,6 +21,15 @@
 				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
 	..()
 
+/datum/reagent/medicine/stimpak/on_mob_add(mob/living/M)
+	. = ..()
+	if(M.mind)
+		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
+		if(istype(job))
+			switch(job.faction)
+				if(FACTION_LEGION)
+					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "betrayed caesar", /datum/mood_event/betrayed_caesar, name)
+
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
 	if(M.health < 0)					//Functions as epinephrine.
 		M.adjustToxLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
@@ -47,12 +56,6 @@
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING - 50)
 		M.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.overeatduration = 0
-	if(M.mind)
-		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
-		if(istype(job))
-			switch(job.faction)
-				if(FACTION_LEGION)
-					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "betrayed caesar", /datum/mood_event/betrayed_caesar, name)
 	..()
 
 /datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
@@ -91,7 +94,16 @@
 	addiction_threshold = 16
 	ghoulfriendly = TRUE
 
-datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
+/datum/reagent/medicine/super_stimpak/on_mob_add(mob/living/M)
+	. = ..()
+	if(M.mind)
+		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
+		if(istype(job))
+			switch(job.faction)
+				if(FACTION_LEGION)
+					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "betrayed caesar", /datum/mood_event/betrayed_caesar, name)
+
+/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	M.adjust_nutrition(-3)
 	if(M.health < 0)					//Functions as epinephrine.
 		M.adjustToxLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, 0)
@@ -118,12 +130,6 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING - 50)
 		M.adjustToxLoss(3*REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.overeatduration = 0
-	if(M.mind)
-		var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
-		if(istype(job))
-			switch(job.faction)
-				if(FACTION_LEGION)
-					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "betrayed caesar", /datum/mood_event/betrayed_caesar, name)
 	..()
 
 /datum/reagent/medicine/super_stimpak/overdose_process(mob/living/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

The time for stimpak(if legion takes them) mood event has been reduced from 30 minutes to 5.
Additionally, it is only sent once, on ingestion.

## Why It's Good For The Game

30 minutes is a bit too much for a thing that you might've not even done yourself.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
