### PR TITLE
emergency salvag fuck

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -207,9 +207,7 @@
 /datum/crafting_recipe/beartrap
 	name = "Bear trap"
 	result = /obj/item/restraints/legcuffs/beartrap
-	reqs = list(/obj/item/stack/crafting/metalparts = 10,
-				/obj/item/stack/crafting/goodparts = 5,
-				/obj/item/crafting = 2) //For the mechanism of the bear trap, crafting parts are needed.
+	reqs = list(/obj/item/stack/crafting/goodparts = 1) //For the mechanism of the bear trap, crafting parts are needed.
 	tools = list(TOOL_WORKBENCH)
 	time = 80
 	subcategory = CAT_FARMING

--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -239,7 +239,7 @@
 
 
 // LEGION SPECIFIC
-/*
+
 /datum/crafting_recipe/spatha
 	name = "Spatha"
 	result = /obj/item/melee/onehanded/machete/spatha
@@ -282,7 +282,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_available = FALSE
-*/
+
 
 /datum/crafting_recipe/legionshield
 	name = "Legion Shield"
@@ -361,8 +361,7 @@
 	name = "Cosmic Knife"
 	result = /obj/item/melee/onehanded/knife/cosmic
 	reqs = list(
-		/obj/item/melee/onehanded/knife/cosmicdirty = 1,
-		/obj/item/crafting/abraxo = 1,
+		/obj/item/melee/onehanded/knife/cosmicdirty = 1
 		)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_WEAPONRY

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -102,9 +102,7 @@
 /datum/crafting_recipe/metalarmor/polish
 	name = "Polished Metal Armor"
 	result = /obj/item/clothing/suit/armor/f13/metalarmor/laserproof
-	reqs = list(/obj/item/clothing/suit/armor/f13/metalarmor = 1,
-				/obj/item/crafting/abraxo,
-				)
+	reqs = list(/obj/item/clothing/suit/armor/f13/metalarmor = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	category = CAT_CLOTHING

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -288,8 +288,7 @@
 	time = 60
 	reqs = list(/obj/item/clothing/suit/f13/tribal/light/rustwalkers =1,
 				/obj/item/clothing/suit/f13/tribal/rustwalkers = 1,
-				/obj/item/stack/sheet/leather = 2,
-				/obj/item/salvage/crafting = 1)
+				/obj/item/stack/sheet/leather = 2)
 
 /datum/crafting_recipe/tribalwar/rustwalkers/garb
 	name = "Rustwalkers Garb"
@@ -329,8 +328,7 @@
 	time = 60
 	reqs = list(/obj/item/clothing/suit/f13/tribal/light/eighties =1,
 				/obj/item/clothing/suit/f13/tribal/eighties = 1,
-				/obj/item/stack/sheet/leather = 2,
-				/obj/item/salvage/crafting = 1)
+				/obj/item/stack/sheet/leather = 2)
 
 /datum/crafting_recipe/tribalwar/eighties/garb
 	name = "Eighties Garb"

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -12,8 +12,7 @@
 /datum/crafting_recipe/melee/scrapspear
 	name = "Scrap Spear"
 	result = /obj/item/twohanded/spear/scrapspear
-	reqs = list(/obj/item/crafting/duct_tape = 1,
-				/obj/item/stack/rods = 2,
+	reqs = list(/obj/item/stack/rods = 2,
 				/obj/item/shard = 1)
 	time = 40
 	category = CAT_WEAPONRY
@@ -23,8 +22,7 @@
 	name = "Scrap Shield"
 	result = /obj/item/shield/riot/scrapshield
 	reqs = list(/obj/item/stack/cable_coil = 30,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/crafting/wonderglue = 1)
+				/obj/item/stack/sheet/metal = 10)
 	tools = list(TOOL_WELDER)
 	time = 100
 	category = CAT_WEAPONRY
@@ -34,9 +32,7 @@
 	name = "Scrap Towershield"
 	result = /obj/item/shield/riot/tower/scrap
 	reqs = list(/obj/item/stack/cable_coil = 30,
-				/obj/item/stack/sheet/metal = 35,
-				/obj/item/crafting/duct_tape = 1,
-				/obj/item/crafting/wonderglue = 1)
+				/obj/item/stack/sheet/metal = 35)
 	tools = list(TOOL_WELDER)
 	time = 100
 	category = CAT_WEAPONRY
@@ -68,8 +64,7 @@
 	name = "Improvised bayonet"
 	result = /obj/item/melee/onehanded/knife/bayonet
 	time = 300
-	reqs = list(/obj/item/melee/onehanded/knife/hunting = 1,
-				/obj/item/crafting/duct_tape = 1)
+	reqs = list(/obj/item/melee/onehanded/knife/hunting = 1)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 
@@ -345,7 +340,6 @@
 	name = ".44 incendiary-tipped ammo box"
 	result = /obj/item/ammo_box/m44box/incendiary
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
-	/obj/item/crafting/abraxo = 1,
 	/obj/item/stack/sheet/metal = 5,
 	/datum/reagent/fuel = 10,
 	/obj/item/stack/ore/blackpowder = 1
@@ -370,7 +364,6 @@
 	name = ".45 ACP incendiary-tipped ammo box"
 	result = /obj/item/ammo_box/c45/incendiary
 	reqs = list(/obj/item/stack/crafting/metalparts = 1,
-	/obj/item/crafting/abraxo = 1,
 	/obj/item/stack/sheet/metal = 5,
 	/datum/reagent/fuel = 10,
 	/obj/item/stack/ore/blackpowder = 1
@@ -581,7 +574,6 @@
 	name = "Zip gun (9mm)"
 	result = /obj/item/gun/ballistic/automatic/hobo/zipgun
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
-				/obj/item/crafting/wonderglue = 1,
 				/obj/item/stack/rods = 1,
 				/obj/item/ammo_casing/c9mm = 5,
 				/obj/item/stack/crafting/metalparts = 1)
@@ -618,7 +610,6 @@
 	result = /obj/item/gun/ballistic/automatic/autopipe
 	reqs = list(/obj/item/ammo_casing/a357 = 30,
 	/obj/item/stack/crafting/metalparts = 2,
-	/obj/item/crafting/duct_tape = 1,
 	/obj/item/stack/sheet/cloth = 1,
 	/obj/item/stack/sheet/mineral/wood = 2)
 	tools = list(TOOL_WORKBENCH)
@@ -786,8 +777,7 @@
 	result = /obj/item/gun/ballistic/automatic/assault_carbine/policerifle
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/advanced_crafting_components/receiver = 1,
-				/obj/item/stack/crafting/metalparts = 2,
-				/obj/item/crafting/duct_tape =1)
+				/obj/item/stack/crafting/metalparts = 2)
 	time = 120
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
@@ -1577,7 +1567,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS
 	always_available = FALSE
-/*
+
 /datum/crafting_recipe/flux
 	name = "Flux capacitor"
 	result = /obj/item/advanced_crafting_components/flux
@@ -1663,7 +1653,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS
 	always_available = FALSE
-
+/*
 Not implemented due to balance at the moment
 /datum/crafting_recipe/caws
 	name = "h&k caws"

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1841,10 +1841,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/stack/crafting/goodparts/five,
 				/obj/item/stack/crafting/electronicparts/three,
 				/obj/item/stack/crafting/electronicparts/five,
-				/obj/item/reagent_containers/glass/bottle/blackpowder,
-				/obj/item/assembly/timer,
-				/obj/item/crafting/wonderglue,
-				/obj/item/crafting/duct_tape)
+				/obj/item/reagent_containers/glass/bottle/blackpowder)
 
 /obj/effect/spawner/lootdrop/f13/crafting/Initialize(mapload) //on mapload, pick how many shit to spawn
 	lootcount = pick(1, 2)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -619,7 +619,7 @@
 	icon_state = "gab4"
 	oneuse = TRUE
 	remarks = list("Always keep your gun well lubricated...", "Keep your barrel free of grime...", "Perfect fitment is the key to a good firearm...", "Maintain a proper trigger pull length...", "Keep your sights zeroed to proper range...")
-	//crafting_recipe_types = list(/datum/crafting_recipe/flux, /datum/crafting_recipe/lenses, /datum/crafting_recipe/conductors, /datum/crafting_recipe/receiver, /datum/crafting_recipe/assembly, /datum/crafting_recipe/alloys)
+	crafting_recipe_types = list(/datum/crafting_recipe/flux, /datum/crafting_recipe/lenses, /datum/crafting_recipe/conductors, /datum/crafting_recipe/receiver, /datum/crafting_recipe/assembly, /datum/crafting_recipe/alloys)
 
 /obj/item/book/granter/crafting_recipe/scav_one
 	name = "SCAV! Issue 1"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -32,6 +32,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("length of chain", /obj/item/blacksmith/chain, 1, time = 50), \
 	null, \
 	new/datum/stack_recipe("lock", /obj/item/lock_construct, 1), \
+	new/datum/stack_recipe("coffee pot", /obj/item/crafting/coffee_pot, 1), \
+	new/datum/stack_recipe("lunchbox", /obj/item/crafting/lunchbox, 1), \
 	new/datum/stack_recipe("key", /obj/item/key, 1), \
 	new/datum/stack_recipe("key chain", /obj/item/storage/keys_set, 1), \
 	null, \
@@ -428,6 +430,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("medical bag", /obj/item/storage/bag/chemistry, 4), \
 	new/datum/stack_recipe("bio bag", /obj/item/storage/bag/bio, 4), \
 	new/datum/stack_recipe("casings bag", /obj/item/storage/bag/casings, 4), \
+	new/datum/stack_recipe("salvage storage bag", /obj/item/storage/bag/salvagestorage, 4), \
 	new/datum/stack_recipe("salvage bag", /obj/item/storage/bag/salvage, 4), \
 	null, \
 	new/datum/stack_recipe("string", /obj/item/weaponcrafting/string, 1, time = 10), \

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -512,6 +512,24 @@ obj/item/storage/bag/chemistry/tribal
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = INFINITY
+	STR.max_items = 50
+	STR.can_hold = typecacheof(list(/obj/item/salvage))
+
+/obj/item/storage/bag/salvagestorage
+	name = "salvage storage sack"
+	desc = "A sack for storing your game-lagging piles of salvage components."
+	icon = 'icons/obj/janitor.dmi' //im lazy
+	icon_state = "trashbag"
+	item_state = "trashbag"
+	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+	resistance_flags = FLAMMABLE
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/bag/salvagestorage/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = INFINITY
 	STR.max_items = INFINITY
-	STR.can_hold = typecacheof(list(/obj/item/salvage, /obj/item/advanced_crafting_components, /obj/item/stack/crafting, /obj/item/crafting, /obj/item/multitool/advanced, /obj/item/crowbar/hightech, /obj/item/wrench/hightech, /obj/item/weldingtool/hightech, /obj/item/screwdriver/hightech, /obj/item/wirecutters/hightech, /obj/item/blueprint/research, /obj/item/multitool/advanced
-, /obj/item/melee/onehanded/knife/cosmic))
+	STR.can_hold = typecacheof(list(/obj/item/advanced_crafting_components, /obj/item/stack/crafting, /obj/item/crafting, /obj/item/multitool/advanced, /obj/item/crowbar/hightech, /obj/item/wrench/hightech, /obj/item/weldingtool/hightech, /obj/item/screwdriver/hightech, /obj/item/wirecutters/hightech, /obj/item/blueprint/research, /obj/item/multitool/advanced))

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -182,18 +182,6 @@
 				)
 
 
-
-/obj/item/salvage/crafting
-	name = "salvaged components"
-	desc = "Some salvaged components, it could contain some useful materials if dissasembled using a workbench..."
-	icon_state = "salvagecomponents"
-	Loot = list(/obj/item/crafting/coffee_pot,
-				/obj/item/crafting/wonderglue,
-				/obj/item/crafting/abraxo,
-				/obj/item/crafting/lunchbox)
-
-
-
 /obj/item/salvage/tool
 	name = "Pre-war tool salvage"
 	desc = "Some tools meshed together. It could contain working tools or other useful items if dissasembled using a workbench..."
@@ -203,8 +191,7 @@
 				/obj/item/screwdriver/hightech,
 				/obj/item/wrench/hightech,
 				/obj/item/wirecutters/hightech,
-				/obj/item/multitool/advanced,
-				/obj/item/melee/onehanded/knife/cosmic)
+				/obj/item/multitool/advanced)
 
 /obj/item/salvage/high
 	name = "Advanced pre-war salvage"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -1,8 +1,7 @@
 /datum/crafting_recipe/food/moleratwondermeat
 	name = "Molerat Wondermeat"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/meat/steak/molerat = 1,
-		/obj/item/crafting/wonderglue = 1
+		/obj/item/reagent_containers/food/snacks/meat/steak/molerat = 1
 	)
 	tools = list(TOOL_LUNCHBOX)
 	result = /obj/item/reagent_containers/food/snacks/f13/molejerky

--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -61,14 +61,9 @@
 			WO.use(3)
 			modifier++
 	for(var/i2 in 1 to (2+modifier))
-		if(prob(50))
-			new /obj/item/salvage/low(usr_turf)
-		else if(prob(40))
-			new /obj/item/salvage/tool(usr_turf)
-		else
-			new /obj/item/salvage/crafting(usr_turf)
+		new /obj/item/salvage/low(usr_turf)
 	for(var/i3 in 1 to (1+modifier)) //this is just less lines for the same thing
-		if(prob(20))
+		if(prob(3))
 			new /obj/item/salvage/high(usr_turf)
 	uses_left--
 	inuse = FALSE //putting this after the -- because the first check prevents cheesing


### PR DESCRIPTION
solutions to salvage:

you're now mainly just getting materials from salvage, which don't lag, if you salvage from cars. you can still get tool salvage and stuff from the machins, of which there are far less of on the map.

component salvage has ceased to exist, the coffeepots and lunchboxes can be found in metal crafting recipes, everything else is gone or unused

book 4 lets you craft advanced weapon crafting parts again now as compensation for the fact that weapon parts are rarer from salvage itself

recipes that needed unused things ahve been changed to no longr need them


the salvage bag infinity stuff is gone, they hold 50 salvage now, there's a separate bag for storing your fucktons of crafting materials

also tweaked the derilected bear trap recipe because it can be made directly from titanium now instead, so

as for if it compiles

![image](https://user-images.githubusercontent.com/72014488/167727370-c75de840-a065-431c-8766-3e6aeeefd5e6.png)


yes