### PR TITLE
Map changes, riot shotgun buff, custom loadout changes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -896,7 +896,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/junk/drawer,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -2036,7 +2035,7 @@
 /area/f13/caves)
 "aRW" = (
 /obj/structure/table,
-/obj/item/clothing/mask/gas/stalker,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -3919,9 +3918,6 @@
 /obj/machinery/light{
 	pixel_x = 16
 	},
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side,
 /area/f13/building)
 "bCp" = (
@@ -4332,11 +4328,11 @@
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/building)
 "bKF" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "ruinswindowdestroyed"
+/obj/structure/sign/plaques/kiddie/library{
+	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place."
 	},
-/turf/open/floor/wood,
-/area/f13/building)
+/turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
 "bKJ" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -4362,12 +4358,10 @@
 	},
 /area/f13/wasteland)
 "bLK" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "bLP" = (
@@ -4456,16 +4450,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "bNA" = (
-/obj/item/stack/sheet/mineral/wood,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_7"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 6;
-	icon_state = "rubble"
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "bNK" = (
@@ -4476,9 +4465,11 @@
 	},
 /area/f13/wasteland)
 "bNL" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/wood/f13/old/ruinedstraightnorth,
-/area/f13/wasteland)
+/obj/machinery/recycler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/caves)
 "bOe" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -4824,9 +4815,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "bUR" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -5132,7 +5121,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "cbX" = (
 /obj/structure/car/rubbish3,
@@ -6240,7 +6229,8 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "cBQ" = (
 /obj/structure/simple_door/house,
@@ -6565,12 +6555,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "cJD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_7"
 	},
-/obj/item/clothing/suit/toggle/labcoat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "cJE" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
@@ -6822,11 +6814,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "cPr" = (
-/obj/item/reagent_containers/glass/beaker/waterbottle/empty,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "cPF" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -7060,10 +7056,13 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cWu" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6;
+	pixel_x = 7
 	},
-/area/f13/followers)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cWy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -7091,7 +7090,7 @@
 	height = 2;
 	id = "shopladder"
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "cXc" = (
 /obj/structure/rack{
@@ -7101,7 +7100,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "cXe" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7193,7 +7192,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "cYu" = (
 /obj/structure/fluff/paper/corner,
@@ -7237,18 +7236,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/village)
-"cYX" = (
-/obj/structure/table/wood,
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
-	},
-/turf/open/floor/wood/f13/old{
-	icon_state = "housebase"
-	},
-/area/f13/building)
 "cYY" = (
 /obj/machinery/vending/coffee,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7326,7 +7313,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dbj" = (
 /obj/machinery/light,
@@ -7468,12 +7455,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "dea" = (
-/obj/item/stack/sheet/mineral/wood,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6;
+	pixel_x = 7
 	},
-/turf/open/floor/wood/f13/old{
-	icon_state = "housebase"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "deo" = (
@@ -7530,7 +7519,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dfr" = (
 /obj/structure/closet,
@@ -7580,7 +7569,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dgp" = (
 /obj/structure/barricade/wooden,
@@ -8375,7 +8364,7 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dve" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8904,15 +8893,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"dEt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/radroach{
-	layer = 2.7
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/building)
 "dEw" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9217,7 +9197,9 @@
 	color = "#363636"
 	},
 /obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
 /area/f13/village)
 "dNo" = (
 /obj/effect/overlay/junk/sink{
@@ -9327,12 +9309,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "dOS" = (
-/obj/structure/table,
 /obj/item/storage/pill_bottle,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "dOW" = (
@@ -9395,7 +9377,7 @@
 "dRs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dRA" = (
 /obj/effect/decal/marking{
@@ -9437,7 +9419,7 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dSg" = (
 /obj/structure/rack,
@@ -9581,7 +9563,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "dVt" = (
 /obj/structure/window/fulltile/store{
@@ -10403,7 +10385,8 @@
 	},
 /area/f13/wasteland)
 "elK" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
 /area/f13/building)
 "elL" = (
 /obj/structure/barricade/wooden,
@@ -10547,7 +10530,9 @@
 	desc = "It's a corgi. He looks hungry";
 	name = "Ol' Scruff"
 	},
-/turf/open/indestructible/ground/outside/ruins,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
 /area/f13/village)
 "enF" = (
 /obj/structure/table/reinforced,
@@ -11108,9 +11093,10 @@
 "eyC" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Store";
-	req_one_access_txt = "34"
+	req_one_access_txt = "34";
+	normal_integrity = 500
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "eyT" = (
 /obj/structure/table/wood,
@@ -11606,7 +11592,7 @@
 	color = "000000"
 	},
 /obj/item/clothing/head/soft/emt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "eJQ" = (
 /obj/structure/table,
@@ -11885,9 +11871,7 @@
 /area/f13/building)
 "eOr" = (
 /obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "eOK" = (
 /obj/effect/decal/cleanable/generic,
@@ -12064,9 +12048,7 @@
 	dir = 4;
 	pixel_y = -16
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "eSC" = (
 /obj/structure/flora/grass/wasteland{
@@ -12419,7 +12401,10 @@
 /area/f13/building)
 "far" = (
 /obj/machinery/trading_machine,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "fas" = (
 /obj/structure/barricade/wooden,
@@ -12436,7 +12421,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "faG" = (
 /turf/open/floor/f13{
@@ -12469,7 +12457,10 @@
 /area/f13/wasteland)
 "fbo" = (
 /obj/machinery/trading_machine/ammo,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "fbq" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -12826,7 +12817,10 @@
 /area/f13/raiders)
 "fgQ" = (
 /obj/machinery/trading_machine/armor,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "fhh" = (
 /obj/structure/rack,
@@ -13431,7 +13425,10 @@
 /area/f13/city)
 "fuV" = (
 /obj/machinery/trading_machine/weapon,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "fvi" = (
 /obj/structure/wreck/car,
@@ -15691,21 +15688,18 @@
 /area/f13/wasteland)
 "gmg" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar"
-	},
-/area/f13/village)
+/obj/structure/simple_door/house,
+/turf/open/floor/wood,
+/area/f13/building)
 "gmn" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "gmz" = (
 /turf/open/floor/wood/f13/old/ruinedcornertl,
@@ -16058,9 +16052,7 @@
 "gso" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder/constructed,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "gsu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16243,9 +16235,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "gva" = (
 /obj/machinery/light/small/broken{
@@ -16754,7 +16744,10 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/wood/f13/oakbroken,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gCR" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -17140,7 +17133,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gMx" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
@@ -17434,8 +17426,9 @@
 	},
 /area/f13/ncr)
 "gSc" = (
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -17727,7 +17720,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "gZD" = (
 /obj/machinery/light{
@@ -17992,7 +17985,7 @@
 	name = "pre-war advertising television";
 	pixel_y = -4
 	},
-/turf/closed/wall/f13/supermart,
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "heh" = (
 /obj/structure/table/wood,
@@ -18077,9 +18070,7 @@
 "hfq" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hft" = (
 /obj/structure/table/optable,
@@ -18120,9 +18111,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hfU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -18161,9 +18150,7 @@
 /obj/structure/table/reinforced,
 /obj/item/roller,
 /obj/item/roller,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hgd" = (
 /obj/structure/stairs/east,
@@ -18227,7 +18214,7 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "hgM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -18344,9 +18331,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hiJ" = (
 /obj/structure/flora/tree/cactus,
@@ -18466,10 +18451,8 @@
 	},
 /area/f13/building)
 "hkF" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "housewindowbroken"
-	},
 /obj/structure/barricade/bars,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "hkP" = (
@@ -18490,9 +18473,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hll" = (
 /obj/structure/flora/grass/wasteland{
@@ -19644,7 +19625,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "hGA" = (
 /mob/living/simple_animal/hostile/raider/baseball,
@@ -19748,9 +19729,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hHM" = (
 /obj/structure/filingcabinet,
@@ -19817,9 +19796,7 @@
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hJg" = (
 /obj/structure/campfire/barrel,
@@ -19875,9 +19852,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "hKo" = (
 /obj/machinery/vending/nukacolavend,
@@ -19891,11 +19866,6 @@
 /obj/item/storage/money_stack/legion,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"hKr" = (
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/followers)
 "hKz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rock/jungle,
@@ -20469,7 +20439,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "hXf" = (
 /obj/effect/decal/fakelattice{
@@ -20659,7 +20629,7 @@
 	},
 /area/f13/building)
 "hZC" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "hZD" = (
 /obj/machinery/grill{
@@ -20749,17 +20719,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
 /obj/item/trash/f13/fancylads,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "iaP" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/sign/plaques/kiddie/library{
+	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place.";
+	name = "RobCo Notice Board"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
-/area/f13/building)
+/turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
 "iaV" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -20997,7 +20965,7 @@
 /obj/structure/chair/booth{
 	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "ifW" = (
 /obj/structure/sign/poster/contraband/space_cola{
@@ -21047,7 +21015,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "ihp" = (
 /obj/effect/decal/remains/human,
@@ -21361,11 +21329,9 @@
 	},
 /area/f13/wasteland)
 "ioT" = (
-/obj/structure/junk/micro,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/closed/wall/f13/tunnel,
+/area/f13/caves)
 "ipj" = (
 /turf/open/floor/wood/f13/old/ruinedcornerbr,
 /area/f13/wasteland)
@@ -22008,14 +21974,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"iDf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/trash/candy,
-/obj/item/trash/sosjerky,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
 "iDg" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -22059,7 +22017,7 @@
 /area/f13/building)
 "iDU" = (
 /obj/effect/landmark/start/f13/shopkeeper,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "iDX" = (
 /obj/item/clothing/head/helmet/f13/combat/rangerbroken,
@@ -22473,9 +22431,7 @@
 	id = "soupkitchen";
 	pixel_y = 31
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "iLr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22495,9 +22451,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "iLQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22563,9 +22517,7 @@
 	dir = 8
 	},
 /obj/structure/bed/roller,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "iNx" = (
 /obj/structure/car/rubbish3,
@@ -22597,9 +22549,7 @@
 	name = "Surgery Room";
 	req_one_access_txt = "124"
 	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "iNM" = (
 /obj/structure/flora/grass/wasteland{
@@ -23190,13 +23140,6 @@
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
-"iWr" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "iWt" = (
 /obj/machinery/light/sign/chiken_ranch{
 	pixel_x = -17
@@ -23734,6 +23677,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/glass/beaker,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
 "jha" = (
@@ -24236,9 +24180,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "jqU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24294,15 +24236,11 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/bed/roller,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "jsq" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "jsz" = (
 /obj/structure/displaycase,
@@ -24720,7 +24658,7 @@
 	pixel_y = 15
 	},
 /obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "jzY" = (
 /obj/structure/fence/wooden{
@@ -25023,14 +24961,11 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "jHQ" = (
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/recycler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/area/f13/wasteland)
 "jIe" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -25829,13 +25764,13 @@
 	},
 /area/f13/building)
 "jXv" = (
-/obj/structure/simple_door/metal/dirtystore,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/structure/simple_door/house,
 /turf/open/floor/wood,
 /area/f13/building)
 "jYb" = (
@@ -26397,7 +26332,7 @@
 /obj/structure/chair/left{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "kje" = (
 /obj/structure/barricade/tentclothedge{
@@ -26795,7 +26730,7 @@
 /area/f13/building)
 "kqv" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "kqx" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -26822,7 +26757,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "krc" = (
 /obj/structure/sign/poster/ncr/democracy,
@@ -27284,7 +27219,7 @@
 	},
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "kCN" = (
 /obj/structure/table/wood,
@@ -27718,7 +27653,7 @@
 /area/f13/village)
 "kLO" = (
 /obj/machinery/trading_machine/medical,
-/turf/closed/wall/f13/supermart,
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "kMl" = (
 /turf/open/floor/f13{
@@ -28181,7 +28116,7 @@
 /area/f13/building)
 "kWt" = (
 /obj/effect/landmark/start/f13/assistant,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kWC" = (
 /obj/structure/table/wood,
@@ -28189,10 +28124,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "kWH" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "housewindowbrokenvertical"
-	},
 /obj/structure/barricade/bars,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "kWJ" = (
@@ -28226,10 +28159,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"kXt" = (
-/obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
 "kXy" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -28574,9 +28503,7 @@
 /area/f13/building)
 "ldX" = (
 /obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "lei" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28636,7 +28563,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "leu" = (
 /obj/structure/barricade/wooden,
@@ -28647,7 +28574,7 @@
 "lez" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "leM" = (
 /obj/structure/fence,
@@ -28665,13 +28592,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"leT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
 "leX" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -28941,6 +28861,7 @@
 /area/f13/wasteland)
 "ljZ" = (
 /obj/machinery/workbench,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -29908,10 +29829,15 @@
 	},
 /area/f13/wasteland)
 "lGf" = (
-/obj/item/trash/candy,
-/obj/item/trash/sosjerky,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "lGq" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30136,7 +30062,7 @@
 /area/f13/wasteland)
 "lMA" = (
 /obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "lMB" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -30708,10 +30634,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/legion)
-"lWp" = (
-/obj/item/trash/sosjerky,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
 "lWx" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
@@ -30822,7 +30744,7 @@
 	pixel_y = -2
 	},
 /obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "lYy" = (
 /obj/structure/chair/booth{
@@ -30831,7 +30753,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "lYA" = (
 /obj/structure/table/booth,
@@ -31050,7 +30972,10 @@
 /area/f13/building)
 "mcI" = (
 /obj/structure/chair/bench,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "mcN" = (
 /turf/closed/wall/f13/tunnel,
@@ -31074,9 +30999,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "mdB" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31101,9 +31024,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "mee" = (
 /obj/structure/rack,
@@ -31141,9 +31062,7 @@
 "meY" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "mfg" = (
 /obj/structure/rack,
@@ -31174,7 +31093,7 @@
 /area/f13/city)
 "mfn" = (
 /obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/f13/supermart,
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "mfo" = (
 /obj/effect/decal/fakelattice{
@@ -31632,9 +31551,7 @@
 /area/f13/caves)
 "moc" = (
 /obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "mof" = (
 /obj/structure/table,
@@ -31841,9 +31758,7 @@
 /area/f13/building)
 "mqG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "mqZ" = (
 /obj/effect/decal/cleanable/blood,
@@ -32241,7 +32156,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "mzL" = (
 /obj/effect/decal/cleanable/dirt{
@@ -32456,18 +32371,11 @@
 	},
 /area/f13/building)
 "mCM" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "mCR" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "mCZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -32519,15 +32427,12 @@
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/brotherhood/surface)
 "mFu" = (
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
-/area/f13/followers)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
 "mFz" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "mGe" = (
 /obj/structure/table,
@@ -32815,7 +32720,7 @@
 /area/f13/village)
 "mKk" = (
 /obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "mKm" = (
 /obj/structure/wreck/trash/engine,
@@ -33983,7 +33888,7 @@
 "ngg" = (
 /obj/item/kitchen/rollingpin,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "ngl" = (
 /obj/effect/decal/cleanable/dirt{
@@ -34030,7 +33935,7 @@
 	desc = "It's a strangely clean little white rodent.";
 	name = "Algernon"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "ngP" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -34136,15 +34041,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/raiders)
 "niI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/gallow,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "niU" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -34228,7 +34127,7 @@
 /area/f13/wasteland)
 "nlv" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/supermart,
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "nly" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34243,9 +34142,7 @@
 /area/f13/brotherhood/surface)
 "nlA" = (
 /obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nlN" = (
 /obj/structure/table/wood,
@@ -34424,9 +34321,7 @@
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "npI" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -34590,12 +34485,8 @@
 	},
 /area/f13/wasteland)
 "nsz" = (
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/caves)
 "nsE" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/building)
@@ -34715,9 +34606,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nvH" = (
 /obj/structure/table/wood,
@@ -34944,7 +34833,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "nAX" = (
 /obj/structure/lattice/catwalk,
@@ -35264,7 +35153,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "nJq" = (
 /obj/effect/decal/cleanable/dirt{
@@ -35440,9 +35329,7 @@
 /area/f13/caves)
 "nMs" = (
 /obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nME" = (
 /obj/effect/decal/remains/human,
@@ -35629,9 +35516,7 @@
 /area/f13/legion)
 "nQk" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nQM" = (
 /obj/structure/barricade/sandbags{
@@ -35641,9 +35526,7 @@
 /area/f13/caves)
 "nQP" = (
 /obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nRb" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -35750,9 +35633,7 @@
 /area/f13/wasteland)
 "nTm" = (
 /obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nTx" = (
 /obj/structure/simple_door/repaired,
@@ -35910,9 +35791,7 @@
 /obj/machinery/door/airlock/glass_large{
 	name = "Followers Clinic"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "nWy" = (
 /obj/structure/chair{
@@ -36663,9 +36542,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "onh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36701,9 +36578,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "onD" = (
 /obj/structure/decoration/clock/old/active,
@@ -36760,9 +36635,7 @@
 "ooE" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/medsprays,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "opl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36860,9 +36733,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/medical,
 /obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "oqL" = (
 /obj/structure/car/rubbish2,
@@ -37281,6 +37152,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/item/clothing/head/f13/police/officer,
 /obj/item/clothing/under/f13/police/officer,
+/obj/item/clothing/mask/gas/sechailer/swat,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -37464,7 +37336,7 @@
 /obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/sugarcookie,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "oFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37689,9 +37561,7 @@
 	name = "Kitchen";
 	req_one_access_txt = "124"
 	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "oJm" = (
 /obj/structure/closet,
@@ -37732,7 +37602,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "oLt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38232,7 +38102,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_west_north"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "oXi" = (
 /obj/structure/window/fulltile/wood,
@@ -38696,10 +38566,10 @@
 /area/f13/wasteland)
 "pfK" = (
 /obj/structure/barricade/wooden,
-/obj/item/clothing/head/helmet/f13/deathskull{
-	anchored = 1
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/closed/wall/f13/wood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "pfX" = (
 /obj/structure/decoration/clock{
@@ -38781,12 +38651,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pgL" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall,
+/area/f13/building)
 "pgM" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38862,9 +38729,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "pix" = (
 /obj/structure/chair/sofa/corner,
@@ -39119,10 +38984,12 @@
 	},
 /area/f13/building)
 "pon" = (
-/obj/effect/decal/remains/human,
-/obj/item/flag/khan,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building)
 "poo" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -39146,7 +39013,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "poJ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -39270,9 +39137,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "greendirtyfull"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "prp" = (
 /obj/structure/barricade/tentclothedge,
@@ -39292,9 +39157,7 @@
 	},
 /area/f13/wasteland)
 "prO" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "ruinswindowbroken"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/f13/building)
 "prP" = (
@@ -39328,9 +39191,9 @@
 /turf/open/floor/wood,
 /area/f13/building)
 "psu" = (
-/obj/item/flag/khan,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/r_wall,
+/area/f13/followers)
 "psK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -39432,7 +39295,7 @@
 /obj/structure/chair/booth{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "puY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39771,20 +39634,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "pDv" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleslab"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "pDw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -40033,6 +39887,8 @@
 	pixel_x = 16
 	},
 /obj/structure/closet/cardboard,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "pIQ" = (
@@ -41775,9 +41631,6 @@
 	},
 /area/f13/village)
 "quv" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41917,9 +41770,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qyo" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "qyt" = (
 /obj/machinery/light{
@@ -42021,7 +41872,7 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "qzI" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -42049,7 +41900,8 @@
 "qAz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "qAJ" = (
 /obj/structure/dresser,
@@ -42376,7 +42228,7 @@
 /area/f13/legion)
 "qHe" = (
 /obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "qHk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42545,13 +42397,7 @@
 /area/f13/wasteland)
 "qKr" = (
 /obj/item/reagent_containers/syringe,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "qKu" = (
 /obj/structure/table/wood,
@@ -42644,7 +42490,7 @@
 /area/f13/building)
 "qMq" = (
 /obj/structure/decoration/smokeold,
-/turf/closed/wall/f13/supermart,
+/turf/closed/wall/r_wall,
 /area/f13/followers)
 "qMt" = (
 /obj/structure/table/wood/settler,
@@ -42867,9 +42713,12 @@
 	},
 /area/f13/wasteland)
 "qQq" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/wood,
-/area/f13/building)
+/obj/structure/sign/plaques/kiddie/library{
+	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place.";
+	name = "RobCo Notice Board"
+	},
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "qQx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -43472,11 +43321,11 @@
 	},
 /area/f13/village)
 "reZ" = (
-/obj/structure/table,
 /obj/structure/barricade/bars,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "rfd" = (
@@ -43902,7 +43751,7 @@
 	color = "000000"
 	},
 /obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "rpe" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44033,8 +43882,7 @@
 "rsA" = (
 /obj/machinery/iv_drip,
 /obj/machinery/iv_drip,
-/obj/item/clothing/under/f13/doctor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "rsH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -44168,9 +44016,7 @@
 	dir = 1;
 	layer = 2.5
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "rwO" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -44471,9 +44317,7 @@
 	dir = 1;
 	layer = 2.5
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "rEm" = (
 /obj/structure/table/wood,
@@ -44565,9 +44409,7 @@
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "rGE" = (
 /obj/structure/rack,
@@ -44650,7 +44492,7 @@
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "rHZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44933,7 +44775,7 @@
 /obj/structure/chair/right{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "rOm" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44961,11 +44803,11 @@
 	},
 /area/f13/building)
 "rOY" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "rPd" = (
@@ -45121,17 +44963,14 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "rSW" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 5;
-	icon_state = "rubble"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "rTa" = (
 /obj/structure/nest/raider{
@@ -45915,7 +45754,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "siR" = (
-/obj/structure/table,
 /obj/item/reagent_containers/pill/happiness{
 	pixel_x = -4;
 	pixel_y = 2
@@ -45924,6 +45762,8 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "siS" = (
@@ -46470,13 +46310,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building)
 "stM" = (
-/obj/item/shard,
-/obj/effect/decal/cleanable/glass,
 /obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "stN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46534,14 +46369,11 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/ruins,
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "svW" = (
 /obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "swk" = (
 /obj/structure/window/fulltile/house{
@@ -46574,9 +46406,7 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "swD" = (
 /obj/structure/chair/bench,
@@ -46612,10 +46442,7 @@
 	pixel_x = -3;
 	pixel_y = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "sxl" = (
 /obj/machinery/light/small/broken,
@@ -46854,10 +46681,7 @@
 	pixel_x = -5;
 	pixel_y = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "sDp" = (
 /obj/structure/simple_door/room,
@@ -47214,10 +47038,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "sKl" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -47802,9 +47623,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "sVe" = (
 /turf/open/indestructible/ground/outside/road{
@@ -47905,9 +47724,7 @@
 /area/f13/building)
 "sWG" = (
 /obj/machinery/processor,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "sWR" = (
 /obj/structure/chair{
@@ -47961,9 +47778,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "sYe" = (
 /obj/structure/chalkboard{
@@ -47972,9 +47787,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
 "sYt" = (
-/obj/item/trash/candy,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sYH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -47984,9 +47805,7 @@
 /obj/structure/chopping_block{
 	pixel_y = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "sYV" = (
 /turf/open/floor/f13/wood{
@@ -48345,20 +48164,6 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
-"tii" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
-/obj/structure/barricade/wooden/strong,
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "tik" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -48630,8 +48435,8 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/table_frame,
-/obj/item/stack/sheet/metal,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
 "tmH" = (
@@ -49069,7 +48874,7 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "tvM" = (
-/obj/structure/junk/small/table,
+/obj/machinery/workbench/bottler,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -49315,9 +49120,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "tBc" = (
 /obj/effect/decal/remains/human,
@@ -49512,7 +49315,9 @@
 /area/f13/village)
 "tGS" = (
 /obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
 /area/f13/village)
 "tGV" = (
 /obj/effect/decal/cleanable/glass,
@@ -49672,16 +49477,19 @@
 	},
 /area/f13/caves)
 "tLP" = (
-/obj/structure/junk/drawer{
-	icon_state = "junk_bench"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6;
+	pixel_x = 7
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/area/f13/building)
-"tLS" = (
-/turf/open/floor/wood/f13/old/ruinedcornerbl,
 /area/f13/wasteland)
+"tLS" = (
+/turf/closed/wall/r_wall,
+/area/f13/building)
 "tLW" = (
 /obj/structure/chair{
 	dir = 4
@@ -49725,14 +49533,9 @@
 /turf/open/floor/plating/rust,
 /area/f13/village)
 "tMU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/junk/machinery,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "tMX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -50232,7 +50035,7 @@
 	},
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "tXo" = (
 /obj/structure/decoration/rag{
@@ -50482,7 +50285,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "ubH" = (
 /obj/structure/table,
@@ -50623,13 +50426,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/legion)
 "udV" = (
-/obj/item/trash/candy{
-	pixel_x = 7;
-	pixel_y = 6
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_7"
 	},
-/obj/item/trash/candy,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/savannah/topcenter,
+/area/f13/wasteland)
 "ued" = (
 /obj/structure/decoration/clock/old/active{
 	pixel_y = 32
@@ -50780,7 +50581,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "ugo" = (
 /obj/machinery/light/small,
@@ -51022,7 +50823,7 @@
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/eyepatch,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "ukh" = (
 /obj/effect/decal/marking{
@@ -51539,9 +51340,7 @@
 /obj/item/reagent_containers/food/snacks/rawbrahmintongue,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
 "uvb" = (
 /obj/structure/tires/five,
@@ -51804,17 +51603,14 @@
 	color = "000000"
 	},
 /obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "uBE" = (
-/obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "uBJ" = (
 /obj/structure/musician/piano,
@@ -51869,8 +51665,8 @@
 /area/f13/legion)
 "uCT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/booth,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "uCW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -51901,7 +51697,7 @@
 "uDk" = (
 /obj/effect/landmark/start/f13/barkeep,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "uDp" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -52111,10 +51907,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "uGB" = (
 /obj/effect/decal/waste{
@@ -52145,14 +51938,10 @@
 /area/f13/village)
 "uHg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	bulb_colour = "#008000";
-	desc = "A lighting fixture.";
-	dir = 4;
-	light_color = "#008000";
-	name = "light tube"
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "uHo" = (
 /obj/machinery/computer/shuttle/bunkerelevator{
@@ -52220,7 +52009,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "uIT" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -52252,12 +52041,9 @@
 /turf/open/water,
 /area/f13/caves)
 "uKB" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
 "uKC" = (
@@ -52265,10 +52051,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uKQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building)
 "uKY" = (
 /obj/structure/chair,
@@ -52283,12 +52072,9 @@
 	},
 /area/f13/village)
 "uLh" = (
-/obj/structure/table_frame,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/obj/structure/table/glass,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "uLk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -52786,9 +52572,6 @@
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "uUM" = (
@@ -53685,10 +53468,7 @@
 /obj/structure/decoration/cctv{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "voF" = (
 /obj/structure/barricade/sandbags,
@@ -54382,7 +54162,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "vDP" = (
 /obj/structure/fence/wooden,
@@ -54392,12 +54172,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vDU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6;
+	pixel_x = 7
 	},
-/obj/item/trash/candy,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vEf" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -54426,11 +54207,8 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "vEQ" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "housewindow"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall,
 /area/f13/building)
 "vFn" = (
 /obj/structure/rack,
@@ -54923,7 +54701,7 @@
 /obj/structure/rack,
 /obj/item/soap,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "vQe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55088,9 +54866,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vUG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oakbroken4,
-/area/f13/building)
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "vVa" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/f13/autumn,
@@ -55271,7 +55049,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "vYK" = (
 /obj/effect/decal/cleanable/dirt{
@@ -55285,10 +55063,8 @@
 /area/f13/building)
 "vYN" = (
 /obj/structure/grille/indestructable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/spawner/structure/window/plastitanium,
+/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "vZm" = (
 /obj/machinery/light/small/broken{
@@ -55323,7 +55099,7 @@
 	pixel_x = 28;
 	req_one_access_txt = "28"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "waA" = (
 /obj/structure/decoration/rag,
@@ -55436,10 +55212,7 @@
 /area/f13/building)
 "wdK" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "wef" = (
 /obj/effect/decal/remains/human,
@@ -55786,10 +55559,7 @@
 	color = "000000"
 	},
 /obj/item/storage/pill_bottle,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "wmN" = (
 /obj/structure/fence,
@@ -55825,10 +55595,7 @@
 /area/f13/village)
 "wnn" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "wno" = (
 /obj/structure/girder/reinforced,
@@ -55931,10 +55698,7 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building)
 "wpd" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -56112,7 +55876,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wtq" = (
-/obj/structure/junk/cabinet,
+/obj/machinery/workbench/forge,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -56409,11 +56173,6 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/building)
-"wAE" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/item/crafting/abraxo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "wAK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57163,12 +56922,12 @@
 "wPU" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
-	icon_state = "skin"
+	icon_state = "skulls";
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "wPW" = (
 /obj/structure/fence/handrail{
 	dir = 1;
@@ -58167,14 +57926,9 @@
 	},
 /area/f13/wasteland)
 "xjv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/junk/small/table,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
+/obj/machinery/recycler,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/caves)
 "xjA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58249,7 +58003,7 @@
 /obj/item/key,
 /obj/item/key,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "xlx" = (
 /obj/structure/tires/five,
@@ -59170,7 +58924,7 @@
 "xDK" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
 "xDL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59550,9 +59304,7 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "xJZ" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
+/obj/structure/simple_door/house,
 /turf/open/floor/wood,
 /area/f13/building)
 "xKb" = (
@@ -59883,7 +59635,7 @@
 	pixel_y = 8
 	},
 /obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/orange,
 /area/f13/building)
 "xSs" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -60263,7 +60015,7 @@
 /area/f13/building)
 "ybC" = (
 /obj/item/trash/f13/porknbeans,
-/turf/open/floor/wood/f13/old/ruinedstraightsouth,
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "ybI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -61884,7 +61636,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+nsz
 cpK
 unI
 qvQ
@@ -62140,8 +61892,8 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
+nsz
+nsz
 cpK
 unI
 qvQ
@@ -62224,7 +61976,7 @@ gcK
 gcK
 gcK
 mwp
-mnl
+mwp
 mwp
 mwp
 mwp
@@ -62397,9 +62149,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+nsz
+nsz
+nsz
 unI
 qvQ
 ehN
@@ -62520,9 +62272,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-kGc
-unI
+vaA
+ehN
+mFu
 qvQ
 ehN
 ehN
@@ -62654,13 +62406,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+vaA
+nsz
+ioT
 unI
 qvQ
 ehN
-rbi
+ehN
 koD
 dMW
 fyf
@@ -62777,9 +62529,9 @@ fyf
 gcK
 gcK
 gcK
-fyf
-kGc
-unI
+mcN
+jHQ
+iaP
 qvQ
 hOl
 ehN
@@ -62911,9 +62663,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-cpK
+vaA
+xjv
+iaP
 pBv
 qvQ
 ehN
@@ -63034,9 +62786,9 @@ fyf
 gcK
 gcK
 fyf
-fyf
-kGc
-unI
+mcN
+mcN
+mcN
 qvQ
 hOl
 ehN
@@ -63168,9 +62920,9 @@ lae
 gcK
 gcK
 gcK
-gcK
-gcK
-cpK
+vaA
+vaA
+mcN
 pBX
 qvQ
 ehN
@@ -63291,9 +63043,9 @@ fyf
 fyf
 gcK
 fyf
-fyf
-kGc
-pBv
+mcN
+mcN
+mFu
 qvQ
 hOl
 hOl
@@ -63425,13 +63177,13 @@ gcK
 gcK
 gcK
 gcK
-gcK
-kGc
-cpK
-xFQ
-rMB
-nUd
-wPU
+vaA
+mcN
+mFu
+wVq
+qvQ
+ehN
+ehN
 wwM
 dMW
 fyf
@@ -82546,7 +82298,7 @@ pfk
 gts
 qHN
 xoh
-dEt
+xoh
 xoh
 xoh
 xoh
@@ -86133,7 +85885,7 @@ vDE
 xlb
 dCV
 rEk
-gHP
+vZE
 mqG
 gts
 mvv
@@ -87926,7 +87678,7 @@ uCO
 lhW
 lVe
 gGz
-fRk
+aRl
 gGz
 gGz
 oHT
@@ -88187,7 +87939,7 @@ aRl
 aRl
 aRl
 aRl
-qAz
+uCT
 kiW
 xft
 gts
@@ -88443,7 +88195,7 @@ ifU
 uHg
 nIP
 aRl
-vUG
+gGz
 qzF
 rHT
 xft
@@ -88701,7 +88453,7 @@ uCT
 jzN
 aRl
 gGz
-qAz
+uCT
 rND
 dCV
 gts
@@ -88954,7 +88706,7 @@ kgU
 uqf
 csQ
 puV
-niI
+puV
 puV
 aRl
 aRl
@@ -89213,7 +88965,7 @@ aRl
 gGz
 aRl
 gGz
-vUG
+gGz
 rQx
 dCV
 uqa
@@ -89983,7 +89735,7 @@ uCO
 lYu
 qAz
 gGz
-vUG
+gGz
 aRl
 iaM
 qHe
@@ -91505,11 +91257,11 @@ uhi
 ees
 gts
 dCV
-cKy
-dCV
-dCV
-dCV
-kJn
+vEQ
+tLS
+tLS
+tLS
+pgL
 eWT
 ftA
 fRM
@@ -91762,11 +91514,11 @@ ptf
 ptf
 gts
 dCV
-sYX
+tLS
 cWS
-aRl
+tOF
 dRs
-sYX
+tLS
 sYX
 sYX
 sYX
@@ -92019,11 +91771,11 @@ fyf
 fyf
 gts
 dCV
-sYX
-sYX
-aRl
-aRl
-sYX
+tLS
+tLS
+tOF
+tOF
+tLS
 far
 fuV
 sYX
@@ -92276,13 +92028,13 @@ fyf
 fyf
 gts
 dCV
-sYX
+tLS
 cXc
-aRl
-aRl
+tOF
+tOF
 eyC
-aRl
-aRl
+uKB
+uKB
 fRQ
 nWl
 cJE
@@ -92533,13 +92285,13 @@ fyf
 fyf
 gts
 dCV
-sYX
+tLS
 cYp
-aRl
-aRl
-sYX
-rEe
-aRl
+tOF
+tOF
+tLS
+uKQ
+uKB
 sYX
 qUC
 cJE
@@ -92790,12 +92542,12 @@ fyf
 fyf
 gts
 dCV
-eWW
+elK
 dbh
-aRl
+tOF
 iDU
 rkt
-aRl
+uKB
 mcI
 xAx
 qUC
@@ -93047,12 +92799,12 @@ fyf
 fyf
 gts
 dCV
-eWW
+elK
 cBO
-aRl
-aRl
+tOF
+tOF
 eLM
-aRl
+uKB
 mcI
 fTr
 qUC
@@ -93094,7 +92846,7 @@ kWH
 usx
 usx
 usx
-qQq
+xJZ
 xJZ
 hfd
 dKW
@@ -93304,12 +93056,12 @@ fyf
 fyf
 gts
 dCV
-eWW
+elK
 dVs
-aRl
+tOF
 kWt
 ezt
-aRl
+uKB
 mcI
 sYX
 vmB
@@ -93351,9 +93103,9 @@ kCG
 ukg
 usx
 voz
-voR
-voR
-nmS
+uBE
+uBE
+gmg
 dKW
 pBv
 qvQ
@@ -93561,12 +93313,12 @@ fyf
 fyf
 gts
 dCV
-eWW
+elK
 deX
-aRl
-aRl
-sYX
-aRl
+tOF
+tOF
+tLS
+uKB
 mcI
 sYX
 sxT
@@ -93603,13 +93355,13 @@ wGJ
 pTC
 usx
 tXe
-uKQ
-uKQ
-uKQ
+uBE
+uBE
+uBE
 reZ
-voR
-voR
-iaP
+kLg
+kLg
+kLg
 jXv
 dKW
 pBX
@@ -93818,13 +93570,13 @@ fyf
 fyf
 gts
 dCV
-eWW
+elK
 dge
 dvc
 dRT
-sYX
+tLS
 faC
-gGz
+pon
 eWW
 sxT
 fGr
@@ -93861,11 +93613,11 @@ pTC
 usx
 ubv
 uIH
-rSQ
-elK
+uBE
+kLg
 siR
-voR
-voR
+kLg
+kLg
 cbS
 hfd
 dKW
@@ -94075,11 +93827,11 @@ gts
 gts
 gts
 dCV
-eWW
-sYX
-sYX
-eWW
-eWW
+elK
+tLS
+tLS
+elK
+elK
 fbo
 fgQ
 sYX
@@ -94117,12 +93869,12 @@ wGJ
 qbF
 usx
 ugm
-uKQ
+uBE
 eJO
-uKQ
+uBE
 rOY
 qKr
-nsz
+kqG
 cbS
 prO
 dKW
@@ -94343,13 +94095,13 @@ sYX
 sxT
 sxT
 qUC
-dxx
+psu
 vYN
 vYN
 vYN
 vYN
 vYN
-dxx
+psu
 oAV
 qUC
 qSN
@@ -94374,14 +94126,14 @@ wGJ
 svA
 usx
 uBC
-uKQ
+uBE
 uIH
-uKQ
+uBE
 tmF
-voR
-voR
+uBE
+uBE
 gZy
-bKF
+prO
 sBk
 vCc
 qvQ
@@ -94599,13 +94351,13 @@ gay
 nWl
 sxT
 sxT
-rhM
-rhM
+mCM
+mCM
 sVc
 hkY
 hkY
-cWu
-cWu
+qyo
+qyo
 nWu
 kgD
 qSN
@@ -94632,7 +94384,7 @@ usx
 usx
 usx
 vYF
-uKQ
+uBE
 uIH
 rOY
 dOS
@@ -94856,14 +94608,14 @@ ftX
 qUC
 nWl
 sxT
-rhM
+mCM
 hdY
 ldX
-cWu
-cWu
-cWu
-cWu
-cWu
+qyo
+qyo
+qyo
+qyo
+qyo
 kgD
 qSN
 nMk
@@ -94889,11 +94641,11 @@ usx
 sKe
 uBE
 wdK
-uKQ
+uBE
 uIH
-uKQ
-uKQ
-uKQ
+uBE
+uBE
+uBE
 pos
 hkF
 sBk
@@ -95113,19 +94865,19 @@ qUC
 qUC
 qUC
 tQl
-rhM
-rhM
+mCM
+mCM
 hHK
-cWu
-cWu
-cWu
+qyo
+qyo
+qyo
 eOr
-dxx
-rhM
+psu
+mCM
 nlv
-rhM
-rhM
-rhM
+mCM
+mCM
+mCM
 dCV
 dCV
 dCV
@@ -95145,14 +94897,14 @@ snB
 oYY
 stM
 uGq
-uKB
-uKQ
-uKQ
+uBE
+kLg
+uBE
 kqG
-uKQ
-uKQ
+uBE
+uBE
 rpa
-vEQ
+hkF
 sBk
 vCc
 qvQ
@@ -95370,19 +95122,19 @@ qUC
 qUC
 qUC
 qUC
-rhM
+mCM
 qMq
 ldX
-cWu
-cWu
-cWu
-cWu
+qyo
+qyo
+qyo
+qyo
 iJR
 hiB
 nlA
 nMs
 omU
-rhM
+mCM
 dCV
 dCV
 gts
@@ -95401,9 +95153,9 @@ usx
 snB
 usx
 svW
-uKB
+uBE
 wmJ
-uIH
+uBE
 rSQ
 fCX
 aRX
@@ -95627,19 +95379,19 @@ iLQ
 tQU
 qUC
 ppd
-rhM
-rhM
+mCM
+mCM
 hJf
-cWu
-cWu
-cWu
-cWu
+qyo
+qyo
+qyo
+qyo
 iJR
 qyo
 qyo
 iLK
 ont
-rhM
+mCM
 dCV
 dCV
 gts
@@ -95658,10 +95410,10 @@ usx
 snB
 usx
 swN
-uKB
+uBE
 wnn
-elK
-uKQ
+kLg
+uBE
 hgp
 vZE
 nzb
@@ -95884,19 +95636,19 @@ fmN
 fmN
 sxT
 qUC
-rhM
-rhM
+mCM
+mCM
 hJt
 hJt
 hJt
 kLO
 lAC
-rhM
+mCM
 iLo
 qyo
 qyo
 ooE
-rhM
+mCM
 dCV
 dCV
 gts
@@ -95917,10 +95669,10 @@ usx
 sDk
 uLh
 woX
-wAE
+kLg
 rsA
 btF
-cJD
+nzb
 nzb
 gMx
 usx
@@ -96141,19 +95893,19 @@ sxT
 fmN
 gaK
 gkZ
-rhM
+mCM
 hfq
 qyo
 iLK
 jqe
-cWu
-cWu
+qyo
+qyo
 oJc
 med
 qyo
 qyo
 gso
-rhM
+mCM
 dCV
 dCV
 gts
@@ -96398,20 +96150,20 @@ fzt
 qSN
 tQl
 qUC
-rhM
+mCM
 hfQ
 qyo
 qyo
 qyo
-cWu
+qyo
 eOr
 dxx
 rhM
 nnl
 meY
 meY
-rhM
-rhM
+mCM
+mCM
 dCV
 gts
 nxY
@@ -96655,20 +96407,20 @@ fjg
 qSN
 sxT
 qUC
-rhM
+mCM
 gmn
 hKe
 hKe
 hKe
-cWu
-cWu
+qyo
+qyo
 mdA
-mCM
-mFu
+hiB
+qyo
 nQP
 npH
 piw
-rhM
+mCM
 dCV
 gts
 fyf
@@ -96912,20 +96664,20 @@ fzB
 vmB
 nWl
 qUC
-rhM
+mCM
 hgc
 guZ
 iNo
 jrS
-cWu
-cWu
+qyo
+qyo
 mdA
-mFu
-mFu
-mFu
-mFu
-mFu
-rhM
+qyo
+qyo
+qyo
+qyo
+qyo
+mCM
 dCV
 gts
 fyf
@@ -97169,20 +96921,20 @@ fmN
 fmN
 qUC
 gle
-rhM
+mCM
 nvx
-hKr
-hKr
+qyo
+qyo
 jsq
-cWu
-cWu
+qyo
+qyo
 mdA
-mFu
-mFu
+qyo
+qyo
 nTm
 nTm
-mFu
-rhM
+qyo
+mCM
 dCV
 gts
 fyf
@@ -97426,20 +97178,20 @@ sxT
 fTK
 sxT
 fmN
-rhM
+mCM
 hgd
-hKr
-hKr
+qyo
+qyo
 jsq
-cWu
-cWu
+qyo
+qyo
 mdF
-mFu
-mFu
+qyo
+qyo
 mCR
 nQk
-mFu
-rhM
+qyo
+mCM
 dCV
 gts
 fyf
@@ -97683,20 +97435,20 @@ lgP
 fUp
 sxT
 gqS
-rhM
-rhM
-rhM
+mCM
+mCM
+mCM
 iNI
 iNI
-rhM
+mCM
 lAI
 rhM
-mFu
-mFu
-mFu
-mFu
-mFu
-rhM
+qyo
+qyo
+qyo
+qyo
+qyo
+mCM
 dCV
 gts
 fyf
@@ -97940,12 +97692,12 @@ dCV
 fqS
 sxT
 fmN
-rhM
+mCM
 hlI
 gWp
 gWp
 gWp
-rhM
+mCM
 hlE
 rhM
 pqR
@@ -97953,7 +97705,7 @@ oqH
 oqH
 oqH
 pqR
-rhM
+mCM
 dCV
 gts
 fyf
@@ -98197,20 +97949,20 @@ dCV
 dCV
 fzw
 fmN
-rhM
+mCM
 hnB
 gWp
 gWp
 pNg
-rhM
-rhM
+mCM
+mCM
 mfn
-rhM
-rhM
-rhM
-rhM
-rhM
-dxx
+mCM
+mCM
+mCM
+mCM
+mCM
+psu
 dCV
 gts
 fyf
@@ -98235,7 +97987,7 @@ usx
 lwN
 xIa
 xIa
-tMU
+aqS
 djV
 dKW
 vCc
@@ -98454,12 +98206,12 @@ aRl
 dCV
 sxT
 sxT
-rhM
+mCM
 hqf
 gWp
 gWp
 gWp
-rhM
+mCM
 dCV
 dCV
 dCV
@@ -98492,7 +98244,7 @@ ljZ
 kwo
 yhs
 xIa
-ioT
+gHP
 gaI
 sBk
 vCc
@@ -98711,12 +98463,12 @@ iBQ
 dCV
 gcv
 gcv
-rhM
+mCM
 hqt
 gWp
 gWp
 juc
-rhM
+mCM
 dCV
 gts
 gts
@@ -98968,12 +98720,12 @@ dCV
 dCV
 dCV
 dCV
-rhM
+mCM
 hto
 gWp
 gWp
 hto
-rhM
+mCM
 dCV
 gts
 fyf
@@ -99002,11 +98754,11 @@ xIa
 xIa
 xIa
 usx
-tLP
+gHP
 xIa
 xIa
 xIa
-xjv
+aqS
 imO
 dKW
 vCc
@@ -99225,12 +98977,12 @@ dCV
 dCV
 dCV
 dCV
-rhM
+mCM
 hum
 hLs
 gWp
 jvP
-rhM
+mCM
 dCV
 gts
 fyf
@@ -99482,12 +99234,12 @@ gts
 gts
 gts
 gts
-rhM
-rhM
-rhM
-rhM
-rhM
-rhM
+mCM
+mCM
+mCM
+mCM
+mCM
+mCM
 dCV
 gts
 fyf
@@ -105339,10 +105091,10 @@ ieQ
 cZc
 bcV
 pcG
-lGf
-iDf
-gmg
-kXt
+qjK
+bbn
+bbn
+qjK
 pcG
 aoL
 iWB
@@ -105597,9 +105349,9 @@ cZc
 vfA
 pcG
 enC
-cPr
-lWp
-leT
+qjK
+qjK
+bbn
 pcG
 aFb
 rKT
@@ -105853,10 +105605,10 @@ ieQ
 cZc
 bcV
 pcG
-sYt
-udV
-vDU
-leT
+qjK
+qjK
+bbn
+bbn
 pcG
 vlw
 pcG
@@ -108135,12 +107887,12 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-fyf
-gcK
-gcK
-gcK
+vUG
+afs
+mvv
+afs
+afs
+afs
 fyf
 fyf
 ppm
@@ -108391,14 +108143,14 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+pfK
+afs
+afs
+niI
+afs
+afs
+niI
+afs
 xTK
 fyf
 fyf
@@ -108648,16 +108400,16 @@ gcK
 ktB
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-psu
+gSc
+afs
+afs
+afs
+afs
+afs
+afs
+afs
+afs
+fyf
 fyf
 jRX
 pyk
@@ -108905,16 +108657,16 @@ gcK
 gcK
 ktB
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-iWr
+pDv
+afs
+afs
+afs
+afs
+afs
+afs
+afs
+afs
+fyf
 fyf
 kGc
 unI
@@ -109162,15 +108914,15 @@ gcK
 gcK
 ktB
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-pgL
+wPU
+afs
+afs
+niI
+afs
+afs
+niI
+afs
+afs
 wDc
 fyf
 kGc
@@ -109419,15 +109171,15 @@ gcK
 gcK
 gcK
 ktB
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-mTd
-pon
+lGf
+afs
+afs
+afs
+afs
+afs
+afs
+afs
+mvv
 bpD
 fyf
 kGc
@@ -109677,13 +109429,13 @@ gcK
 gcK
 kgn
 dfR
-gcK
-gcK
-gcK
-jHQ
-gcK
-tii
-pfK
+vUG
+afs
+afs
+afs
+afs
+afs
+afs
 iHu
 bpD
 fyf
@@ -109900,7 +109652,7 @@ rXN
 fCM
 iyy
 aVn
-gSc
+stD
 mvv
 mvv
 vDb
@@ -109939,8 +109691,8 @@ mvv
 mvv
 mvv
 mvv
-fzN
-bGM
+mvv
+mvv
 mvv
 bpD
 fyf
@@ -110345,7 +110097,7 @@ ozI
 acf
 pSp
 vYv
-hHj
+sYt
 sGp
 vYv
 vYv
@@ -112938,7 +112690,7 @@ oXV
 vXF
 xfy
 hom
-tBN
+bNA
 mvv
 bpD
 gcK
@@ -114712,7 +114464,7 @@ cWG
 cWG
 wqJ
 ltK
-mvv
+vXv
 mvv
 mvv
 mvv
@@ -114995,7 +114747,7 @@ tQV
 oXV
 hom
 iDN
-mvv
+vXv
 bpD
 xys
 rkU
@@ -116254,7 +116006,7 @@ xXm
 xXm
 wFT
 xwW
-mvv
+vXv
 mvv
 mvv
 mvv
@@ -116281,7 +116033,7 @@ agd
 bpD
 tBN
 mvv
-bpD
+tLP
 hom
 glt
 xNm
@@ -116644,11 +116396,11 @@ tFU
 oOi
 xBR
 hSz
-mMu
 gCM
+gCM
+gCM
+tAZ
 mMu
-wnh
-iYo
 mMu
 xBR
 mMu
@@ -116900,12 +116652,12 @@ xgu
 tFU
 hSz
 mMu
-cYX
-eQN
-eQN
-eQN
-tLS
-nTa
+nKA
+tAZ
+tAZ
+tAZ
+tAZ
+cPr
 gLW
 hcw
 pBj
@@ -117157,8 +116909,8 @@ jUb
 tFU
 xBR
 mMu
-sSr
-bNA
+oTK
+bUL
 tAZ
 rSW
 ybC
@@ -117300,7 +117052,7 @@ jzY
 hKd
 udF
 ltK
-mvv
+vXv
 wjO
 cWG
 ltK
@@ -117414,9 +117166,9 @@ qzK
 tFU
 wcw
 mMu
-sSr
+oTK
 svR
-xBx
+mMu
 eSy
 mKk
 wLX
@@ -117563,9 +117315,9 @@ mvv
 mvv
 mvv
 mvv
+vXv
 mvv
-mvv
-mvv
+vDU
 bpD
 xys
 cJx
@@ -117670,8 +117422,8 @@ vTz
 qzK
 tFU
 etU
-cQH
-bNL
+xBR
+oTK
 bUL
 tAZ
 xBx
@@ -117806,7 +117558,7 @@ hyQ
 hNc
 vYs
 aLd
-mvv
+vXv
 mvv
 mvv
 mvv
@@ -117927,8 +117679,8 @@ dit
 tFL
 tFU
 tiz
-dea
-pDv
+tAZ
+tAZ
 bUL
 giZ
 ioH
@@ -118070,7 +117822,7 @@ bJo
 pjA
 oSC
 uFN
-mvv
+vDU
 cMb
 hom
 hom
@@ -118842,7 +118594,7 @@ xYS
 uXj
 gpo
 mvv
-bpD
+cJD
 xys
 wxL
 cvZ
@@ -119350,7 +119102,7 @@ gLI
 xQE
 mvv
 bpD
-fyf
+aVc
 xkl
 xYS
 vQB
@@ -119861,7 +119613,7 @@ mvv
 mvv
 cdL
 dXo
-jIz
+udV
 mvv
 bpD
 fyf
@@ -119869,7 +119621,7 @@ xkl
 xYS
 uXj
 gpo
-mvv
+vXv
 wjO
 mpu
 hom
@@ -120378,7 +120130,7 @@ dXo
 jIz
 mvv
 bpD
-fyf
+cWu
 uNC
 xYS
 uXj
@@ -121149,7 +120901,7 @@ hom
 mvv
 mvv
 dCL
-mfD
+dea
 mfD
 vvn
 rEb
@@ -121403,7 +121155,7 @@ rgS
 udh
 sbx
 xys
-mvv
+vXv
 mvv
 wjO
 cWG
@@ -121920,12 +121672,12 @@ jEp
 xwW
 mvv
 mvv
-mvv
+vXv
 gbz
 hom
 hom
 hom
-mvv
+vDU
 wjO
 cWG
 cWG
@@ -121959,9 +121711,9 @@ mGC
 mGC
 mGC
 mGC
-mGC
-mGC
-mGC
+qQq
+nAz
+tMU
 mGC
 mGC
 mGC
@@ -122216,9 +121968,9 @@ ktB
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+vaA
+bNL
+vaA
 gcK
 gcK
 gcK
@@ -122473,9 +122225,9 @@ ktB
 gcK
 csk
 csk
-csk
-csk
-gcK
+vaA
+vaA
+vaA
 gcK
 gcK
 gcK
@@ -122730,9 +122482,9 @@ ktB
 csk
 csk
 csk
-csk
-csk
-csk
+vaA
+vaA
+ioT
 csk
 csk
 gcK
@@ -123163,9 +122915,9 @@ fyf
 hAC
 fyf
 hAC
-fyf
-fyf
-uey
+mcN
+ehN
+mFu
 kGc
 unI
 qvQ
@@ -123420,9 +123172,9 @@ hAC
 fyf
 uey
 hAC
-uey
-fyf
-fyf
+mcN
+jHQ
+bKF
 kGc
 unI
 qvQ
@@ -123677,9 +123429,9 @@ fyf
 uey
 fyf
 fyf
-fyf
-fyf
-fyf
+mcN
+mcN
+mcN
 kGc
 unI
 qvQ
@@ -123934,9 +123686,9 @@ fyf
 fyf
 hAC
 uey
-hAC
-fyf
-fyf
+mcN
+mcN
+mFu
 kGc
 unI
 qvQ

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -113,15 +113,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"adf" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "adr" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/handrail/g_central{
@@ -660,7 +651,7 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "awE" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -1277,15 +1268,6 @@
 /obj/item/trash/plate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"aNH" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "aNS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze,
@@ -1467,15 +1449,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "aUs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/tunnel)
+/turf/closed/wall/f13/tunnel,
+/area/f13/caves)
 "aUB" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -1513,10 +1488,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aVZ" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
 /obj/structure/decoration/hatch,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -7778,7 +7749,7 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /obj/effect/spawner/lootdrop/f13/bomb/tier3,
 /obj/effect/spawner/lootdrop/f13/bomb/top_tier,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "eeT" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7796,9 +7767,6 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "efg" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/structure/simple_door/metal/ventilation{
 	name = "drainage system"
 	},
@@ -7834,7 +7802,7 @@
 	layer = 3
 	},
 /obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
 /obj/structure/table,
@@ -7888,7 +7856,7 @@
 	dir = 1;
 	layer = 3
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "ehk" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -9635,15 +9603,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
-"faH" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "fbn" = (
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -10653,7 +10612,8 @@
 "fBE" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Store Storage";
-	req_one_access_txt = "34"
+	req_one_access_txt = "34";
+	normal_integrity = 500
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -11146,13 +11106,6 @@
 	icon_state = "oakfloor2-broken"
 	},
 /area/f13/den)
-"fRB" = (
-/obj/structure/disposalpipe/broken,
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -11393,15 +11346,6 @@
 	smooth = 1
 	},
 /area/f13/brotherhood/operating)
-"fXC" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 8
-	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "fXF" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -11509,7 +11453,7 @@
 /obj/item/stack/sheet/cardboard/fifty,
 /obj/item/stack/sheet/cardboard/fifty,
 /obj/item/stack/sheet/cardboard/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "gap" = (
 /obj/structure/decoration/rag{
@@ -11543,12 +11487,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/offices2nd)
-"gbp" = (
-/obj/structure/disposalpipe/broken{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gbC" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12231,18 +12169,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"gxB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gxS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/tunnel)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/enclave)
@@ -12302,12 +12231,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"gzq" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gzr" = (
 /obj/structure/nest/supermutant,
 /turf/open/indestructible/ground/inside/subway,
@@ -12681,10 +12604,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"gIu" = (
-/obj/structure/disposalpipe/junction/yjunction,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12704,20 +12623,18 @@
 	},
 /area/f13/clinic)
 "gJn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "gJz" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
+	icon_state = "darkdirtysolid"
 	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/area/f13/tunnel)
 "gJA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -12797,9 +12714,12 @@
 	},
 /area/f13/den)
 "gMw" = (
-/obj/structure/disposalpipe/sorting/mail,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "gMZ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -12807,12 +12727,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"gNa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gNj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13079,16 +12993,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
-"gVs" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"gVu" = (
-/obj/structure/disposalpipe/sorting/wrap/flip,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gVy" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -13146,12 +13050,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
-"gWt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gWH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13716,15 +13614,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"hox" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "hoL" = (
 /obj/item/candle{
 	pixel_y = -7
@@ -13875,12 +13764,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
-"htm" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "hts" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib6-old";
@@ -13956,10 +13839,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/enclave)
-"hwF" = (
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "hxd" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -14586,7 +14465,7 @@
 "hSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/shopkeeper,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "hSz" = (
 /obj/structure/window/reinforced/spawner/north{
@@ -16898,12 +16777,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "jqE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "jqR" = (
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/building)
@@ -18528,12 +18404,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"kqK" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/caves)
 "krj" = (
 /obj/structure/guncase,
 /obj/effect/decal/fakelattice{
@@ -18708,7 +18578,7 @@
 "kvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/workbench/forge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kvU" = (
 /obj/structure/simple_door/bunker{
@@ -18756,7 +18626,7 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kxH" = (
 /obj/structure/decoration/shock,
@@ -18796,7 +18666,7 @@
 "kzL" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kzO" = (
 /obj/machinery/vending/nukacolavend,
@@ -18846,7 +18716,7 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kBw" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -19283,7 +19153,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
 /obj/structure/sink/puddle,
@@ -20673,7 +20543,7 @@
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lFT" = (
 /obj/structure/cable{
@@ -20709,7 +20579,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/plasteel/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lHt" = (
 /obj/structure/simple_door,
@@ -20726,7 +20596,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lHY" = (
 /obj/machinery/door/airlock/grunge{
@@ -20817,7 +20687,7 @@
 /obj/item/stack/sheet/mineral/sandstone/thirty,
 /obj/item/stack/sheet/mineral/sandstone/thirty,
 /obj/item/stack/sheet/mineral/sandstone/thirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lLX" = (
 /obj/item/storage/trash_stack{
@@ -20840,14 +20710,14 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/stack/ore/blackpowder/fifty,
 /obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lMp" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
 	id = "shopladder"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "lMs" = (
 /obj/machinery/light/small{
@@ -21137,9 +21007,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
 "lWb" = (
-/obj/structure/disposalpipe/broken,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/building)
 "lWm" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -21509,11 +21379,9 @@
 	},
 /area/f13/bunker)
 "mjG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "mjI" = (
 /obj/structure/chair/comfy/black{
@@ -21552,12 +21420,6 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/dorms)
-"mkT" = (
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "mlz" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -21893,12 +21755,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"mvR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
 "mvU" = (
 /obj/structure/statue/bos/ladyright{
 	pixel_y = -16
@@ -22069,13 +21925,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"mEd" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/obj/structure/disposalpipe/broken,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "mEB" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -22182,7 +22031,7 @@
 /obj/item/stack/sheet/cloth/ten,
 /obj/item/stack/sheet/cloth/ten,
 /obj/item/stack/sheet/cloth/ten,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "mIp" = (
 /obj/structure/chair/f13chair1,
@@ -22279,7 +22128,7 @@
 /obj/item/circuitboard/machine/autolathe/ammo,
 /obj/item/circuitboard/machine/autolathe/ammo,
 /obj/item/circuitboard/machine/autolathe/ammo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "mNd" = (
 /obj/structure/spacevine{
@@ -22315,7 +22164,8 @@
 /area/f13/caves)
 "mNA" = (
 /obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "mNE" = (
 /obj/structure/barricade/bars,
@@ -22489,7 +22339,7 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "mTF" = (
 /obj/structure/timeddoor/sixtyminute,
@@ -22786,10 +22636,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "nce" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/sign/plaques/kiddie/library{
+	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place.";
+	name = "RobCo Notice Board"
+	},
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "ncf" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plating/tunnel,
@@ -23078,7 +22930,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nmy" = (
 /turf/closed/indestructible/f13vaultrusted,
@@ -23134,7 +22986,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/book/granter/crafting_recipe/ODF,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "noo" = (
 /obj/machinery/light/small{
@@ -23494,7 +23346,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nxk" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -23939,7 +23791,7 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/stack/sheet/prewar/twenty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nLM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24117,7 +23969,7 @@
 /area/f13/brotherhood/armory)
 "nRX" = (
 /obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nSk" = (
 /obj/structure/barricade/wooden,
@@ -24144,7 +23996,9 @@
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/effect/spawner/lootdrop/f13/blueprintLowMid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintVHigh,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nTf" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -24154,7 +24008,7 @@
 /obj/item/stack/sheet/hay/fifty,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nTt" = (
 /obj/structure/chair/f13chair1{
@@ -24445,7 +24299,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "oaY" = (
 /obj/structure/barricade/sandbags,
@@ -24486,7 +24340,7 @@
 /area/f13/brotherhood/medical)
 "ocl" = (
 /obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -26096,12 +25950,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"peB" = (
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/caves)
 "peN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/caution{
@@ -26449,7 +26297,7 @@
 /obj/structure/sign/poster/contraband/tools{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "pqH" = (
 /obj/structure/table/wood,
@@ -26839,12 +26687,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"pEY" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/generic,
-/obj/structure/curtain,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "pFE" = (
 /obj/structure/fence/handrail{
 	density = 0;
@@ -27475,13 +27317,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "pXY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/recycler,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "pYd" = (
 /obj/structure/timeddoor,
@@ -30377,12 +30216,6 @@
 "rDk" = (
 /turf/closed/mineral/random/protective_area,
 /area/f13/caves)
-"rDt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "rDJ" = (
 /obj/item/screwdriver/power,
 /obj/item/wirecutters/power,
@@ -30570,10 +30403,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"rId" = (
-/obj/structure/disposalpipe/broken,
-/turf/open/water,
-/area/f13/caves)
 "rIn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -30907,15 +30736,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"rPK" = (
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "rQp" = (
 /obj/structure/fluff/railing,
 /obj/structure/table_frame,
@@ -32869,12 +32689,9 @@
 /turf/open/water,
 /area/f13/building)
 "tdS" = (
-/obj/structure/barricade/wooden,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/closed/wall/f13/tunnel,
+/area/f13/tunnel)
 "tdU" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -33676,10 +33493,8 @@
 	},
 /area/f13/brotherhood/operations)
 "tDF" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/closed/wall/rust,
 /area/f13/caves)
 "tDW" = (
 /obj/structure/table/reinforced,
@@ -33947,7 +33762,7 @@
 /obj/structure/window/reinforced{
 	color = "#3e3d42"
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "tKv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34129,7 +33944,7 @@
 	color = "#3e3d42"
 	},
 /obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "tQb" = (
 /obj/machinery/door/airlock/hatch{
@@ -36100,13 +35915,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
-"vfh" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "vfj" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
@@ -36926,12 +36734,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
-"vHC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
 "vHE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -38143,10 +37945,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"wuf" = (
-/obj/structure/disposalpipe/sorting,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "wuj" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	desc = "All hail the Chinese Communist Party!"
@@ -38793,7 +38591,7 @@
 /obj/item/stack/sheet/leather/twenty,
 /obj/item/stack/sheet/leather/twenty,
 /obj/item/stack/sheet/leather/twenty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "wMe" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39132,7 +38930,7 @@
 "wWN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "wXg" = (
 /obj/effect/landmark/start/f13/Knight,
@@ -40613,10 +40411,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"xOn" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "xOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent{
@@ -40915,7 +40709,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "xWT" = (
 /obj/structure/table/wood,
@@ -51317,7 +51111,7 @@ dXE
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 uKf
@@ -51330,7 +51124,7 @@ weW
 weW
 aUb
 dXE
-faH
+buN
 dXE
 eLE
 xVz
@@ -51574,7 +51368,7 @@ fDc
 xMh
 ncf
 dXE
-rDt
+uPr
 jpr
 uPr
 gSS
@@ -51587,7 +51381,7 @@ weW
 weW
 aUb
 dXE
-rDt
+uPr
 dXE
 eLE
 xVz
@@ -51831,7 +51625,7 @@ hxd
 eKb
 rtG
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -51844,7 +51638,7 @@ weW
 weW
 sKt
 dXE
-rDt
+uPr
 dXE
 eLE
 aoj
@@ -52080,7 +51874,7 @@ tur
 nuA
 tur
 dXE
-faH
+buN
 dXE
 wDw
 rRf
@@ -52088,7 +51882,7 @@ rtG
 nUM
 tNi
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -52101,7 +51895,7 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
 eLE
 aoj
@@ -52337,7 +52131,7 @@ tur
 nuA
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 rrq
@@ -52345,7 +52139,7 @@ yiw
 omD
 nsa
 dXE
-rDt
+uPr
 jpr
 tGU
 rrq
@@ -52358,7 +52152,7 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
 eLE
 aoj
@@ -52594,7 +52388,7 @@ tur
 nuA
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 umD
@@ -52602,7 +52396,7 @@ nUM
 qZM
 fUa
 dXE
-rDt
+uPr
 dXE
 dXE
 lsK
@@ -52615,7 +52409,7 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
 eLE
 aoj
@@ -52851,7 +52645,7 @@ tur
 nuA
 tur
 dXE
-rDt
+uPr
 dXE
 fRK
 yiw
@@ -52859,7 +52653,7 @@ gSS
 rtG
 frX
 dXE
-rDt
+uPr
 dXE
 dXE
 uhX
@@ -52872,7 +52666,7 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
 eLE
 eLE
@@ -53108,7 +52902,7 @@ tur
 bdF
 tur
 dXE
-rDt
+uPr
 dXE
 jpr
 dXE
@@ -53116,7 +52910,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -53129,7 +52923,7 @@ weW
 weW
 aUb
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -53365,28 +53159,28 @@ tur
 nuA
 tur
 dXE
-gJn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-tDF
-gVs
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-gJz
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 weW
 weW
 weW
 aUb
 dXE
-gbp
+uPr
 dXE
 vcf
 ovu
@@ -53629,7 +53423,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 jpr
@@ -53886,7 +53680,7 @@ jzO
 dgR
 dgR
 dXE
-rDt
+uPr
 dXE
 dXE
 efw
@@ -54143,7 +53937,7 @@ lzb
 uqE
 fJQ
 jpr
-rDt
+uPr
 dXE
 dXE
 nbA
@@ -54400,7 +54194,7 @@ wDa
 gSS
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 gSS
@@ -54414,9 +54208,9 @@ weW
 weW
 cSE
 cSY
-vfh
-xOn
-gzq
+buN
+uPr
+uPr
 uPr
 uPr
 dXE
@@ -54657,7 +54451,7 @@ uqE
 ncJ
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 efw
@@ -54675,7 +54469,7 @@ dXE
 dXE
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
 tur
@@ -54914,7 +54708,7 @@ fxD
 gSS
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -54932,7 +54726,7 @@ hQE
 hQE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -55171,7 +54965,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -55189,9 +54983,9 @@ cSE
 wnQ
 wnQ
 dXE
-gJn
-mEd
-gJz
+uPr
+uPr
+uPr
 weW
 weW
 weW
@@ -55428,7 +55222,7 @@ jPC
 jPC
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -55447,7 +55241,7 @@ cSE
 wnQ
 wnQ
 dXE
-mkT
+uPr
 dXE
 tur
 weW
@@ -55685,7 +55479,7 @@ bzQ
 mvK
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -55704,8 +55498,8 @@ cSE
 cSE
 wnQ
 hQE
-gJn
-gxB
+uPr
+uPr
 tur
 weW
 weW
@@ -55942,7 +55736,7 @@ nfe
 aOF
 jPC
 dXE
-rDt
+uPr
 dXE
 dXE
 wnQ
@@ -55962,7 +55756,7 @@ cSE
 cSE
 hQE
 hQE
-rDt
+uPr
 tur
 weW
 weW
@@ -56219,7 +56013,7 @@ weW
 cSE
 dii
 hQE
-adf
+buN
 tur
 oBD
 oBD
@@ -57741,7 +57535,7 @@ glr
 jaB
 dXE
 dXE
-faH
+buN
 dXE
 hQE
 hQE
@@ -57998,7 +57792,7 @@ uFh
 uFh
 dXE
 dXE
-rDt
+uPr
 jpr
 dXE
 dXE
@@ -58255,7 +58049,7 @@ jpJ
 kij
 dXE
 dXE
-rDt
+uPr
 dXE
 lVr
 imx
@@ -58512,7 +58306,7 @@ jpJ
 jpJ
 juh
 dXE
-rDt
+uPr
 dXE
 glr
 cSY
@@ -58530,9 +58324,9 @@ cSE
 cSE
 wnQ
 hQE
-gNa
-xOn
-gJz
+uPr
+uPr
+buN
 weW
 weW
 weW
@@ -58769,7 +58563,7 @@ jpJ
 jpJ
 yiw
 dXE
-rDt
+uPr
 jpr
 glr
 cSY
@@ -58787,7 +58581,7 @@ dii
 hQE
 hQE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -58795,9 +58589,9 @@ weW
 weW
 cSE
 cSY
-vfh
-xOn
-gxB
+buN
+uPr
+uPr
 dXE
 vPg
 vPg
@@ -59026,7 +58820,7 @@ tvv
 fxD
 gSS
 dXE
-rDt
+uPr
 dXE
 juh
 glr
@@ -59044,7 +58838,7 @@ hQE
 hQE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -59054,7 +58848,7 @@ cSE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 aoj
@@ -59283,7 +59077,7 @@ jpJ
 gSS
 uFh
 bwM
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -59298,10 +59092,10 @@ wWB
 sKt
 dXE
 dXE
-gNa
-xOn
-xOn
-htm
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 tur
@@ -59311,7 +59105,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -59540,7 +59334,7 @@ hvO
 lQz
 lQz
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -59555,10 +59349,10 @@ wWB
 aUb
 dXE
 dXE
-gbp
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -59568,7 +59362,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 aoj
@@ -59797,7 +59591,7 @@ ngX
 gSS
 etr
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -59815,7 +59609,7 @@ dXE
 uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -59825,7 +59619,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 aoj
 aoj
@@ -60054,7 +59848,7 @@ wLX
 gSS
 glr
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -60072,7 +59866,7 @@ dXE
 uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -60082,7 +59876,7 @@ aUb
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 vPg
 vPg
@@ -60311,7 +60105,7 @@ lQz
 juh
 jaB
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -60329,7 +60123,7 @@ dXE
 uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -60568,7 +60362,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -60586,7 +60380,7 @@ dXE
 uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -60825,7 +60619,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -60840,10 +60634,10 @@ weW
 cSE
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -61075,34 +60869,34 @@ aUb
 bDl
 weW
 weW
-vfh
-xOn
-xOn
-gVu
-xOn
-xOn
-xOn
-wuf
-xOn
-xOn
-gVu
-xOn
-xOn
-gVu
-xOn
-gJz
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 weW
 weW
 weW
 cSE
 cSY
-vfh
-gMw
-xOn
-hwF
-gMw
-xOn
-gJz
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 weW
 weW
 weW
@@ -61335,17 +61129,17 @@ tur
 dXE
 dXE
 dXE
-gbp
+uPr
 dXE
 dXE
 dXE
 dXE
 dXE
 dXE
-cSY
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -61356,7 +61150,7 @@ dXE
 dXE
 dXE
 dXE
-gbp
+uPr
 dXE
 dXE
 dXE
@@ -61367,7 +61161,7 @@ aUb
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 vPg
 dYY
@@ -61592,17 +61386,17 @@ tur
 dXE
 dXE
 dXE
-cSY
+uPr
 dXE
 dXE
 dXE
 dXE
 dXE
 dXE
-cSY
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -61624,7 +61418,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 xVz
@@ -61849,17 +61643,17 @@ tur
 dXE
 dXE
 dXE
-peB
+uPr
 dXE
 dXE
 dXE
 dXE
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -61881,7 +61675,7 @@ cSE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 xVz
@@ -62106,17 +61900,17 @@ tur
 dXE
 dXE
 dXE
-gJn
-gzq
-cSY
-cSY
-cSY
-cSY
-lWb
-htm
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -62136,9 +61930,9 @@ weW
 weW
 cSE
 cSY
-vfh
-xOn
-htm
+buN
+uPr
+uPr
 dXE
 vPg
 xVz
@@ -62370,10 +62164,10 @@ dXE
 dXE
 dXE
 dXE
-gbp
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -62395,7 +62189,7 @@ cSE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 xVz
@@ -62627,10 +62421,10 @@ fka
 fka
 fka
 dXE
-cSY
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -62652,7 +62446,7 @@ sKt
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 xVz
@@ -62884,10 +62678,10 @@ kiM
 moK
 fka
 dXE
-peB
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -62909,7 +62703,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 xVz
@@ -63141,10 +62935,10 @@ kiM
 mst
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -63155,7 +62949,7 @@ dXE
 dXE
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
 dXE
@@ -63166,7 +62960,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -63398,10 +63192,10 @@ kIS
 moK
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -63409,10 +63203,10 @@ weW
 weW
 cSE
 cSY
-vfh
-xOn
-xOn
-gWt
+buN
+uPr
+uPr
+uPr
 dXE
 dXE
 dXE
@@ -63423,7 +63217,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -63655,10 +63449,10 @@ kiM
 mNt
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -63680,7 +63474,7 @@ aUb
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -63912,10 +63706,10 @@ kiM
 mSs
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -63935,9 +63729,9 @@ weW
 weW
 aUb
 dXE
-gNa
-xOn
-htm
+uPr
+uPr
+uPr
 dXE
 vPg
 aoj
@@ -64169,10 +63963,10 @@ kIS
 kiM
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -64192,9 +63986,9 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
-rDt
+uPr
 dXE
 vPg
 aoj
@@ -64426,10 +64220,10 @@ iPH
 iPH
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -64449,9 +64243,9 @@ weW
 wWB
 aUb
 dXE
-rDt
+uPr
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -64683,10 +64477,10 @@ kIS
 kiM
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -64706,9 +64500,9 @@ weW
 weW
 sKt
 dXE
-rDt
+uPr
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -64940,10 +64734,10 @@ kiM
 mYI
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -64963,9 +64757,9 @@ weW
 weW
 aUb
 dXE
-adf
+buN
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -65197,10 +64991,10 @@ fka
 mYV
 fka
 dXE
-rDt
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -65222,7 +65016,7 @@ aUb
 vlu
 vlu
 dXE
-rDt
+uPr
 dXE
 vPg
 vPg
@@ -65444,20 +65238,20 @@ vXU
 weW
 weW
 weW
-vfh
-gzq
-cSY
-cSY
-cSY
-cSY
-cSY
-cSY
-mkT
-lWb
-gVs
-kqK
-rId
-htm
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 tur
@@ -65479,7 +65273,7 @@ aUb
 vlu
 vlu
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -65703,18 +65497,18 @@ weW
 tur
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -65736,9 +65530,9 @@ tur
 vlu
 vlu
 dXE
-pXY
-xOn
-gxB
+uPr
+uPr
+uPr
 dXE
 vPg
 vPg
@@ -65960,7 +65754,7 @@ weW
 tur
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -65971,7 +65765,7 @@ wYo
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 tur
@@ -65995,7 +65789,7 @@ sKt
 tur
 dXE
 dXE
-adf
+buN
 dXE
 vPg
 vPg
@@ -66217,7 +66011,7 @@ weW
 tur
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 dXE
@@ -67256,7 +67050,7 @@ vrQ
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 tur
@@ -67270,7 +67064,7 @@ dXE
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 dXE
@@ -67283,7 +67077,7 @@ dXE
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 dXE
@@ -67513,7 +67307,7 @@ vrQ
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -67527,7 +67321,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -67540,7 +67334,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -67770,7 +67564,7 @@ vrQ
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -67778,13 +67572,13 @@ weW
 weW
 cSE
 cSY
-vfh
-xOn
-xOn
-gxB
+buN
+uPr
+uPr
+uPr
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -67797,7 +67591,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -68027,7 +67821,7 @@ vrQ
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -68038,23 +67832,23 @@ dXE
 dXE
 dXE
 dXE
-gIu
-xOn
-xOn
-gVs
-xOn
-xOn
-gJz
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 weW
 weW
 weW
 weW
-vfh
-xOn
-xOn
-hwF
-xOn
-gWt
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 dXE
@@ -68282,9 +68076,9 @@ vrQ
 vrQ
 vrQ
 cSY
-vfh
-fRB
-htm
+buN
+uPr
+uPr
 dXE
 dXE
 tur
@@ -68295,7 +68089,7 @@ dXE
 jkU
 vdE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -68309,7 +68103,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -68541,7 +68335,7 @@ ixH
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -68552,7 +68346,7 @@ dXE
 fPb
 wpv
 jpr
-rDt
+uPr
 dXE
 ncJ
 rrq
@@ -68566,7 +68360,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -68798,7 +68592,7 @@ vrQ
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -68809,7 +68603,7 @@ dXE
 uPr
 rrq
 dXE
-rDt
+uPr
 dXE
 rrq
 uPr
@@ -68823,7 +68617,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -69066,7 +68860,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 wzt
 rrq
@@ -69080,7 +68874,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -69337,7 +69131,7 @@ wnQ
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -69590,11 +69384,11 @@ fJQ
 wnQ
 weW
 weW
-wnQ
+weW
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -69851,7 +69645,7 @@ wnQ
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 dXE
@@ -72870,7 +72664,7 @@ dXE
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 dXE
@@ -73127,7 +72921,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -73384,7 +73178,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -73632,20 +73426,20 @@ dXE
 dXE
 myy
 myy
-vfh
-xOn
-tDF
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-gVs
-tDF
-xOn
-xOn
-aNH
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+efg
 cfL
 csw
 cyy
@@ -73891,7 +73685,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -73899,7 +73693,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -74148,7 +73942,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -74156,7 +73950,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -74405,7 +74199,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -74413,14 +74207,14 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
 dXE
-dXE
-dXE
-tur
+gey
+gey
+miI
 abB
 weW
 weW
@@ -74662,7 +74456,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -74670,14 +74464,14 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
-dXE
-dXE
-dXE
-tur
+tDF
+gey
+gey
+miI
 abB
 weW
 weW
@@ -74919,7 +74713,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -74927,14 +74721,14 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
 dXE
-dXE
-dXE
-tur
+gey
+gey
+miI
 abB
 weW
 weW
@@ -75176,7 +74970,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -75184,14 +74978,14 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
 dXE
-dXE
-dXE
-tur
+aUs
+mjG
+tdS
 miI
 weW
 weW
@@ -75433,7 +75227,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -75446,9 +75240,9 @@ tur
 tur
 tur
 tur
-dXE
-dXE
-tur
+aUs
+pXY
+nce
 miI
 weW
 weW
@@ -75690,7 +75484,7 @@ bqO
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -75703,14 +75497,14 @@ buD
 bBh
 bPI
 tur
-dXE
-dXE
-tur
-miI
-weW
-weW
-miI
 aUs
+aUs
+kxd
+miI
+weW
+weW
+miI
+wWF
 tur
 wjM
 nFt
@@ -75947,7 +75741,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -75960,9 +75754,9 @@ bBh
 buD
 bvT
 tur
-dXE
-dXE
-tur
+aUs
+aUs
+tdS
 abB
 weW
 weW
@@ -76204,7 +75998,7 @@ nBk
 aUW
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -76461,7 +76255,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -76487,8 +76281,8 @@ tur
 tur
 tur
 tur
-cQW
-cQW
+gJz
+gJz
 tur
 tur
 tur
@@ -76718,7 +76512,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -76975,7 +76769,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 tur
 tur
@@ -77232,7 +77026,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 tur
 aeN
@@ -77489,7 +77283,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 tur
 anM
@@ -77543,17 +77337,17 @@ weW
 weW
 weW
 cSE
-vfh
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-hwF
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 vPg
 vPg
@@ -77746,7 +77540,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 tur
 aDY
@@ -77810,7 +77604,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -78003,7 +77797,7 @@ nBk
 nBk
 tur
 dXE
-rDt
+uPr
 dXE
 tur
 tur
@@ -78067,7 +77861,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 rvb
 dUe
@@ -78260,7 +78054,7 @@ dgC
 dsK
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 tur
@@ -78324,7 +78118,7 @@ tur
 tur
 tur
 dXE
-rDt
+uPr
 dXE
 kgW
 vVx
@@ -78581,7 +78375,7 @@ rBS
 rBS
 tur
 dXE
-rDt
+uPr
 dXE
 glx
 omD
@@ -78838,7 +78632,7 @@ jZT
 sbE
 tur
 dXE
-rDt
+uPr
 dXE
 jRa
 jRa
@@ -79095,7 +78889,7 @@ jZT
 sqt
 tur
 dXE
-rDt
+uPr
 jpr
 rtG
 gSS
@@ -79290,7 +79084,7 @@ tur
 tur
 tur
 tur
-hox
+efg
 tur
 tur
 tur
@@ -79298,7 +79092,7 @@ tur
 tur
 pDx
 tur
-hox
+efg
 tur
 tur
 tur
@@ -79352,7 +79146,7 @@ jZT
 rBS
 tur
 dXE
-rDt
+uPr
 dXE
 omD
 omD
@@ -79547,7 +79341,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -79555,7 +79349,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -79609,7 +79403,7 @@ rFn
 tur
 tur
 dXE
-rDt
+uPr
 dXE
 kgW
 omD
@@ -79804,7 +79598,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -79812,7 +79606,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -79866,7 +79660,7 @@ jZT
 jZT
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80061,7 +79855,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80069,7 +79863,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80123,10 +79917,10 @@ jZT
 ssK
 tur
 dXE
-gIu
-xOn
-xOn
-gxB
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 vPg
@@ -80318,7 +80112,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80326,7 +80120,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80380,10 +80174,10 @@ tur
 tur
 tur
 dXE
-rDt
+uPr
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -80565,28 +80359,28 @@ tur
 weW
 weW
 weW
-vfh
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-gVs
-tDF
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-gVs
-xOn
-xOn
-gxB
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 tur
 abB
@@ -80637,10 +80431,10 @@ dXE
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -80833,7 +80627,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -80843,7 +80637,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 miI
@@ -80897,7 +80691,7 @@ dXE
 cSY
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -81100,9 +80894,9 @@ dXE
 dXE
 dXE
 dXE
-gJn
-xOn
-aNH
+uPr
+uPr
+efg
 abB
 weW
 weW
@@ -81154,7 +80948,7 @@ sQR
 weW
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -81411,7 +81205,7 @@ weW
 weW
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -81668,7 +81462,7 @@ weW
 weW
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 vPg
@@ -81924,9 +81718,9 @@ dXE
 weW
 weW
 cSY
-vfh
-gVs
-gxB
+buN
+uPr
+uPr
 dXE
 vPg
 vPg
@@ -82170,11 +81964,11 @@ wFD
 weW
 saE
 dXE
-gNa
-xOn
-xOn
-xOn
-gxB
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 dXE
@@ -82183,7 +81977,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -82199,7 +81993,7 @@ hgW
 xZl
 xnl
 mFA
-mXm
+lWb
 kIS
 kiM
 kIS
@@ -82427,11 +82221,11 @@ weW
 weW
 saE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -82440,7 +82234,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -82452,15 +82246,15 @@ jSy
 iYS
 tth
 tth
-fka
-fka
-fka
-fka
-fka
+tth
+tth
+tth
+tth
+tth
 fBE
-fka
-fka
-fka
+tth
+tth
+tth
 kiM
 vuz
 wHf
@@ -82684,12 +82478,12 @@ weW
 weW
 cSE
 dXE
-rDt
-dXE
-dXE
-dXE
-rDt
-dXE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 weW
@@ -82697,7 +82491,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -82709,15 +82503,15 @@ jSy
 jSy
 tth
 kvJ
-kPB
+gMw
 lFR
-kIS
-kiM
-kiM
-kiM
-nwX
+jqE
+cDP
+cDP
+cDP
+gJn
 nRX
-fka
+tth
 sAc
 xyk
 xyk
@@ -82878,13 +82672,13 @@ tur
 weW
 weW
 weW
-vfh
-xOn
-xOn
-tDF
-xOn
-xOn
-aNH
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+efg
 dxj
 dxj
 dxj
@@ -82940,21 +82734,21 @@ weW
 weW
 weW
 cSE
-vfh
-jqE
-xOn
-xOn
-xOn
-gVs
-hwF
-gJz
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 cSY
 weW
 uAY
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -82965,18 +82759,18 @@ vPg
 jSy
 iAu
 tth
-kIS
-kIS
+jqE
+jqE
 lGM
-kIS
+jqE
 gan
-kiM
+cDP
 eeN
-kiM
+cDP
 nTe
-fka
+tth
 kiM
-tdS
+xyk
 pOo
 qgz
 pOo
@@ -83138,7 +82932,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 tur
@@ -83198,12 +82992,12 @@ weW
 weW
 cSE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -83211,7 +83005,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 aoj
@@ -83223,15 +83017,15 @@ jSy
 jSy
 tth
 wWN
-kIS
+jqE
 lHU
-kIS
+jqE
 wMb
-kiM
+cDP
 mNA
-kIS
+jqE
 nTf
-fka
+tth
 kiM
 trA
 hkn
@@ -83395,7 +83189,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 bgV
@@ -83422,27 +83216,27 @@ weW
 miI
 miI
 buN
-xOn
-hwF
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-hwF
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-xOn
-gzq
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
 uPr
 uPr
 uPr
@@ -83455,12 +83249,12 @@ weW
 weW
 aUb
 dXE
-gxS
+uPr
 dXE
 juh
 cSY
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -83468,7 +83262,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 aoj
 vPg
@@ -83480,15 +83274,15 @@ yhT
 jSy
 jGP
 nLJ
-kIS
+jqE
 xWQ
 hSr
 mHL
-kiM
+cDP
 nmg
-kIS
+jqE
 nTf
-mYV
+jGP
 kiM
 xyk
 hkn
@@ -83652,7 +83446,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 bit
@@ -83680,7 +83474,7 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -83702,7 +83496,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 uPr
 dXE
 dXE
@@ -83712,12 +83506,12 @@ weW
 weW
 aUb
 dXE
-gxS
+uPr
 dXE
 glr
 cSY
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -83725,7 +83519,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -83737,15 +83531,15 @@ yhT
 yhT
 tth
 kxy
-kIS
+jqE
 lLQ
-kIS
+jqE
 awy
-kIS
+jqE
 mSW
-kIS
+jqE
 nTf
-fka
+tth
 kiM
 xyk
 pOz
@@ -83909,7 +83703,7 @@ tur
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 dxj
@@ -83937,14 +83731,14 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 cSY
 cSY
 dXE
-mkT
+uPr
 dXE
 dXE
 pYd
@@ -83959,7 +83753,7 @@ dXE
 dXE
 dXE
 dXE
-rPK
+uPr
 jpr
 uPr
 uPr
@@ -83969,12 +83763,12 @@ wFD
 weW
 aUb
 dXE
-gxS
+uPr
 dXE
 etr
 dXE
 dXE
-mvR
+uPr
 dXE
 dXE
 weW
@@ -83982,7 +83776,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -83994,17 +83788,17 @@ yhT
 jdw
 tth
 kzL
-kiM
+cDP
 lLZ
-kiM
+cDP
 mMR
-kIS
+jqE
 noi
-kIS
+jqE
 oaU
-fka
+tth
 sAc
-nce
+oWJ
 xyk
 xyk
 xyk
@@ -84166,7 +83960,7 @@ tur
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 tur
 biT
@@ -84194,14 +83988,14 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 cSY
 cSY
 dXE
-rDt
+uPr
 dXE
 eCe
 pYd
@@ -84216,7 +84010,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -84226,12 +84020,12 @@ weW
 weW
 aUb
 dXE
-gxS
+uPr
 glr
 pcO
 glr
 dba
-rDt
+uPr
 dXE
 dXE
 weW
@@ -84239,7 +84033,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -84253,13 +84047,13 @@ tth
 kBo
 kQL
 lMp
-kIS
-kIS
-kIS
+jqE
+jqE
+jqE
 pqE
 nxf
 ocl
-fka
+tth
 kiM
 kiM
 kiM
@@ -84451,14 +84245,14 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 cSY
 cSY
 dXE
-rDt
+uPr
 dXE
 pYd
 eEt
@@ -84473,7 +84267,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -84483,12 +84277,12 @@ weW
 weW
 saE
 dXE
-vHC
+uPr
 juh
 cSY
 qNm
 glr
-rDt
+uPr
 dXE
 dXE
 weW
@@ -84496,7 +84290,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 aoj
@@ -84506,20 +84300,20 @@ vPg
 vPg
 yhT
 yhT
-fka
-fka
-fka
-fka
-fka
-fka
-fka
-fka
-fka
-fka
-fka
+tth
+tth
+tth
+tth
+tth
+tth
+tth
+tth
+tth
+tth
+tth
 kiM
-pEY
-pPc
+vxF
+xyk
 xyk
 xyk
 xyk
@@ -84708,14 +84502,14 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 cSY
 cSY
 dXE
-rDt
+uPr
 dXE
 pYd
 eFi
@@ -84730,7 +84524,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -84740,12 +84534,12 @@ weW
 weW
 saE
 dXE
-vHC
+uPr
 cSY
 cSY
 cSY
 glr
-mvR
+uPr
 dXE
 dXE
 weW
@@ -84753,7 +84547,7 @@ uAY
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -84965,14 +84759,14 @@ miI
 tur
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 iUn
 cSY
 dXE
-rDt
+uPr
 dXE
 pYd
 eHs
@@ -84987,7 +84781,7 @@ pYd
 pYd
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -84997,12 +84791,12 @@ weW
 weW
 saE
 dXE
-gxS
+uPr
 pcO
 cSY
 cSY
 pcO
-mvR
+uPr
 dXE
 dXE
 weW
@@ -85010,7 +84804,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -85221,15 +85015,15 @@ weW
 miI
 tur
 dXE
-gNa
-gWt
+uPr
+uPr
 dXE
 dXE
 dXE
 cSY
 cSY
 dXE
-rDt
+uPr
 dXE
 pYd
 pYd
@@ -85244,7 +85038,7 @@ mZL
 pYd
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -85254,12 +85048,12 @@ weW
 weW
 aUb
 dXE
-gxS
+uPr
 dba
 glr
 etr
 glr
-rDt
+uPr
 dXE
 dXE
 weW
@@ -85267,7 +85061,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -85478,7 +85272,7 @@ wWB
 miI
 tur
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -85486,7 +85280,7 @@ dXE
 cSY
 cSY
 dXE
-rDt
+uPr
 dXE
 dXE
 pYd
@@ -85501,7 +85295,7 @@ xJE
 nIP
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -85511,12 +85305,12 @@ weW
 weW
 aUb
 dXE
-vHC
+uPr
 dXE
 dXE
 glr
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -85524,7 +85318,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -85735,7 +85529,7 @@ wWB
 miI
 tur
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -85743,7 +85537,7 @@ dXE
 cSY
 cSY
 dXE
-gbp
+uPr
 dXE
 dXE
 pYd
@@ -85758,7 +85552,7 @@ nhu
 nNx
 pYd
 dXE
-gbp
+uPr
 dXE
 dXE
 uPr
@@ -85768,12 +85562,12 @@ weW
 weW
 aUb
 dXE
-gxS
+uPr
 dXE
 juh
 cSY
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -85781,7 +85575,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -85992,7 +85786,7 @@ wWB
 miI
 tur
 dXE
-gxS
+uPr
 uPr
 dXE
 dXE
@@ -86025,12 +85819,12 @@ wFD
 weW
 saE
 dXE
-gxS
+uPr
 dXE
 glr
 cSY
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
@@ -86038,7 +85832,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -86249,7 +86043,7 @@ weW
 cSE
 tur
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -86282,20 +86076,20 @@ weW
 weW
 cSE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 weW
 weW
 cSY
-vfh
-xOn
-htm
+buN
+uPr
+uPr
 dXE
 vPg
 vPg
@@ -86505,11 +86299,11 @@ weW
 weW
 cSE
 weW
-vfh
-wuf
-xOn
-hwF
-gJz
+buN
+uPr
+uPr
+uPr
+buN
 cSY
 cSY
 cSY
@@ -86529,7 +86323,7 @@ eBg
 qju
 pYd
 dXE
-mkT
+uPr
 dXE
 dXE
 uPr
@@ -86538,21 +86332,21 @@ dXE
 weW
 weW
 cSE
-vfh
-mjG
-xOn
-xOn
-xOn
-tDF
-gVs
-gJz
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 cSY
 weW
 weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -86765,7 +86559,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 cSY
@@ -86786,7 +86580,7 @@ eBg
 eBg
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 uPr
@@ -86796,11 +86590,11 @@ weW
 weW
 cSE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -86809,7 +86603,7 @@ uAY
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -87022,14 +86816,14 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 iUn
 cSY
 dXE
 dXE
-mkT
+uPr
 dXE
 dXE
 dXE
@@ -87043,7 +86837,7 @@ eBg
 eBg
 pYd
 dXE
-rPK
+uPr
 jpr
 uPr
 uPr
@@ -87053,11 +86847,11 @@ weW
 weW
 saE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -87066,7 +86860,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -87279,15 +87073,15 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 cSY
 cSY
 cSY
-vfh
-gMw
-gxB
+buN
+uPr
+uPr
 dXE
 dXE
 pYd
@@ -87300,7 +87094,7 @@ eBg
 xJE
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -87310,11 +87104,11 @@ weW
 weW
 saE
 dXE
-gJn
-xOn
-xOn
-xOn
-gWt
+uPr
+uPr
+uPr
+uPr
+uPr
 dXE
 dXE
 dXE
@@ -87323,7 +87117,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -87536,7 +87330,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 cSY
@@ -87544,7 +87338,7 @@ cSY
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 pYd
@@ -87557,7 +87351,7 @@ nsZ
 nqV
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -87580,7 +87374,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -87793,7 +87587,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 cSY
@@ -87801,7 +87595,7 @@ cSY
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 dXE
 pYd
@@ -87814,7 +87608,7 @@ nEz
 oif
 pYd
 dXE
-rDt
+uPr
 dXE
 dXE
 dXE
@@ -87837,7 +87631,7 @@ weW
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 vPg
 vPg
@@ -88050,7 +87844,7 @@ tur
 dXE
 dXE
 dXE
-fXC
+buN
 dXE
 dXE
 cSY
@@ -88058,7 +87852,7 @@ cSY
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 eCe
@@ -88071,7 +87865,7 @@ pYd
 pYd
 eCe
 dXE
-fXC
+buN
 dXE
 dXE
 dXE
@@ -88094,7 +87888,7 @@ uAY
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 vPg
 vPg
@@ -88328,7 +88122,7 @@ tur
 tur
 tur
 tur
-weW
+gxS
 tur
 tur
 tur
@@ -89333,7 +89127,7 @@ tur
 dXE
 dXE
 dXE
-faH
+buN
 dXE
 dXE
 tur
@@ -89590,7 +89384,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -89847,7 +89641,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -90104,7 +89898,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -90114,7 +89908,7 @@ weW
 weW
 tur
 dXE
-faH
+buN
 weW
 weW
 weW
@@ -90361,7 +90155,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -90371,7 +90165,7 @@ weW
 weW
 tur
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -90618,7 +90412,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 chR
@@ -90628,7 +90422,7 @@ iOK
 chR
 chR
 dXE
-gxS
+uPr
 tur
 weW
 uAY
@@ -90875,7 +90669,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 chR
@@ -90885,7 +90679,7 @@ jAZ
 kxg
 chR
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -91132,7 +90926,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 chR
@@ -91142,7 +90936,7 @@ klj
 kMF
 chR
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -91389,7 +91183,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 chR
 chR
@@ -91399,7 +91193,7 @@ ctV
 kOP
 chR
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -91646,7 +91440,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 chR
 ctV
@@ -91656,7 +91450,7 @@ ctV
 klj
 chR
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -91903,7 +91697,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 chR
 chR
@@ -91913,7 +91707,7 @@ chR
 chR
 chR
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -92160,7 +91954,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -92170,7 +91964,7 @@ chR
 dXE
 dXE
 dXE
-gxS
+uPr
 tur
 mNE
 mNE
@@ -92417,7 +92211,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -92427,7 +92221,7 @@ chR
 dXE
 dXE
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -92674,7 +92468,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 fLU
@@ -92684,7 +92478,7 @@ fLU
 fLU
 dXE
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -92931,7 +92725,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 fLU
 fLU
@@ -92941,7 +92735,7 @@ eBg
 fLU
 fLU
 dXE
-gxS
+uPr
 tur
 weW
 uAY
@@ -93188,7 +92982,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 fLU
 wHg
@@ -93198,7 +92992,7 @@ xSY
 lmG
 fLU
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -93445,7 +93239,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 fLU
 eBg
@@ -93455,7 +93249,7 @@ eBg
 eBg
 fLU
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -93702,7 +93496,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 fLU
 dQc
@@ -93712,7 +93506,7 @@ xSY
 dQc
 fLU
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -93959,7 +93753,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 fLU
 fLU
@@ -93969,7 +93763,7 @@ nNH
 fLU
 fLU
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -94216,7 +94010,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 fLU
@@ -94226,7 +94020,7 @@ fLU
 fLU
 dXE
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -94473,7 +94267,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -94483,7 +94277,7 @@ dXE
 dXE
 dXE
 dXE
-gxS
+uPr
 tur
 weW
 weW
@@ -94730,7 +94524,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -94739,8 +94533,8 @@ dXE
 dXE
 dXE
 dXE
-gNa
-gWt
+uPr
+uPr
 tur
 weW
 weW
@@ -94987,7 +94781,7 @@ tur
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -94996,7 +94790,7 @@ dXE
 dXE
 dXE
 dXE
-rDt
+uPr
 dXE
 tur
 weW
@@ -95241,20 +95035,20 @@ tur
 vXU
 weW
 weW
-vfh
-xOn
-xOn
-gMw
-xOn
-xOn
-hwF
-xOn
-xOn
-xOn
-xOn
-xOn
-gMw
-gJz
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
 weW
 weW
 weW
@@ -95504,7 +95298,7 @@ dXE
 dXE
 dXE
 dXE
-gxS
+uPr
 dXE
 dXE
 dXE
@@ -95761,7 +95555,7 @@ dXE
 dXE
 dXE
 dXE
-adf
+buN
 dXE
 dXE
 dXE

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -98,7 +98,7 @@
 	name = "broken riot helmet"
 	icon_state = "ranger_broken"
 	desc = "An old riot police helmet, out of use around the time of the war."
-	armor = list("melee" = 38, "bullet" = 45, "laser" = 38, "energy" = 18, "bomb" = 45, "bio" = 55, "rad" = 10, "fire" = 60, "acid" = 20)
+	armor = list("melee" = 55, "bullet" = 55, "laser" = 45, "energy" = 30, "bomb" = 45, "bio" = 55, "rad" = 10, "fire" = 60, "acid" = 20)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = LAVA_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -181,7 +181,7 @@
 	icon_state = "combat_coat"
 	item_state = "combat_coat"
 	desc = "A heavy armor with ballistic inserts, sewn into a padded riot police coat."
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 35, "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 5, "acid" = 35, "wound" = 45)
+	armor = list("melee" = 55, "bullet" = 55, "laser" = 45, "energy" = 35, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 5, "acid" = 35, "wound" = 45)
 	slowdown = 0.15
 
 /obj/item/clothing/suit/armor/f13/combat/mk2

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1281,7 +1281,7 @@
 	automatic = 1
 	autofire_shot_delay = 3
 	mag_type = /obj/item/ammo_box/magazine/m762
-	spread = 16 //infamously hard to control on full-auto
+	spread = 12 //infamously hard to control on full-auto
 	recoil = 0.25
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -393,7 +393,7 @@
 	item_state = "shotgunriot"
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/d12g
-	fire_delay = 6
+	fire_delay = 5
 	burst_size = 1
 	recoil = 0.5
 	automatic_burst_overlay = FALSE

--- a/config/config.txt
+++ b/config/config.txt
@@ -171,10 +171,10 @@ PICTURE_LOGGING_CAMERA
 # INACTIVITY_PERIOD 300
 
 ## period of time in seconds for players to be considered afk and kickable
-# AFK_PERIOD 600
+AFK_PERIOD 1200
 
 ## disconnect players who are considered afk
-# KICK_INACTIVE
+KICK_INACTIVE
 
 ## Comment this out to stop admins being able to choose their personal ooccolor
 ALLOW_ADMIN_OOCCOLOR
@@ -222,7 +222,7 @@ DEFAULT_NO_VOTE
 # DONT_DEL_NEWMOB
 
 ## set a hosted by name for unix platforms
-HOSTEDBY Rigbe
+#HOSTEDBY Rigbe
 
 ## Set to jobban "Guest-" accounts from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 ## Set to 1 to jobban them from those positions, set to 0 to allow them.
@@ -367,7 +367,7 @@ NOTIFY_NEW_PLAYER_AGE 0
 
 ## Notify admins when a player connects if their byond account was created in the last X days
 ## Requires database
-NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
+NOTIFY_NEW_PLAYER_ACCOUNT_AGE 30
 
 ## Notify the irc channel when a new player makes their first connection
 ##	Requres database

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -131,11 +131,7 @@
 	ckeywhitelist = list("silveredsoul")
 
 /obj/item/storage/box/large/custom_kit/evosolus/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator(src)
-	new /obj/item/ammo_box/magazine/m556/rifle(src)
-	new /obj/item/gun/ballistic/automatic/pistol/m1911/custom(src)
-	new /obj/item/ammo_box/magazine/m45(src)
-	new /obj/item/storage/belt/holster(src)
+	new /obj/item/melee/powered/ripper(src)
 	new /obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced(src)
 	new /obj/item/clothing/head/beret/ncr/ncr_recon(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)


### PR DESCRIPTION
Changed the combat body armor to have decent stats again. It was a decent set of armor and was supposed to be a mid-high tier set so it's been buffed up a bit so it's viable once more.

Riot shotgun fire rate changed to 5. I noticed when changing from 5-6 there is a significant difference. Anything lower than 5 is ridiculous and even 5 is seemingly great so if it becomes overpowered I will nerf it again. 6 Has some strange issue where it feels like it chokes up and gets stuck where it can't fire probably because of tickrate.

FN Fal slightly less spread, tested still pretty wide spread on full auto but at least a tiny bit tighter. I understand leaving the high spread rate as it's definitely a powerful weapon.

Custom loadout change to remove items and readd a different melee option for EvoSolus.

Map changes -

Buffed followers clinic due to bombings. (Just structural changes to help with the resistance to such.)

Updated carpet in the bar.

Buffed small hospital south but barely, for individuals to take over. 

Removed disposal piping system in the sewers (It was dumb.)

Added some grass in the legion for a more lived in look.

Buffed the oasis shop with a few extra blueprints, some black carpet and stronger doors so brainlets don't try to unga their way in as easily.

Adds an auto kick feature after 20 minutes of inactivity to test - If you're just afking here why be here yeah? If I find it's annoying or glitchy easily reversible.


