### PR TITLE
Move NCR Botany to the Medbay top

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -239,9 +239,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "apL" = (
-/mob/living/simple_animal/hostile/securitron/sentrybot,
-/turf/open/floor/plasteel/dark,
-/area/f13/bunker)
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "aqU" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -273,6 +277,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"ast" = (
+/obj/structure/table/reinforced/brass,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
+/turf/open/floor/carpet,
+/area/f13/city)
 "asW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -609,6 +618,11 @@
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
+"aMc" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "aMK" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -619,7 +633,6 @@
 	desc = "A large button which is connected to a mass of wires that snake across the room... can't be good. It was triggered long ago.";
 	name = "Used Detonator"
 	},
-/obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "aNv" = (
@@ -1184,8 +1197,8 @@
 /area/f13/legion)
 "bxq" = (
 /mob/living/simple_animal/hostile/venus_human_trap{
-	faction = list("hostile","vines","plants","cazador");
 	aggro_vision_range = 12;
+	faction = list("hostile","vines","plants","cazador");
 	vision_range = 12
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -1393,6 +1406,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"bLY" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/carpet,
+/area/f13/city)
 "bMf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins{
@@ -1841,7 +1858,8 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "coG" = (
-/obj/structure/frame/machine,
+/obj/machinery/plantgenes,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "cpr" = (
@@ -1900,8 +1918,8 @@
 	},
 /mob/living/simple_animal/hostile/jungle/seedling{
 	faction = list("cazador");
-	name = "temple seedling";
-	health = 250
+	health = 250;
+	name = "temple seedling"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -2169,6 +2187,9 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland)
+"cKO" = (
+/turf/open/floor/carpet,
+/area/f13/city)
 "cLP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2556,6 +2577,7 @@
 "dhZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "djo" = (
@@ -3276,7 +3298,9 @@
 /area/f13/followers)
 "dRt" = (
 /obj/structure/stone_tile/center/burnt,
-/obj/structure/nest/cazador,
+/obj/machinery/door/keycard{
+	puzzle_id = "deathclaw"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "dRx" = (
@@ -3584,6 +3608,11 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ncr)
+"efC" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/candle/infinite,
+/turf/open/floor/carpet,
+/area/f13/city)
 "efE" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /obj/effect/decal/cleanable/dirt,
@@ -4147,6 +4176,7 @@
 	desc = "A pre-war military robot equipped with a high-yield gatling laser and improved dual fusion cores setup to detonate in the event of the robot's destruction. This one looks armored up and powered up to an exponential degree. Oh, fuck.";
 	extra_projectiles = 5;
 	health = 3500;
+	loot = list(/obj/item/keycard/vault);
 	maxHealth = 3500;
 	melee_queue_distance = 15;
 	name = "legendary sentry bot"
@@ -4193,7 +4223,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "eLS" = (
-/obj/machinery/door/airlock/grunge/abandoned,
+/obj/machinery/door/keycard{
+	puzzle_id = "vault"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "eMc" = (
@@ -4262,6 +4294,10 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "eSb" = (
@@ -4331,7 +4367,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "eVx" = (
@@ -4524,12 +4560,17 @@
 	},
 /area/f13/wasteland)
 "fga" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/riverbank{
-	dir = 8
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
-/turf/open/water,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/dark,
+/area/f13/bunker)
 "fge" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/wattz/recharger,
@@ -4555,7 +4596,10 @@
 /area/f13/ncr)
 "fhn" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "fhJ" = (
@@ -4620,9 +4664,9 @@
 /area/f13/bunker)
 "foH" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper{
+	faction = list("cazador");
 	health = 200;
-	name = "temple spider";
-	faction = list("cazador")
+	name = "temple spider"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -5057,9 +5101,9 @@
 /area/f13/legion)
 "fRV" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/ice{
+	faction = list("cazador");
 	health = 250;
-	name = "giant temple spider";
-	faction = list("cazador")
+	name = "giant temple spider"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -5835,6 +5879,16 @@
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/carpet/green,
 /area/f13/underground/cave)
+"gRq" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/punji_sticks{
+	color = "#4E4943";
+	max_integrity = 200
+	},
+/turf/closed/indestructible/riveted/boss{
+	name = "temple wall"
+	},
+/area/f13/underground/cave)
 "gRC" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plating/tunnel{
@@ -5890,6 +5944,9 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "gWV" = (
@@ -6164,12 +6221,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "hmv" = (
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -7297,6 +7349,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"iFy" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/carpet,
+/area/f13/city)
 "iGc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
@@ -9048,9 +9104,9 @@
 	icon_state = "stickyweb2"
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife{
+	faction = list("cazador");
 	health = 300;
-	name = "giant midwife temple spider";
-	faction = list("cazador")
+	name = "giant midwife temple spider"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -9095,9 +9151,9 @@
 /area/f13/followers)
 "kQm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper{
+	faction = list("cazador");
 	health = 200;
-	name = "temple spider";
-	faction = list("cazador")
+	name = "temple spider"
 	},
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -9583,6 +9639,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen{
+	id = "bonnie"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "ltq" = (
@@ -9660,11 +9719,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "lvs" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bonnie"
-	},
 /obj/effect/turf_decal/loading_area/white{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bonnie"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
@@ -10975,6 +11034,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"mRq" = (
+/obj/structure/barricade/wooden{
+	max_integrity = 30;
+	obj_integrity = 30
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
 "mRR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/autolathe/constructionlathe,
@@ -11108,15 +11174,18 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
 "mYC" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife{
+	faction = list("cazador");
 	health = 300;
-	name = "giant midwife temple spider";
-	faction = list("cazador")
+	name = "giant midwife temple spider"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -11356,6 +11425,9 @@
 /area/f13/city)
 "nqo" = (
 /obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -11422,6 +11494,12 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"nst" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "ntG" = (
@@ -11763,6 +11841,8 @@
 "nSz" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/revolver/needler,
+/obj/item/ammo_box/needle,
 /turf/open/floor/pod/dark,
 /area/f13/underground/cave)
 "nSW" = (
@@ -12053,7 +12133,6 @@
 /area/f13/bunker)
 "okf" = (
 /obj/structure/chair/office/dark,
-/mob/living/simple_animal/hostile/deathclaw/legendary,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -12105,6 +12184,16 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
+/area/f13/bunker)
+"olz" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "olH" = (
 /obj/machinery/doorButtons/vaultButton,
@@ -12275,6 +12364,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/holofloor/carpet,
 /area/f13/legion)
+"ovt" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "ovu" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /obj/effect/decal/cleanable/dirt,
@@ -12423,8 +12518,8 @@
 "oIv" = (
 /mob/living/simple_animal/hostile/jungle/seedling{
 	faction = list("cazador");
-	name = "temple seedling";
-	health = 250
+	health = 250;
+	name = "temple seedling"
 	},
 /obj/structure/spacevine{
 	name = "vines"
@@ -13837,12 +13932,13 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/deathclaw/power_armor{
-	faction = list("cazador");
 	aggro_vision_range = 30;
-	vision_range = 30;
-	name = "power armored genetically altered deathclaw";
+	desc = "A massive, reptillian creature with powerful muscles, razor-sharp claws, and aggression to match. This one in particular has power armor and seems to have a much of an aggression tone, this seems to be more an alpha deathclaw rather than a legendary. Some tribals would consider this an razorclaw to many ways";
+	faction = list("cazador");
+	loot = list(/obj/item/keycard/deathclaw);
 	melee_damage_lower = 80;
-	desc = "A massive, reptillian creature with powerful muscles, razor-sharp claws, and aggression to match. This one in particular has power armor and seems to have a much of an aggression tone, this seems to be more an alpha deathclaw rather than a legendary. Some tribals would consider this an razorclaw to many ways"
+	name = "power armored genetically altered deathclaw";
+	vision_range = 30
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -13928,7 +14024,7 @@
 	},
 /area/f13/followers)
 "qhW" = (
-/mob/living/simple_animal/hostile/deathclaw/legendary,
+/mob/living/simple_animal/hostile/deathclaw/power_armor,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -13957,6 +14053,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"qjZ" = (
+/obj/structure/car/rubbish4,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qkm" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/structure/barricade/wooden/strong,
@@ -14140,9 +14241,8 @@
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/bunker)
 "qso" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
-/turf/open/floor/wood/f13/old,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/carpet,
 /area/f13/city)
 "qss" = (
 /obj/structure/closet/cabinet{
@@ -14216,9 +14316,9 @@
 	icon_state = "stickyweb2"
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper{
+	faction = list("cazador");
 	health = 200;
-	name = "temple spider";
-	faction = list("cazador")
+	name = "temple spider"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
@@ -15109,8 +15209,8 @@
 /area/f13/wasteland)
 "rrs" = (
 /mob/living/simple_animal/hostile/venus_human_trap{
-	faction = list("hostile","vines","plants","cazador");
 	aggro_vision_range = 12;
+	faction = list("hostile","vines","plants","cazador");
 	vision_range = 12
 	},
 /obj/structure/spacevine{
@@ -15794,6 +15894,10 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"sbb" = (
+/obj/structure/table/reinforced/brass,
+/turf/open/floor/carpet,
+/area/f13/city)
 "sbC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16064,15 +16168,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"soG" = (
-/obj/structure/stone_tile/surrounding/burnt,
-/obj/structure/punji_sticks{
-	color = "#4E4943";
-	max_integrity = 200
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
 "soH" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -16537,6 +16632,8 @@
 	pixel_x = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/whiskey,
+/obj/item/clothing/suit/armor/f13/rangercombat/desert/whiskey,
 /turf/open/floor/pod/light,
 /area/f13/underground/cave)
 "sTT" = (
@@ -18988,6 +19085,7 @@
 /area/f13/bunker)
 "vYC" = (
 /obj/structure/stone_tile/surrounding_tile,
+/obj/structure/nest/cazador,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
 "vYK" = (
@@ -19542,8 +19640,8 @@
 	name = "vines"
 	},
 /mob/living/simple_animal/hostile/venus_human_trap{
-	faction = list("hostile","vines","plants","cazador");
 	aggro_vision_range = 12;
+	faction = list("hostile","vines","plants","cazador");
 	vision_range = 12
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -25680,7 +25778,7 @@ fzi
 fzi
 nBS
 dcB
-rPD
+frs
 rPD
 rPD
 pPi
@@ -25937,7 +26035,7 @@ fzi
 fzi
 fzi
 jXF
-hmv
+rPD
 rPD
 rPD
 nqo
@@ -26452,9 +26550,9 @@ dlC
 jXF
 dcB
 omv
-rPD
-rPD
-rPD
+apL
+hmv
+hmv
 dcB
 heT
 bYA
@@ -37899,9 +37997,9 @@ bYA
 vKV
 vOG
 nmQ
-qDz
-qDz
-qDz
+efC
+bLY
+cKO
 jZj
 sHw
 sHw
@@ -37921,7 +38019,7 @@ xdM
 xdM
 fMG
 imw
-qhW
+xdM
 fMG
 xdM
 swh
@@ -38156,15 +38254,15 @@ bYA
 vKV
 vOG
 nmQ
-qDz
-qDz
+ast
+bLY
 qso
-qDz
-qDz
-jZj
-qDz
-qDz
-wus
+cKO
+cKO
+qso
+cKO
+cKO
+iFy
 ksx
 ksx
 ksx
@@ -38173,9 +38271,9 @@ ksx
 ygO
 fMG
 xdM
+ovt
 xdM
 xdM
-qhW
 fMG
 pIk
 nWv
@@ -38413,15 +38511,15 @@ bYA
 vKV
 vOG
 nmQ
-qDz
-qDz
-uel
-jZj
-qDz
-qDz
-qDz
-qDz
-wus
+sbb
+bLY
+cKO
+qso
+cKO
+cKO
+cKO
+cKO
+iFy
 ksx
 ksx
 ksx
@@ -38435,7 +38533,7 @@ xdM
 tin
 fMG
 tMi
-xdM
+qhW
 fMG
 xdM
 rYL
@@ -38670,9 +38768,9 @@ bYA
 vKV
 vOG
 nmQ
-qDz
-jZj
-qDz
+efC
+bLY
+cKO
 qDz
 sHw
 sHw
@@ -38947,10 +39045,10 @@ xdM
 xtU
 xdM
 xdM
-qhW
+xdM
 xtU
 xdM
-qhW
+xdM
 xdM
 xtU
 vOG
@@ -39200,13 +39298,13 @@ ksx
 svf
 ygO
 fMG
+xdM
+xdM
+xdM
+xdM
+xdM
+xdM
 qhW
-xdM
-xdM
-xdM
-xdM
-xdM
-xdM
 xdM
 xdM
 xdM
@@ -39460,7 +39558,7 @@ fMG
 xdM
 lZM
 xWq
-xdM
+qhW
 wRZ
 xWq
 xdM
@@ -39576,11 +39674,11 @@ vHC
 vHC
 vHC
 vHC
-dut
+vHC
 vHC
 eLS
 vHC
-dut
+vHC
 vHC
 vHC
 vHC
@@ -40236,7 +40334,7 @@ dyP
 xWq
 xdM
 fMG
-xdM
+qhW
 sUU
 vOG
 vKV
@@ -40345,15 +40443,15 @@ heT
 heT
 vHC
 vHC
-bVI
+fga
 daB
-apL
 cdl
 cdl
 cdl
-apL
+cdl
+cdl
 fWH
-bVI
+olz
 vHC
 vHC
 vHC
@@ -40493,7 +40591,7 @@ xWq
 kPn
 xdM
 fMG
-qhW
+xdM
 npi
 vOG
 vKV
@@ -42029,7 +42127,7 @@ rVh
 vES
 vES
 vES
-fga
+wUa
 ksx
 ksx
 pTK
@@ -42286,7 +42384,7 @@ dlh
 wUa
 wUa
 wUa
-dpP
+qjZ
 ksx
 ksx
 pTK
@@ -80640,7 +80738,7 @@ heT
 heT
 heT
 heT
-eub
+gRq
 rri
 vZK
 pog
@@ -80833,15 +80931,15 @@ vQV
 vHC
 vHC
 vHC
-rdL
-rdL
-rdL
-rdL
-rdL
-rdL
-rdL
-rdL
-tZn
+aMc
+aMc
+aMc
+aMc
+aMc
+aMc
+mRq
+aMc
+nst
 vHC
 vHC
 vHC
@@ -80897,7 +80995,7 @@ heT
 heT
 heT
 wxj
-heT
+mpp
 mpp
 hvN
 miM
@@ -81411,7 +81509,7 @@ rjt
 eGJ
 vYC
 qbS
-soG
+mpp
 qPK
 vrh
 ewf
@@ -81668,7 +81766,7 @@ heT
 heT
 heT
 wxj
-heT
+mpp
 mpp
 nnl
 glo
@@ -81925,7 +82023,7 @@ heT
 heT
 heT
 heT
-eub
+gRq
 sYU
 rri
 pog
@@ -82889,15 +82987,15 @@ vHC
 vHC
 vHC
 vHC
-rdL
-rdL
-tZn
-tZn
-rdL
-rdL
-rdL
-rdL
-rdL
+aMc
+aMc
+nst
+nst
+aMc
+aMc
+mRq
+aMc
+aMc
 vHC
 vHC
 vHC

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -857,6 +857,10 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/building)
+"dx" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/ncr)
 "dy" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -936,10 +940,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "dM" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
 /area/f13/ncr)
 "dO" = (
 /obj/structure/fence/wooden{
@@ -1011,6 +1018,12 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
+/area/f13/caves)
+"ec" = (
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ed" = (
 /obj/structure/decoration/rag,
@@ -1797,10 +1810,10 @@
 	},
 /area/f13/building)
 "hm" = (
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_y = 32
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "hn" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2102,6 +2115,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iB" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "iD" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -2135,17 +2158,7 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
 "iO" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/corn,
-/obj/item/seeds/corn,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/soya,
-/obj/item/seeds/soya,
+/obj/machinery/seed_extractor,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -3601,9 +3614,6 @@
 /area/f13/building)
 "nW" = (
 /obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_y = 32
 	},
@@ -4258,12 +4268,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qk" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/wood,
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/ncr)
 "ql" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4395,8 +4406,19 @@
 	},
 /area/f13/wasteland)
 "qK" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/ncr)
 "qM" = (
 /obj/structure/simple_door/house,
@@ -4567,7 +4589,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/caves)
 "rw" = (
-/obj/machinery/seed_extractor,
+/obj/structure/rack,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/corn,
+/obj/item/seeds/corn,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/soya,
+/obj/item/seeds/soya,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -6161,6 +6193,11 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building)
+"xu" = (
+/obj/effect/decal/riverbank,
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/ncr)
 "xw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -6426,11 +6463,7 @@
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
 "yD" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/fence/wooden{
+/obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -6970,6 +7003,7 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
 	name = "air";
 	sunlight_state = 1
@@ -7993,6 +8027,16 @@
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/caves)
+"Fq" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "Fr" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
@@ -9214,13 +9258,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "JX" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/hatchet,
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -9414,6 +9452,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"KO" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
@@ -10150,6 +10198,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"Od" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Medbay";
+	req_access_txt = "121"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/ncr)
 "Oe" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -10177,12 +10232,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "Om" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/wood,
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "On" = (
 /obj/structure/simple_door/wood,
@@ -11198,6 +11251,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"Sm" = (
+/obj/structure/decoration/rag,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "So" = (
 /obj/structure/table,
 /obj/item/crafting/abraxo{
@@ -11397,6 +11460,11 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/raiders)
+"Tg" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/ncr)
 "Tk" = (
 /obj/structure/chair/stool{
 	dir = 8;
@@ -11533,18 +11601,27 @@
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
 "TJ" = (
-/obj/structure/reagent_dispensers/compostbin,
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "TL" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/raiders)
+"TM" = (
+/obj/structure/railing/corner{
+	color = "#A47449"
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "TS" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -11576,6 +11653,10 @@
 /obj/machinery/autolathe/ammo,
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/carpet/black,
+/area/f13/ncr)
+"TX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "Ua" = (
 /obj/item/kirbyplants{
@@ -12169,13 +12250,8 @@
 	},
 /area/f13/building)
 "Wq" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
+/obj/effect/decal/riverbank,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
 "Wr" = (
 /obj/structure/rack,
@@ -12826,6 +12902,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
+"Zp" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "Zq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker{
@@ -12922,6 +13008,9 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_large,
+/area/f13/ncr)
+"ZC" = (
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/ncr)
 "ZD" = (
 /obj/structure/table,
@@ -20746,13 +20835,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+dM
+hm
+hm
+hm
+hm
+hm
+Jd
 PL
 PL
 PL
@@ -21003,13 +21092,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+hm
+iO
+JS
+ot
+Wq
+ZC
+TX
 PL
 PL
 PL
@@ -21260,13 +21349,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+hm
+nW
+JS
+fW
+Wq
+ZC
+TX
 PL
 PL
 PL
@@ -21275,14 +21364,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-ay
+Ge
+tS
+tS
+tS
+tS
+tS
+tS
+Fq
 Gl
 Gl
 Jd
@@ -21517,20 +21606,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+hm
+qk
+Om
+fW
+Tg
+dx
+TX
 PL
 PL
 PL
@@ -21540,6 +21622,13 @@ PL
 PL
 PL
 ay
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
 Gl
 Gl
 Jd
@@ -21774,13 +21863,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+dM
+qK
+JS
+JS
+Tg
+dx
+TX
 PL
 PL
 PL
@@ -21788,15 +21877,15 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-AU
 PL
 ay
+Gl
+Gl
+Gl
+Gl
+AU
+Gl
+Gl
 Gl
 Gl
 Jd
@@ -22031,13 +22120,13 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
+hm
+rw
+JS
+JS
+Tg
+dx
+TX
 PL
 PL
 PL
@@ -22046,9 +22135,9 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
+ay
+Gl
+Gl
 Jd
 Jd
 Jd
@@ -22288,24 +22377,24 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+hm
+JX
+JS
+JS
+xu
+ZC
+TX
+tS
+tS
+tS
+tS
+tS
+tS
+tS
+tS
+iB
+Gl
+Gl
 Jd
 PX
 yc
@@ -22545,24 +22634,24 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Jd
+JS
+JS
+JS
+JS
+JS
+Od
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
 Jd
 UM
 JS
@@ -22802,24 +22891,24 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Jd
+JS
+Az
+TJ
+JS
+JS
+Od
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
+Gl
 Jd
 JS
 df
@@ -23059,24 +23148,24 @@ Al
 CC
 CC
 CC
-CC
-CC
-CC
-CC
-CC
-CC
-CC
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+dX
 Jd
 gU
 qO
@@ -28064,11 +28153,11 @@ kC
 kC
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+BY
+BY
+BY
+BY
+BY
 kC
 kC
 kC
@@ -28321,11 +28410,11 @@ PL
 PL
 PL
 PL
-PL
 BY
 BY
 BY
-PL
+BY
+BY
 PL
 PL
 PL
@@ -28578,11 +28667,11 @@ PL
 PL
 PL
 PL
-PL
 BY
 BY
 BY
-PL
+BY
+BY
 PL
 PL
 PL
@@ -28835,11 +28924,11 @@ PL
 PL
 PL
 PL
-PL
 BY
 BY
 BY
-PL
+BY
+BY
 PL
 PL
 PL
@@ -29092,11 +29181,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+BY
+BY
+BY
+BY
+BY
 PL
 PL
 PL
@@ -29349,11 +29438,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+BY
+BY
+BY
+BY
+BY
 PL
 PL
 PL
@@ -29606,11 +29695,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+BY
+BY
+BY
+BY
+BY
 PL
 PL
 PL
@@ -29863,11 +29952,11 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
+BY
+BY
+BY
+BY
+BY
 PL
 PL
 PL
@@ -37973,12 +38062,12 @@ kC
 kC
 kC
 kC
-Jd
-rw
-JS
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 rj
 tX
@@ -38230,12 +38319,12 @@ kC
 kC
 kC
 kC
-Jd
-nW
-JS
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 rj
 tX
@@ -38487,12 +38576,12 @@ kC
 kC
 kC
 kC
-Jd
-Om
-hm
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 rK
 sM
@@ -38744,12 +38833,12 @@ lH
 kC
 kC
 kC
-Jd
-JX
-JS
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 nf
 sM
@@ -39001,12 +39090,12 @@ kC
 kC
 kC
 kC
-Jd
-iO
-JS
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 lh
 rK
@@ -39258,12 +39347,12 @@ kC
 kC
 kC
 kC
-Jd
-TJ
-JS
-JS
-qK
-Wq
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 lh
 rK
@@ -39515,12 +39604,12 @@ kC
 kC
 kC
 kC
-Jd
-Jd
-JS
-dM
-dM
-Jd
+kC
+kC
+kC
+kC
+kC
+kC
 Jd
 Jd
 Jd
@@ -39773,11 +39862,11 @@ kC
 kC
 kC
 kC
-Jd
-JS
-Az
-Az
-Jd
+kC
+kC
+kC
+kC
+kC
 kC
 kC
 kC
@@ -40030,11 +40119,11 @@ kC
 kC
 kC
 kC
-Jd
-Jd
-Jd
-Jd
-Jd
+kC
+kC
+kC
+kC
+kC
 kC
 kC
 kC
@@ -59064,13 +59153,13 @@ oU
 pN
 cp
 XS
-PL
+TM
 tY
 tY
 tY
 tY
 tY
-PL
+KO
 PL
 PL
 PL
@@ -59328,7 +59417,7 @@ HA
 op
 ol
 Ds
-PL
+KO
 PL
 PL
 PL
@@ -59568,7 +59657,7 @@ tY
 tY
 tY
 tY
-PL
+KO
 Hy
 vN
 fU
@@ -60127,7 +60216,7 @@ tY
 tY
 tY
 tY
-PL
+KO
 PL
 PL
 PL
@@ -60385,7 +60474,7 @@ AM
 AM
 AM
 Ds
-PL
+KO
 PL
 PL
 PL
@@ -60643,7 +60732,7 @@ GY
 AM
 AM
 Ds
-PL
+KO
 PL
 PL
 PL
@@ -60870,7 +60959,7 @@ vP
 Bo
 Wx
 nd
-PL
+eU
 PL
 PL
 PL
@@ -61120,13 +61209,13 @@ PL
 PL
 lz
 PL
-PL
+Zp
 nE
 nE
 nE
 nE
 nE
-PL
+eU
 PL
 PL
 PL
@@ -61156,7 +61245,7 @@ xj
 xo
 AM
 AM
-Xt
+AM
 bJ
 PL
 PL
@@ -61412,7 +61501,7 @@ kC
 AM
 AM
 AM
-AM
+Xt
 yD
 aJ
 PL
@@ -61625,7 +61714,7 @@ pg
 jZ
 Wx
 aD
-PL
+eU
 PL
 PL
 PL
@@ -61927,7 +62016,7 @@ AM
 UB
 ES
 nE
-PL
+eU
 PL
 PL
 PL
@@ -62144,7 +62233,7 @@ tY
 tY
 tY
 tY
-PL
+KO
 PL
 PL
 PL
@@ -62168,7 +62257,7 @@ Ue
 Wx
 bJ
 PL
-PL
+Zp
 nE
 nE
 nE
@@ -62182,7 +62271,7 @@ Ya
 nE
 nE
 nE
-PL
+eU
 PL
 PL
 PL
@@ -62402,7 +62491,7 @@ ol
 Wx
 tj
 nL
-PL
+KO
 PL
 PL
 PL
@@ -62425,7 +62514,7 @@ ke
 Wx
 Cm
 tY
-PL
+KO
 PL
 PL
 PL
@@ -62685,7 +62774,7 @@ AM
 Ds
 tY
 tY
-PL
+KO
 PL
 PL
 PL
@@ -62943,7 +63032,7 @@ AM
 AM
 AM
 nL
-PL
+KO
 PL
 PL
 PL
@@ -63212,7 +63301,7 @@ tY
 tY
 PR
 tY
-PL
+KO
 PL
 PL
 PL
@@ -63468,7 +63557,7 @@ AM
 AM
 AM
 AM
-qk
+Hj
 aJ
 PL
 PL
@@ -63725,8 +63814,8 @@ AM
 xo
 AM
 xo
-AM
-Hj
+GV
+ec
 aJ
 PL
 PL
@@ -63983,7 +64072,7 @@ xj
 AM
 xo
 xo
-GV
+AM
 aJ
 PL
 PL
@@ -64752,7 +64841,7 @@ kC
 kC
 kC
 kC
-mm
+Sm
 OI
 AM
 bJ
@@ -65752,7 +65841,7 @@ tY
 tY
 tY
 tY
-PL
+KO
 PL
 PL
 PL
@@ -66789,7 +66878,7 @@ xo
 kC
 nE
 nE
-PL
+eU
 PL
 PL
 PL

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -723,7 +723,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/village)
 "anq" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt{
@@ -1738,7 +1738,7 @@
 "aKX" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/village)
 "aLd" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
@@ -2690,7 +2690,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "beh" = (
@@ -3574,11 +3574,13 @@
 	},
 /area/f13/building)
 "buO" = (
-/obj/machinery/door/window/eastright{
-	dir = 8
+/obj/item/bedsheet/medical,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "buU" = (
@@ -5976,7 +5978,7 @@
 /obj/structure/bed/old,
 /obj/structure/window/spawner/west,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "cvu" = (
@@ -7164,9 +7166,13 @@
 	},
 /area/f13/building)
 "cYn" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/ncr)
 "cYp" = (
 /obj/structure/rack,
@@ -8285,11 +8291,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dts" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/wood,
-/obj/item/reagent_containers/glass/bucket/wood,
+/obj/structure/stairs/north,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "dtO" = (
@@ -8490,7 +8494,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "dxT" = (
 /obj/structure/gallow,
 /turf/open/floor/wood/f13/stage_tr,
@@ -8566,15 +8570,10 @@
 	},
 /area/f13/building)
 "dzq" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/hatchet,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "dzA" = (
@@ -8619,7 +8618,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "dAb" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -8696,22 +8695,6 @@
 /obj/structure/sign/poster/contraband/pinup_ride,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"dBx" = (
-/obj/structure/rack,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/corn,
-/obj/item/seeds/corn,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/soya,
-/obj/item/seeds/soya,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/ncr)
 "dBM" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/water,
@@ -9411,13 +9394,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"dRD" = (
-/obj/structure/stairs/north,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
 "dRF" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9431,6 +9407,12 @@
 	},
 /obj/structure/target_stake,
 /obj/item/target,
+/obj/item/clothing/head/helmet/f13/legion/recruit{
+	pixel_y = 11
+	},
+/obj/item/clothing/suit/armor/f13/legion/recruit{
+	pixel_y = -3
+	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
 "dRJ" = (
@@ -9484,12 +9466,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"dTl" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/ncr)
 "dUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9604,15 +9580,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/village)
-"dVu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Botany";
-	req_access_txt = "121"
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/ncr)
 "dVy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -9646,15 +9613,6 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/building)
-"dWH" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
-	},
-/area/f13/ncr)
 "dWZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench,
@@ -10067,7 +10025,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "eej" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -11323,7 +11281,8 @@
 "eCh" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	dir = 6;
+	icon_state = "bluemark"
 	},
 /area/f13/ncr)
 "eCq" = (
@@ -12010,7 +11969,9 @@
 	},
 /area/f13/building)
 "eQn" = (
-/obj/machinery/computer/operating,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -12242,11 +12203,6 @@
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"eWQ" = (
-/obj/effect/decal/riverbank,
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/ncr)
 "eWT" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/fakelattice{
@@ -13860,7 +13816,7 @@
 /obj/item/reagent_containers/pill/patch/bitterdrink,
 /obj/item/reagent_containers/pill/patch/bitterdrink,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/village)
 "fDi" = (
 /obj/structure/fence{
 	color = "#515249";
@@ -14883,12 +14839,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"fVF" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/ncr)
 "fVH" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/f13{
@@ -20610,11 +20560,10 @@
 	},
 /area/f13/building)
 "hYh" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hYp" = (
 /obj/structure/sink/greyscale{
@@ -20748,7 +20697,7 @@
 	req_access_txt = "121"
 	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "iav" = (
@@ -22759,7 +22708,8 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	dir = 6;
+	icon_state = "bluemark"
 	},
 /area/f13/ncr)
 "iOY" = (
@@ -22786,7 +22736,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "iPq" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22797,7 +22747,8 @@
 "iPB" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	dir = 6;
+	icon_state = "bluemark"
 	},
 /area/f13/ncr)
 "iPG" = (
@@ -23263,7 +23214,8 @@
 "iXi" = (
 /obj/machinery/sleeper,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	dir = 6;
+	icon_state = "bluemark"
 	},
 /area/f13/ncr)
 "iXt" = (
@@ -27178,12 +27130,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"kzu" = (
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/ncr)
 "kzR" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
@@ -28569,12 +28515,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"lde" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/ncr)
 "ldw" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -36786,10 +36726,6 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/village)
-"oou" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/ncr)
 "ooz" = (
 /mob/living/simple_animal/chicken,
 /turf/open/floor/wood/f13/oak,
@@ -38594,15 +38530,6 @@
 	icon_state = "bar"
 	},
 /area/f13/raiders)
-"pdl" = (
-/obj/machinery/biogenerator,
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/ncr)
 "pdm" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/item/stack/sheet/bone,
@@ -42628,7 +42555,7 @@
 "qLC" = (
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/village)
 "qLO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -43541,7 +43468,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/village)
 "rft" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker,
@@ -51316,7 +51243,7 @@
 "upu" = (
 /obj/machinery/chem_master/primitive,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/village)
 "upz" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalright"
@@ -54100,16 +54027,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"vxi" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "vxl" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/indestructible/ground/outside/dirt,
@@ -54244,7 +54161,7 @@
 	req_access_txt = "121"
 	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
 "vAe" = (
@@ -55249,10 +55166,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"vXs" = (
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/ncr)
 "vXv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_7"
@@ -57888,9 +57801,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"xdi" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/ncr)
 "xdp" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/blood/radaway,
@@ -69067,10 +68977,10 @@ wvV
 bcj
 vpm
 eCh
-eQn
+cYn
 lgR
+dzq
 qQQ
-loX
 qQQ
 wvV
 koD
@@ -69328,7 +69238,7 @@ wyi
 wyi
 mJH
 hVU
-buO
+hVU
 wvV
 bfu
 unI
@@ -69580,10 +69490,10 @@ ktB
 wvV
 gsV
 cuG
-fVF
+bca
 cuG
-fVF
-loX
+qQQ
+qQQ
 qQQ
 qQQ
 wvV
@@ -70350,12 +70260,12 @@ ktB
 ktB
 wvV
 gsV
-bsV
-fVF
-bsV
+buO
 bca
-loX
-fVF
+buO
+qQQ
+qQQ
+qQQ
 bsV
 sBf
 koD
@@ -70610,7 +70520,7 @@ wyi
 wyi
 wyi
 wyi
-qQQ
+dts
 qQQ
 wvV
 wvV
@@ -71127,7 +71037,7 @@ qQQ
 lmc
 lmc
 qQQ
-loX
+qQQ
 iau
 dKW
 unI
@@ -71384,7 +71294,7 @@ lmc
 qQQ
 qQQ
 qQQ
-loX
+qQQ
 vAb
 dKW
 unI
@@ -71634,14 +71544,14 @@ ktB
 (43,1,1) = {"
 ktB
 wvV
-bsV
-bsV
-bsV
+buO
+buO
+buO
 bca
-bsV
+buO
 bca
-bsV
-fVF
+buO
+bca
 wvV
 dKW
 unI
@@ -77155,10 +77065,10 @@ mvv
 mvv
 mvv
 eSC
-vxi
+kje
 upu
-mvv
-mvv
+peu
+peu
 dxM
 cWG
 mpu
@@ -77412,9 +77322,9 @@ mfD
 mfD
 xGH
 mvv
-hYh
+aMo
 fDc
-mvv
+peu
 qLC
 aKX
 dCL
@@ -85522,12 +85432,12 @@ qQQ
 wvV
 wvV
 wvV
-dWH
-wyi
-dVu
-wyi
-wyi
-wyi
+wvV
+wvV
+wvV
+wvV
+wvV
+wvV
 wvV
 wvV
 ayH
@@ -85778,15 +85688,15 @@ fVg
 qQQ
 kXg
 qQQ
-qQQ
-wyi
-lde
-xGv
-nVM
-vXs
-xdi
 wvV
-wvV
+ayH
+ayH
+ayH
+ayH
+ayH
+ayH
+ayH
+ayH
 ayH
 mrq
 mrq
@@ -86035,16 +85945,16 @@ wvV
 lOj
 wvV
 wvV
-lOj
-wyi
-pdl
-xGv
-jQd
-vXs
-xdi
-wvV
 wvV
 ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 mrq
 tOL
 tOL
@@ -86292,16 +86202,16 @@ kyT
 uPy
 wvV
 kyT
-uPy
-wyi
-dts
-kzu
-jQd
-cYn
-oou
-wvV
 wvV
 ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 mrq
 tOL
 tOL
@@ -86549,16 +86459,16 @@ wvV
 bjA
 wvV
 wvV
-bjA
-dWH
-dzq
-xGv
-xGv
-cYn
-oou
-wvV
 wvV
 ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 mrq
 tOL
 tOL
@@ -86807,15 +86717,15 @@ ayH
 ayH
 ayH
 ayH
-wyi
-dBx
-xGv
-xGv
-cYn
-oou
-wvV
-wvV
 ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 mrq
 tOL
 tOL
@@ -87063,16 +86973,16 @@ gcK
 gcK
 gcK
 gbL
-ayH
-wyi
-dTl
-xGv
-xGv
-eWQ
-xdi
-wvV
-wvV
-ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 mrq
 mrq
 mrq
@@ -87320,16 +87230,16 @@ gcK
 gcK
 gcK
 gcK
-ayH
-wvV
-wvV
-xGv
-xGv
-xGv
-wvV
-wvV
-wvV
-ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -87577,16 +87487,16 @@ gcK
 gcK
 gbL
 gcK
-ayH
-ayH
-wvV
-wvV
-dRD
-xGv
-wvV
-ayH
-ayH
-ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 dkg
@@ -87835,13 +87745,13 @@ gcK
 gcK
 gcK
 gcK
-ayH
-wvV
-wvV
-wvV
-wvV
-wvV
-ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -88092,13 +88002,13 @@ gcK
 gcK
 gcK
 gcK
-ayH
-ayH
-ayH
-ayH
-ayH
-ayH
-ayH
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 gcK
 gcK
 gcK
@@ -88352,7 +88262,7 @@ gcK
 gcK
 gcK
 gcK
-gbL
+gcK
 gcK
 gcK
 gcK
@@ -109325,7 +109235,7 @@ kin
 mmH
 cax
 rkr
-cdp
+wGJ
 pRo
 pTC
 koD
@@ -109577,13 +109487,13 @@ fyf
 kGc
 uCW
 pBX
+pOC
 pWN
 plq
-plq
 rkr
-pTC
-snB
-ehN
+wGJ
+wGJ
+wGJ
 ehN
 koD
 gts
@@ -109834,11 +109744,11 @@ igz
 psR
 cpK
 unI
-qvQ
-ehN
+pOC
+pRo
 tPy
 pRo
-ehN
+wGJ
 rbi
 ehN
 ehN
@@ -110091,11 +110001,11 @@ cpK
 cpK
 wVn
 unI
-qvQ
-ehN
-ehN
-ehN
-ehN
+pOC
+pRo
+wGJ
+wGJ
+wGJ
 ehN
 ehN
 ehN
@@ -110348,9 +110258,9 @@ uCW
 uCW
 cpK
 unI
-qvQ
-ehN
-ehN
+rQh
+wGJ
+wGJ
 ehN
 ehN
 ehN
@@ -110606,8 +110516,8 @@ uCW
 uCW
 unI
 qvQ
-iWm
-ehN
+hYh
+wGJ
 ehN
 iWm
 ehN

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -27,6 +27,19 @@
 	color = "#3bbbdb"
 	puzzle_id = "swordfish"
 
+/obj/item/keycard/deathclaw
+	name = "titanic keycard"
+	desc = "Smells like it was stuck in the jaw of that plated Deathclaw. Nasty!"
+	color = "#9edb3b"
+	puzzle_id = "deathclaw"
+
+/obj/item/keycard/vault
+	name = "titanic keycard"
+	desc = "It seems a bit burned from the explosion, but otherwise fine!"
+	color = "#e93737"
+	puzzle_id = "vault"
+
+
 //***************
 //*****Doors*****
 //***************

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -458,7 +458,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	slowdown = 0.05
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 25, "bomb" = 16, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 60, "laser" = 40, "energy" = 25, "bomb" = 16, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/head/hooded/cloakhood/hhunter
 	name = "Razorclaw helm"
@@ -466,7 +466,7 @@
 	icon_state = "rchelmet"
 	heat_protection = HEAD
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 25, "bomb" = 16, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 60, "laser" = 40, "energy" = 25, "bomb" = 16, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/f13/jamrock
 	name = "disco-ass blazer"


### PR DESCRIPTION
## Screenshots
![grafik](https://user-images.githubusercontent.com/69112131/168561863-70c0b9a0-58b1-4ae5-be62-c67dcdb1095d.png)
![grafik](https://user-images.githubusercontent.com/69112131/168561888-c27280d1-acb1-4b3e-a901-0f300f14b00b.png)
![grafik](https://user-images.githubusercontent.com/69112131/168561905-7f835f79-9ebc-42eb-9065-9e7e20f61b44.png)
![grafik](https://user-images.githubusercontent.com/69112131/168561936-30085313-546a-4eec-b527-48ac7fa64c12.png)
![grafik](https://user-images.githubusercontent.com/69112131/168561956-7e7c15f8-4e55-4ad5-88c3-5f066b63e472.png)


## About The Pull Request
This PR does a few things:
- Adds keycard locked doors to the two frequently cheesed dungeons so you'd have to kill "the final boss" to receive the loot
- Removes that one table from the followers
- Patches a few roads
- Increases the melee resistence on the head hunter armour

## Why It's Good For The Game
It would be nice if the dungeons are completed as they were designed to.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: puzzle keycards for the deathclaw dungeon and the vault dungeon
tweak: moved the NCR botany to the medbay
fix: fixed a few patches on the map
/:cl:
