### PR TITLE
Merges Robodrobe and Scidrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -246,7 +246,22 @@
 					/obj/item/clothing/suit/toggle/labcoat/depjacket/sci = 4,
 					/obj/item/clothing/shoes/sneakers/white = 4,
 					/obj/item/radio/headset/headset_sci = 4,
+					/obj/item/clothing/glasses/hud/diagnostic = 3,
+					/obj/item/clothing/head/beret/robo = 3,
+					/obj/item/clothing/under/rank/rnd/roboticist = 3,
+					/obj/item/clothing/under/rank/rnd/roboticist/sleek = 3,
+					/obj/item/clothing/under/rank/rnd/roboticist/skirt = 3,
+					/obj/item/clothing/suit/hooded/wintercoat/robotics = 3,
+					/obj/item/clothing/suit/toggle/labcoat = 3,
+					/obj/item/clothing/shoes/sneakers/black = 3,
+					/obj/item/clothing/gloves/fingerless = 3,
+					/obj/item/clothing/head/soft/black = 3,
+					/obj/item/clothing/mask/bandana/skull = 2,
 					/obj/item/clothing/mask/gas = 5)
+	contraband = list(/obj/item/clothing/suit/hooded/techpriest = 2,
+					/obj/item/clothing/under/misc/mechsuitred = 1,
+					/obj/item/clothing/under/misc/mechsuitwhite = 1,
+					/obj/item/clothing/under/misc/mechsuitblue = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 	payment_department = ACCOUNT_SCI
 	cost_multiplier_per_dept = list(ACCOUNT_SCI = 0)


### PR DESCRIPTION

## About The Pull Request
As the title says I added all the Robodrobe items into the Scidrobe, simple as.

## Why It's Good For The Game
It allows people to obtain the roboticist clothing, robotic hud, and costumes without asking a admin for a restock unit.

## Pre-Merge Checklist
- [ ✓] You tested this on a local server.
- [✓ ] This code did not runtime during testing.
- [✓ ] You documented all of your changes.


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
code: Moved everything from the Robodrobe to the Scidrobe
/:cl: