### PR TITLE
Fix the Khan front

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -805,6 +805,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"dm" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "do" = (
 /obj/structure/table/wood,
 /obj/item/binoculars,
@@ -1083,9 +1092,6 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
 "et" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/mineral/wasteland_vendor/followerterminal,
 /turf/open/floor/plasteel/blueyellow,
 /area/f13/followers)
@@ -5060,6 +5066,13 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"tf" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/wood_tiled,
+/area/f13/followers)
 "tg" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -5776,6 +5789,13 @@
 	sunlight_state = 1
 	},
 /area/f13/raiders)
+"vO" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/f13/followers)
 "vP" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -6206,6 +6226,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
+"xr" = (
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls";
+	pixel_y = -4
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/raiders)
 "xs" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -6772,6 +6802,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"zW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/blueyellow,
+/area/f13/followers)
 "zX" = (
 /obj/structure/table/booth,
 /obj/item/gun/ballistic/automatic/marksman/sniper/gold,
@@ -8780,6 +8816,9 @@
 /area/f13/building)
 "HZ" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/blueyellow,
 /area/f13/followers)
 "Ia" = (
@@ -11147,6 +11186,22 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
+"RG" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "RH" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -46995,7 +47050,7 @@ PL
 PL
 PL
 oK
-ol
+dm
 ol
 ol
 au
@@ -47775,7 +47830,7 @@ rn
 Zl
 hj
 Kq
-mw
+vO
 mQ
 fh
 Ql
@@ -48035,7 +48090,7 @@ Kq
 mw
 mQ
 DF
-Ql
+tf
 rn
 al
 PL
@@ -49063,7 +49118,7 @@ Kq
 mw
 mQ
 DF
-Ql
+tf
 rn
 al
 PL
@@ -50338,7 +50393,7 @@ PL
 Jg
 OB
 OB
-OB
+zW
 et
 gQ
 zn
@@ -62330,10 +62385,10 @@ nE
 Ya
 nE
 nE
-Ya
-nE
-nE
-nE
+RG
+Gl
+Gl
+nd
 eU
 PL
 PL
@@ -62587,10 +62642,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
+Gl
+Gl
+aJ
 PL
 PL
 PL
@@ -62844,10 +62899,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
+Gl
+Gl
+aJ
 PL
 PL
 PL
@@ -63101,10 +63156,10 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
+Gl
+Gl
+aJ
 PL
 PL
 PL
@@ -63358,10 +63413,10 @@ PR
 tY
 tY
 tY
-tY
-tY
-tY
-tY
+JN
+Gl
+Gl
+Ds
 PR
 tY
 KO
@@ -64352,7 +64407,7 @@ kC
 jZ
 Wx
 ol
-Oe
+xr
 fN
 EV
 pB
@@ -66765,7 +66820,7 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
 kC
 kC
@@ -66783,7 +66838,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 kC
 kC
@@ -67022,7 +67077,7 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
 kC
 kC
@@ -67040,7 +67095,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 kC
 kC
@@ -67279,9 +67334,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -67297,7 +67352,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 kC
 kC
@@ -67536,9 +67591,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -67546,7 +67601,7 @@ PL
 LP
 PL
 PL
-PL
+Mj
 Ud
 Wx
 Wx
@@ -67554,7 +67609,7 @@ Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -67793,8 +67848,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -67802,16 +67858,15 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
-PL
+Wx
+Wx
+nd
+eU
 PL
 PL
 PL
@@ -68050,8 +68105,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -68059,15 +68115,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 PL
 PL
 PL
@@ -68307,6 +68362,9 @@ PL
 PL
 PL
 PL
+Mj
+Gl
+aJ
 PL
 PL
 PL
@@ -68314,17 +68372,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -68564,8 +68619,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -68573,15 +68629,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 PL
 PL
 PL
@@ -68821,6 +68876,9 @@ PL
 PL
 PL
 PL
+Mj
+Gl
+aJ
 PL
 PL
 PL
@@ -68828,17 +68886,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -69078,6 +69133,9 @@ PL
 PL
 PL
 PL
+Mj
+Gl
+aJ
 PL
 PL
 PL
@@ -69085,17 +69143,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -69335,8 +69390,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -69344,15 +69400,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 PL
 PL
 PL
@@ -69592,6 +69647,9 @@ PL
 PL
 PL
 PL
+Mj
+Gl
+aJ
 PL
 PL
 PL
@@ -69599,17 +69657,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
+Mj
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 PL
 PL
@@ -69849,8 +69904,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -69858,15 +69914,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 PL
 PL
 PL
@@ -70106,8 +70161,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -70115,15 +70171,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 PL
 Wx
 Wx
@@ -70363,8 +70418,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -70372,15 +70428,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 Wx
 Wx
 Wx
@@ -70620,8 +70675,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -70629,15 +70685,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 Wx
 Wx
 Wx
@@ -70877,8 +70932,9 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+aJ
 PL
 PL
 PL
@@ -70886,15 +70942,14 @@ PL
 PL
 PL
 PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 Wx
 Wx
 Wx
@@ -71134,24 +71189,24 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
+nL
+tY
+tY
+tY
+tY
+KO
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-Wx
-Wx
+Mj
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+aJ
 Wx
 Wx
 Wx
@@ -71391,24 +71446,24 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
-PL
-PL
-PL
+Ds
+tY
+tY
+QL
 Wx
 Wx
 Wx
 Wx
 Wx
 Wx
-PL
+aJ
 PL
 Wx
 Wx
@@ -71648,24 +71703,24 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
+Zp
+nE
+nE
+nE
+nE
+jS
 Wx
 Wx
-PL
-PL
-Wx
-Wx
-Wx
+Gl
+Gl
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+Wx
+aJ
 PL
 PL
 al
@@ -71910,19 +71965,19 @@ PL
 PL
 PL
 PL
-PL
+Mj
 Wx
 Wx
-PL
-PL
-Wx
-Wx
-Wx
+Gl
+Gl
 Wx
 Wx
 Wx
 Wx
-PL
+Wx
+Wx
+Wx
+aJ
 PL
 PL
 PL
@@ -72167,19 +72222,19 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
-PL
+Zp
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+nE
+eU
 PL
 PL
 PL

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -1618,6 +1618,18 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/rust,
 /area/f13/building)
+"gE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/raiders)
 "gF" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4021,6 +4033,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/ncr)
+"pn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/woodalt,
+/area/f13/raiders)
 "pp" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -4588,6 +4606,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/caves)
+"rv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/open/floor/f13,
+/area/f13/brotherhood/surface)
 "rw" = (
 /obj/structure/rack,
 /obj/item/seeds/poppy/broc,
@@ -4886,6 +4909,9 @@
 "sF" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
@@ -7619,6 +7645,19 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/legion)
+"Dv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/f13/police/trooper{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/obj/item/flashlight/seclite,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/f13,
+/area/f13/brotherhood/surface)
 "Dx" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/black,
@@ -9849,6 +9888,13 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"Mk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/f13,
+/area/f13/brotherhood/surface)
 "Ml" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -12553,6 +12599,14 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"XG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/f13,
+/area/f13/brotherhood/surface)
 "XH" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -12739,6 +12793,12 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"YF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/corner,
+/turf/open/floor/f13,
+/area/f13/brotherhood/surface)
 "YH" = (
 /obj/item/clothing/under/f13/tribe,
 /obj/structure/rack,
@@ -47356,10 +47416,10 @@ cL
 tl
 dj
 IB
-ZM
-ZM
-ZM
-Rr
+YF
+XG
+XG
+Mk
 Rr
 xm
 Rr
@@ -47613,10 +47673,10 @@ VR
 tl
 PO
 TU
-Rr
+rv
 de
 de
-or
+Dv
 Rr
 hc
 Kc
@@ -58892,7 +58952,7 @@ PL
 PL
 MM
 RK
-bs
+gE
 oU
 Kl
 eZ
@@ -60179,7 +60239,7 @@ Gl
 sf
 fN
 fN
-fN
+pn
 lZ
 yR
 fN

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -11186,22 +11186,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
-"RG" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
 "RH" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -12746,6 +12730,9 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449"
 	},
 /turf/open/transparent/openspace{
 	name = "air";
@@ -62383,12 +62370,12 @@ nE
 nE
 nE
 Ya
-nE
-nE
-RG
 Gl
 Gl
 nd
+nE
+nE
+nE
 eU
 PL
 PL
@@ -62639,13 +62626,13 @@ PL
 PL
 PL
 PL
-PL
-PL
-PL
 Mj
 Gl
 Gl
 aJ
+PL
+PL
+PL
 PL
 PL
 PL
@@ -62896,13 +62883,13 @@ KO
 PL
 PL
 PL
-PL
-PL
-PL
 Mj
 Gl
 Gl
 aJ
+PL
+PL
+PL
 PL
 PL
 PL
@@ -63153,13 +63140,13 @@ nL
 KO
 PL
 PL
-PL
-PL
-PL
 Mj
 Gl
 Gl
 aJ
+PL
+PL
+PL
 PL
 PL
 PL
@@ -63410,13 +63397,13 @@ AM
 Ds
 tY
 PR
-tY
-tY
-tY
 JN
 Gl
 Gl
 Ds
+tY
+tY
+tY
 PR
 tY
 KO
@@ -65698,9 +65685,9 @@ xg
 fN
 iX
 mn
-PL
-PL
-PL
+tY
+tY
+KO
 PL
 PL
 PL
@@ -65954,12 +65941,12 @@ Hy
 fN
 fN
 XS
-tY
-tY
-tY
-tY
-tY
-KO
+Wx
+Wx
+Wx
+aJ
+PL
+PL
 PL
 PL
 PL
@@ -66211,12 +66198,12 @@ Mj
 Gl
 Gl
 pu
-Gl
-Gl
 Wx
-jZ
-jZ
+Wx
+Wx
 Ds
+tY
+tY
 tY
 tY
 tY
@@ -66468,8 +66455,8 @@ Mj
 Gl
 Gl
 Gl
-Gl
-Gl
+Wx
+Wx
 Wx
 jZ
 jZ

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -95,6 +95,27 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"ach" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/raiders)
 "acj" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -206,6 +227,13 @@
 	},
 /turf/open/floor/wood,
 /area/f13/building)
+"aev" = (
+/obj/structure/barricade/wooden,
+/obj/item/clothing/head/helmet/f13/deathskull{
+	anchored = 1
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "aeZ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -541,6 +569,10 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"akf" = (
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "akk" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -724,6 +756,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"amK" = (
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
 "anq" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt{
@@ -1659,6 +1696,12 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland)
+"aJc" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "aJd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -2856,6 +2899,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"bhQ" = (
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "bia" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -4328,11 +4377,15 @@
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/building)
 "bKF" = (
-/obj/structure/sign/plaques/kiddie/library{
-	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place."
+/mob/living/simple_animal/hostile/handy/gutsy{
+	icon_living = "pvtgutsy";
+	icon_state = "pvtgutsy";
+	name = "Mr. Gutsy"
 	},
-/turf/closed/wall/f13/tunnel,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/bunker)
 "bKJ" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -5319,6 +5372,10 @@
 /obj/structure/junk/small/table,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"chg" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
 "chv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/gardentool,
@@ -6789,6 +6846,13 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"cOX" = (
+/obj/structure/grille/indestructable,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "cPg" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9847,10 +9911,8 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/closet,
+/obj/item/clothing/under/f13/rag,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
@@ -9979,7 +10041,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/small,
 /obj/item/reagent_containers/food/drinks/bottle/rum/empty,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
@@ -10997,6 +11058,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"ewE" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/structure/sign/plaques/kiddie/library{
+	desc = "Once you're done with your garbage you can toss it in this machine to keep the world a cleaner place."
+	},
+/turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
 "ewI" = (
 /obj/item/trash/f13/cram,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11093,8 +11161,8 @@
 "eyC" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Store";
-	req_one_access_txt = "34";
-	normal_integrity = 500
+	normal_integrity = 500;
+	req_one_access_txt = "34"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -11576,6 +11644,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"eJC" = (
+/obj/machinery/vending/medical{
+	req_access = null
+	},
+/turf/closed/wall/r_wall,
+/area/f13/followers)
 "eJN" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -11871,7 +11945,9 @@
 /area/f13/building)
 "eOr" = (
 /obj/machinery/light,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "eOK" = (
 /obj/effect/decal/cleanable/generic,
@@ -11978,11 +12054,8 @@
 	},
 /area/f13/ncr)
 "eQq" = (
-/mob/living/simple_animal/hostile/handy/gutsy{
-	icon_living = "pvtgutsy";
-	icon_state = "pvtgutsy";
-	name = "Mr. Gutsy"
-	},
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden,
 /turf/open/floor/f13{
 	icon_state = "darkredfull"
 	},
@@ -12800,6 +12873,13 @@
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"fgD" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "fgG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -15415,6 +15495,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/item/reagent_containers/hypospray/medipen/stimulants,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -15699,7 +15780,16 @@
 	},
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
+"gmp" = (
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "gmz" = (
 /turf/open/floor/wood/f13/old/ruinedcornertl,
@@ -15843,6 +15933,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/village)
+"goE" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "goK" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
@@ -15880,16 +15976,33 @@
 /turf/open/floor/carpet/blackred,
 /area/f13/ncr)
 "gpC" = (
-/obj/structure/fermenting_barrel,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/tires/two,
+/obj/structure/tires/five,
+/obj/structure/wreck/bus/rusted/segmented1{
+	layer = 3.2
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+/obj/structure/fence/wooden{
+	climbable = 0;
+	dir = 4;
+	layer = 6.1;
+	pixel_x = -13
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	layer = 6.1;
+	pixel_x = -13;
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/raiders)
 "gpE" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -16052,7 +16165,9 @@
 "gso" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder/constructed,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "gsu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16235,7 +16350,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "gva" = (
 /obj/machinery/light/small/broken{
@@ -16520,7 +16637,6 @@
 /area/f13/village)
 "gzq" = (
 /obj/structure/table,
-/obj/item/stack/medical/gauze,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -17034,6 +17150,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"gIU" = (
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gIZ" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -17426,9 +17546,12 @@
 	},
 /area/f13/ncr)
 "gSc" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/structure/chair/sofa/corner{
+	color = "#800000";
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "gSf" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -17668,6 +17791,7 @@
 "gYA" = (
 /obj/machinery/light,
 /obj/structure/table,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -18070,7 +18194,9 @@
 "hfq" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "hft" = (
 /obj/structure/table/optable,
@@ -18111,7 +18237,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "hfU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -18150,12 +18278,14 @@
 /obj/structure/table/reinforced,
 /obj/item/roller,
 /obj/item/roller,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "hgd" = (
 /obj/structure/stairs/east,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/followers)
 "hge" = (
@@ -18331,7 +18461,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "hiJ" = (
 /obj/structure/flora/tree/cactus,
@@ -18473,7 +18605,9 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "hll" = (
 /obj/structure/flora/grass/wasteland{
@@ -18537,6 +18671,9 @@
 /area/f13/followers)
 "hlI" = (
 /obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -18680,7 +18817,6 @@
 	},
 /area/f13/wasteland)
 "hoz" = (
-/obj/structure/sign/barsign,
 /obj/structure/sign/barsign,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/raiders)
@@ -19729,7 +19865,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "hHM" = (
 /obj/structure/filingcabinet,
@@ -19796,7 +19934,9 @@
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "hJg" = (
 /obj/structure/campfire/barrel,
@@ -19804,7 +19944,11 @@
 /area/f13/wasteland)
 "hJt" = (
 /obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "followersdeskshutters";
 	name = "followers shutters"
@@ -19852,7 +19996,9 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "hKo" = (
 /obj/machinery/vending/nukacolavend,
@@ -21740,6 +21886,19 @@
 /obj/machinery/workbench,
 /turf/open/floor/wood,
 /area/f13/village)
+"ixA" = (
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "ixG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -22343,12 +22502,16 @@
 /area/f13/wasteland)
 "iJR" = (
 /obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "soupkitchen"
 	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
 "iJV" = (
@@ -22431,7 +22594,9 @@
 	id = "soupkitchen";
 	pixel_y = 31
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "iLr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22451,7 +22616,9 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "iLQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22517,7 +22684,9 @@
 	dir = 8
 	},
 /obj/structure/bed/roller,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "iNx" = (
 /obj/structure/car/rubbish3,
@@ -22549,7 +22718,9 @@
 	name = "Surgery Room";
 	req_one_access_txt = "124"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
 /area/f13/followers)
 "iNM" = (
 /obj/structure/flora/grass/wasteland{
@@ -23943,6 +24114,14 @@
 	dir = 10
 	},
 /area/f13/village)
+"jlZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "jmb" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -24180,7 +24359,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "jqU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24236,11 +24417,15 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/bed/roller,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "jsq" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "jsz" = (
 /obj/structure/displaycase,
@@ -24398,8 +24583,8 @@
 	color = "#363636"
 	},
 /obj/vehicle/ridden/wheelchair{
-	name = "hawtrod bitch magnet";
-	desc = "A wheelchair, that seems to be wheels, it seems to be moveable by person on the wheelchair and it picks up bitches."
+	desc = "A wheelchair, that seems to be wheels, it seems to be moveable by person on the wheelchair and it picks up bitches.";
+	name = "hawtrod bitch magnet"
 	},
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -24810,14 +24995,24 @@
 	},
 /area/f13/bunker)
 "jDk" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
+/obj/structure/wreck/bus/rusted{
+	layer = 3.5
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt"
+/obj/structure/fence/corner/wooden{
+	dir = 1;
+	layer = 6.1;
+	pixel_x = -13
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/raiders)
 "jDm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -24909,10 +25104,31 @@
 	},
 /area/f13/wasteland)
 "jGe" = (
-/obj/structure/fermenting_barrel,
-/obj/structure/flora/tree/cactus,
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented2{
+	layer = 3.2
+	},
+/obj/structure/fence/corner/wooden{
+	dir = 4;
+	layer = 6.1;
+	pixel_x = 13
+	},
+/obj/structure/fence/wooden{
+	climbable = 0;
+	dir = 4;
+	layer = 6.1;
+	pixel_x = -17
+	},
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
+	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/raiders)
 "jGL" = (
 /obj/structure/displaycase,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -24962,8 +25178,8 @@
 /area/f13/building)
 "jHQ" = (
 /obj/machinery/recycler,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
 "jIe" = (
@@ -26382,15 +26598,14 @@
 	},
 /area/f13/wasteland)
 "kkk" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented7{
+	layer = 6
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/raiders)
+/area/f13/wasteland)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -26502,25 +26717,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kmz" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented9{
+	layer = 6
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/raiders)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "kmA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9;
@@ -26699,6 +26903,25 @@
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"kpR" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = 13;
+	pixel_y = 1
+	},
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/raiders)
 "kpW" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -27456,26 +27679,12 @@
 	},
 /area/f13/village)
 "kHB" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/raiders)
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented10,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/caves)
 "kHC" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -28264,9 +28473,14 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "kZp" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/wood,
-/area/f13/raiders)
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented11{
+	layer = 3.2
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/caves)
 "kZz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28411,13 +28625,15 @@
 	},
 /area/f13/enclave)
 "lcl" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented12{
+	layer = 6
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood,
-/area/f13/raiders)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/caves)
 "lcm" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -28503,7 +28719,9 @@
 /area/f13/building)
 "ldX" = (
 /obj/structure/chair,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "lei" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29563,7 +29781,7 @@
 	name = "followers shutters"
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "lAD" = (
@@ -29829,15 +30047,14 @@
 	},
 /area/f13/wasteland)
 "lGf" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -4;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/structure/chair/sofa/left{
+	color = "#800000"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "lGq" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29855,8 +30072,22 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "lGH" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
+/obj/structure/wreck/bus/rusted/segmented3{
+	layer = 3.2
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	layer = 6.1;
+	pixel_x = 2;
+	pixel_y = 13
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	layer = 6.1;
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lGV" = (
 /obj/structure/table,
@@ -30996,10 +31227,9 @@
 	},
 /area/f13/building)
 "mdA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "rampdowntop"
 	},
-/turf/open/floor/mineral/plastitanium,
 /area/f13/followers)
 "mdB" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31009,10 +31239,13 @@
 /turf/open/floor/wood,
 /area/f13/village)
 "mdF" = (
-/obj/machinery/vending/medical{
-	req_access = null
+/obj/structure/window/reinforced/spawner{
+	dir = 1
 	},
-/turf/closed/wall/f13/supermart,
+/obj/structure/chair,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "mdP" = (
 /obj/structure/car/rubbish2,
@@ -31024,7 +31257,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "mee" = (
 /obj/structure/rack,
@@ -31062,7 +31297,9 @@
 "meY" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "mfg" = (
 /obj/structure/rack,
@@ -31493,6 +31730,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"mmV" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/raiders)
 "mna" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -32373,10 +32620,6 @@
 "mCM" = (
 /turf/closed/wall/r_wall,
 /area/f13/followers)
-"mCR" = (
-/obj/structure/closet/crate/freezer/blood/anchored,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/followers)
 "mCZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32411,6 +32654,17 @@
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mEO" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/medical,
+/obj/structure/curtain,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "mFe" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -34041,9 +34295,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/raiders)
 "niI" = (
-/obj/structure/gallow,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/sofa/right{
+	color = "#800000";
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "niU" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -34142,7 +34402,9 @@
 /area/f13/brotherhood/surface)
 "nlA" = (
 /obj/machinery/chem_dispenser,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "nlN" = (
 /obj/structure/table/wood,
@@ -34221,9 +34483,13 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "nnl" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
+/obj/structure/wreck/bus/rusted/segmented4{
+	layer = 3.2
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "nnB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cabinet/anchored{
@@ -34317,11 +34583,13 @@
 	},
 /area/f13/wasteland)
 "npH" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "npI" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -34606,7 +34874,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "nvH" = (
 /obj/structure/table/wood,
@@ -34852,6 +35122,23 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland)
+"nBv" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = -13;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/raiders)
 "nBA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light,
@@ -35019,13 +35306,13 @@
 	},
 /area/f13/building)
 "nFA" = (
-/obj/structure/fence{
-	dir = 4
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented8{
+	layer = 6
 	},
-/obj/structure/fence/wooden{
-	dir = 4
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nFL" = (
 /turf/open/indestructible/ground/outside/road{
@@ -35082,11 +35369,11 @@
 	},
 /area/f13/wasteland)
 "nHQ" = (
-/obj/item/flag/khan,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	pixel_y = 12
 	},
+/obj/structure/gallow,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nHT" = (
@@ -35329,7 +35616,9 @@
 /area/f13/caves)
 "nMs" = (
 /obj/machinery/chem_master,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "nME" = (
 /obj/effect/decal/remains/human,
@@ -35514,10 +35803,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/legion)
-"nQk" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/mineral/plastitanium,
-/area/f13/followers)
 "nQM" = (
 /obj/structure/barricade/sandbags{
 	name = "go away"
@@ -35525,8 +35810,10 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "nQP" = (
-/obj/structure/table/optable,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "nRb" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -35613,6 +35900,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"nTb" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/raiders)
 "nTe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -35632,8 +35923,9 @@
 	},
 /area/f13/wasteland)
 "nTm" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "nTx" = (
 /obj/structure/simple_door/repaired,
@@ -35791,7 +36083,9 @@
 /obj/machinery/door/airlock/glass_large{
 	name = "Followers Clinic"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "nWy" = (
 /obj/structure/chair{
@@ -36243,6 +36537,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
+"ohr" = (
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/followers)
 "ohA" = (
 /obj/machinery/light,
 /obj/structure/decoration/sign{
@@ -36542,7 +36845,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "onh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36578,7 +36883,9 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "onD" = (
 /obj/structure/decoration/clock/old/active,
@@ -36635,7 +36942,9 @@
 "ooE" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/medsprays,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "opl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36733,7 +37042,9 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/medical,
 /obj/structure/curtain,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "oqL" = (
 /obj/structure/car/rubbish2,
@@ -36922,6 +37233,11 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"ouF" = (
+/obj/structure/tires/two,
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ouJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37561,7 +37877,12 @@
 	name = "Kitchen";
 	req_one_access_txt = "124"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/followers)
 "oJm" = (
 /obj/structure/closet,
@@ -38565,12 +38886,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "pfK" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/table,
+/obj/item/lighter/gold{
+	desc = "A shiny and relatively expensive zippo lighter. There's a small world etched on the bottom that reads, ''Sunflower'";
+	pixel_x = -6;
+	pixel_y = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_y = 7
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "pfX" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -38582,10 +38908,10 @@
 /obj/item/stack/ore/blackpowder/fifty,
 /obj/item/stack/sheet/hay/twenty,
 /obj/item/stack/sheet/cloth/five,
-/obj/item/grenade/frag,
-/obj/item/grenade/frag,
 /obj/structure/table,
 /obj/machinery/light/small,
+/obj/item/grenade/f13/stinger,
+/obj/item/grenade/f13/stinger,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "pgl" = (
@@ -38722,15 +39048,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "piw" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
+/obj/structure/tires/two,
+/obj/structure/wreck/bus/rusted/segmented5{
+	layer = 3.2
 	},
-/obj/machinery/light{
-	dir = 8
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/f13/followers)
+/area/f13/caves)
 "pix" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/wood,
@@ -39131,13 +39456,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pqR" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/medical,
-/obj/structure/curtain,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "prp" = (
 /obj/structure/barricade/tentclothedge,
@@ -39208,6 +39533,14 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"pta" = (
+/obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/raiders)
 "ptb" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/wood{
@@ -39634,11 +39967,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "pDv" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "pDw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -40758,6 +41092,26 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/village)
+"qcC" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/wood,
+/area/f13/raiders)
 "qcG" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
@@ -41744,13 +42098,12 @@
 	},
 /area/f13/building)
 "qxH" = (
-/obj/structure/closet,
-/obj/item/clothing/under/f13/rag,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
+	},
+/obj/structure/campfire/stove,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
@@ -41770,7 +42123,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qyo" = (
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/followers)
 "qyt" = (
 /obj/machinery/light{
@@ -43258,6 +43613,14 @@
 "rct" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"rcv" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/followers)
 "rcC" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -43469,9 +43832,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/village)
-"rhM" = (
-/turf/closed/wall/f13/supermart,
-/area/f13/followers)
 "rhT" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -44674,6 +45034,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
+"rLs" = (
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/caves)
 "rLz" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -45237,6 +45604,7 @@
 /obj/item/storage/fancy/rollingpapers,
 /obj/item/storage/fancy/rollingpapers,
 /obj/structure/table/wood/junk,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "rZk" = (
@@ -46667,6 +47035,21 @@
 "sDc" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/legion)
+"sDg" = (
+/obj/structure/table/booth,
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/raiders)
 "sDk" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles{
@@ -47623,7 +48006,9 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "sVe" = (
 /turf/open/indestructible/ground/outside/road{
@@ -50905,7 +51290,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ulI" = (
-/obj/structure/fluff/fokoff_sign,
+/obj/item/flag/khan,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirtcorner"
@@ -51185,6 +51570,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"urs" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/followers)
 "urt" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -51440,6 +51833,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
+"uxI" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "uxR" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/wood/f13/oak,
@@ -53100,6 +53499,11 @@
 "vfJ" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/raiders)
+"vfT" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "vfU" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -54464,6 +54868,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
+"vJY" = (
+/obj/effect/decal/remains/human,
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vKl" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -54866,8 +55275,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vUG" = (
-/obj/item/flag/khan,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "vVa" = (
 /obj/structure/rack,
@@ -55024,6 +55438,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vYj" = (
+/obj/structure/flora/tree/cactus,
+/obj/structure/fluff/fokoff_sign{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vYn" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/oak,
@@ -55064,7 +55486,9 @@
 "vYN" = (
 /obj/structure/grille/indestructable,
 /obj/effect/spawner/structure/window/plastitanium,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/followers)
 "vZm" = (
 /obj/machinery/light/small/broken{
@@ -56743,9 +57167,14 @@
 	},
 /area/f13/wasteland)
 "wMF" = (
-/obj/structure/campfire/stove,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
+	},
+/obj/structure/bed/wooden{
+	color = "#323538"
+	},
+/obj/item/blanket{
+	color = "#800000"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
@@ -56920,11 +57349,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "wPU" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -57351,6 +57785,15 @@
 	icon_state = "verticalleftborderright2bottom"
 	},
 /area/f13/village)
+"wXE" = (
+/obj/structure/flora/tree/cactus{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "wXJ" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -57833,6 +58276,13 @@
 /obj/structure/simple_door/repaired,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"xgT" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "xgX" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -61759,7 +62209,7 @@ gcK
 gcK
 gcK
 gcK
-kGc
+bFJ
 unI
 qvQ
 ehN
@@ -62016,7 +62466,7 @@ gcK
 gcK
 gcK
 gcK
-kGc
+bFJ
 unI
 qvQ
 ehN
@@ -62273,7 +62723,7 @@ gcK
 gcK
 gcK
 vaA
-ehN
+bFJ
 mFu
 qvQ
 ehN
@@ -94356,8 +94806,8 @@ mCM
 sVc
 hkY
 hkY
-qyo
-qyo
+nTm
+nTm
 nWu
 kgD
 qSN
@@ -94611,11 +95061,11 @@ sxT
 mCM
 hdY
 ldX
-qyo
-qyo
-qyo
-qyo
-qyo
+nTm
+nTm
+nTm
+nTm
+nTm
 kgD
 qSN
 nMk
@@ -94868,9 +95318,9 @@ tQl
 mCM
 mCM
 hHK
-qyo
-qyo
-qyo
+nTm
+nTm
+nTm
 eOr
 psu
 mCM
@@ -95125,10 +95575,10 @@ qUC
 mCM
 qMq
 ldX
-qyo
-qyo
-qyo
-qyo
+nTm
+nTm
+nTm
+nTm
 iJR
 hiB
 nlA
@@ -95382,14 +95832,14 @@ ppd
 mCM
 mCM
 hJf
-qyo
-qyo
-qyo
-qyo
+nTm
+nTm
+nTm
+nTm
 iJR
-qyo
-qyo
-iLK
+amK
+amK
+rcv
 ont
 mCM
 dCV
@@ -95645,8 +96095,8 @@ kLO
 lAC
 mCM
 iLo
-qyo
-qyo
+amK
+amK
 ooE
 mCM
 dCV
@@ -95895,15 +96345,15 @@ gaK
 gkZ
 mCM
 hfq
-qyo
+vfT
 iLK
 jqe
-qyo
-qyo
+vfT
+vfT
 oJc
 med
-qyo
-qyo
+amK
+amK
 gso
 mCM
 dCV
@@ -96152,18 +96602,18 @@ tQl
 qUC
 mCM
 hfQ
-qyo
-qyo
-qyo
-qyo
-eOr
+vfT
+vfT
+vfT
+vfT
+goE
 dxx
-rhM
-nnl
+cOX
+meY
 meY
 meY
 mCM
-mCM
+dCV
 dCV
 gts
 nxY
@@ -96412,15 +96862,15 @@ gmn
 hKe
 hKe
 hKe
-qyo
-qyo
+vfT
+vfT
 mdA
-hiB
-qyo
+urs
+gmp
 nQP
 npH
-piw
 mCM
+dCV
 dCV
 gts
 fyf
@@ -96669,15 +97119,15 @@ hgc
 guZ
 iNo
 jrS
-qyo
-qyo
+vfT
+vfT
 mdA
-qyo
-qyo
-qyo
-qyo
-qyo
+nTm
+nTm
+nTm
+nQP
 mCM
+dCV
 dCV
 gts
 fyf
@@ -96926,15 +97376,15 @@ nvx
 qyo
 qyo
 jsq
-qyo
-qyo
-mdA
-qyo
-qyo
+vfT
+vfT
+mdF
 nTm
 nTm
-qyo
+nTm
+ixA
 mCM
+dCV
 dCV
 gts
 fyf
@@ -97183,15 +97633,15 @@ hgd
 qyo
 qyo
 jsq
-qyo
-qyo
+vfT
+vfT
 mdF
-qyo
-qyo
-mCR
-nQk
-qyo
+nTm
+nTm
+nTm
+nTm
 mCM
+dCV
 dCV
 gts
 fyf
@@ -97437,18 +97887,18 @@ sxT
 gqS
 mCM
 mCM
-mCM
+eJC
 iNI
 iNI
 mCM
 lAI
-rhM
-qyo
-qyo
-qyo
-qyo
-qyo
 mCM
+jlZ
+nTm
+nTm
+aJc
+mCM
+dCV
 dCV
 gts
 fyf
@@ -97699,13 +98149,13 @@ gWp
 gWp
 mCM
 hlE
-rhM
-pqR
-oqH
-oqH
-oqH
-pqR
 mCM
+pqR
+oqH
+oqH
+mEO
+mCM
+dCV
 dCV
 gts
 fyf
@@ -97962,7 +98412,7 @@ mCM
 mCM
 mCM
 mCM
-psu
+dCV
 dCV
 gts
 fyf
@@ -98210,7 +98660,7 @@ mCM
 hqf
 gWp
 gWp
-gWp
+ohr
 mCM
 dCV
 dCV
@@ -98854,7 +99304,7 @@ lxW
 dJQ
 qbD
 vnR
-eQq
+lxW
 lxW
 qbD
 gcK
@@ -99369,7 +99819,7 @@ lxW
 qbD
 qbD
 qbD
-mEh
+eQq
 qbD
 gcK
 gcK
@@ -99625,7 +100075,7 @@ hre
 lxW
 lxW
 mEh
-lxW
+bKF
 lxW
 qbD
 gcK
@@ -107887,12 +108337,12 @@ gcK
 gcK
 gcK
 gcK
-vUG
-afs
-mvv
-afs
-afs
-afs
+gcK
+gcK
+fyf
+gcK
+gcK
+gcK
 fyf
 fyf
 ppm
@@ -108143,14 +108593,14 @@ gcK
 gcK
 gcK
 gcK
-pfK
-afs
-afs
-niI
-afs
-afs
-niI
-afs
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
 xTK
 fyf
 fyf
@@ -108367,7 +108817,7 @@ stD
 fzN
 stD
 mvv
-dEc
+iCH
 aav
 hQr
 unl
@@ -108400,16 +108850,16 @@ gcK
 ktB
 gcK
 gcK
-gSc
-afs
-afs
-afs
-afs
-afs
-afs
-afs
-afs
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gIU
 fyf
 jRX
 pyk
@@ -108657,16 +109107,16 @@ gcK
 gcK
 ktB
 gcK
-pDv
-afs
-afs
-afs
-afs
-afs
-afs
-afs
-afs
-fyf
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+mTd
+fgD
 fyf
 kGc
 unI
@@ -108872,9 +109322,9 @@ gcK
 gcK
 dEc
 dEc
-dEc
-aDW
 iCH
+aDW
+dEc
 qdS
 lPT
 aLd
@@ -108914,15 +109364,15 @@ gcK
 gcK
 ktB
 ktB
-wPU
-afs
-afs
-niI
-afs
-afs
-niI
-afs
-afs
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+xgT
 wDc
 fyf
 kGc
@@ -109128,8 +109578,8 @@ gcK
 ktB
 gcK
 cQs
-hMz
-gSx
+gSc
+niI
 gSx
 ebx
 eBu
@@ -109153,7 +109603,7 @@ stD
 mvv
 mvv
 lXB
-lPT
+chg
 mxO
 mRH
 nhW
@@ -109171,15 +109621,15 @@ gcK
 gcK
 gcK
 ktB
-lGf
-afs
-afs
-afs
-afs
-afs
-afs
-afs
-mvv
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+gcK
+mTd
+vJY
 bpD
 fyf
 kGc
@@ -109385,8 +109835,8 @@ gcK
 gcK
 gcK
 taV
-gSx
-hMz
+lGf
+pfK
 gSx
 edF
 qdS
@@ -109429,13 +109879,13 @@ gcK
 gcK
 kgn
 dfR
+gcK
+gcK
+gcK
 vUG
-afs
-afs
-afs
-afs
-afs
-afs
+gcK
+wPU
+aev
 iHu
 bpD
 fyf
@@ -109644,7 +110094,7 @@ gcK
 iHR
 qxH
 gSx
-gSx
+pDv
 iHR
 gQy
 eXn
@@ -109691,8 +110141,8 @@ mvv
 mvv
 mvv
 mvv
-mvv
-mvv
+fzN
+bGM
 mvv
 bpD
 fyf
@@ -110181,7 +110631,7 @@ cTp
 clL
 aLd
 lXB
-lPT
+chg
 lDz
 mvY
 bBY
@@ -111237,7 +111687,7 @@ ktB
 gcK
 ayd
 ulI
-fyf
+vYj
 kGc
 unI
 qvQ
@@ -111493,7 +111943,7 @@ gcK
 ktB
 gcK
 gcK
-fyf
+wZe
 fyf
 kGc
 unI
@@ -112007,8 +112457,8 @@ iHR
 gcK
 gcK
 gcK
-fyf
-eHt
+wZe
+hAC
 kGc
 unI
 qnS
@@ -112264,7 +112714,7 @@ taV
 gcK
 gcK
 gcK
-fyf
+wZe
 hAC
 kGc
 unI
@@ -112521,7 +112971,7 @@ iHR
 gcK
 gcK
 gcK
-tNX
+wZe
 giS
 kGc
 unI
@@ -112778,8 +113228,8 @@ xdG
 gcK
 gcK
 gcK
-ptP
-tNX
+ouF
+fyf
 kGc
 unI
 pOC
@@ -113000,7 +113450,7 @@ rxE
 dEc
 tDH
 jyz
-fff
+iDN
 mvv
 mvv
 stD
@@ -113036,7 +113486,7 @@ gcK
 gcK
 gcK
 fyf
-fyf
+tNX
 kGc
 unI
 pKq
@@ -113255,9 +113705,9 @@ mvv
 egy
 blv
 dEc
-iEp
+kkk
 jDk
-mfD
+nBv
 xGH
 mvv
 mvv
@@ -113514,10 +113964,10 @@ pye
 mvv
 nFA
 gpC
-fyf
-iCH
-kkk
-rxE
+sDg
+tBN
+mvv
+mvv
 qTe
 qTe
 qTe
@@ -113769,13 +114219,13 @@ jIz
 pye
 mvv
 pye
-nFA
-jGe
-vtg
-gVt
 kmz
-kHB
-kZp
+jGe
+kpR
+tBN
+mvv
+mvv
+mvv
 xwW
 mvv
 mhJ
@@ -114026,16 +114476,16 @@ jIz
 mvv
 mvv
 gcK
-gcK
-gcK
-gcK
-dEc
-dEc
-dEc
-lcl
-mvv
+kHB
 lGH
-gcK
+wXE
+tBN
+iCH
+mmV
+rxE
+jaa
+jaa
+ayd
 gcK
 gcK
 gcK
@@ -114283,17 +114733,17 @@ htN
 tan
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+kZp
+nnl
+bhQ
+ltK
+gVt
+qcC
+ach
+nTb
+ggK
+ggK
+ggK
 gcK
 gcK
 aip
@@ -114540,17 +114990,17 @@ mTd
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
-gcK
+lcl
+piw
+rLs
+akf
+dEc
+dEc
+dEc
+pta
+ggK
+ggK
+ggK
 gcK
 gcK
 amc
@@ -114805,9 +115255,9 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-gcK
+ggK
+ggK
+ggK
 gcK
 gcK
 apk
@@ -115063,7 +115513,7 @@ gcK
 gcK
 gcK
 gcK
-gcK
+ggK
 gcK
 gcK
 gcK
@@ -122915,9 +123365,9 @@ fyf
 hAC
 fyf
 hAC
-mcN
-ehN
-mFu
+fyf
+fyf
+fyf
 kGc
 unI
 qvQ
@@ -123172,9 +123622,9 @@ hAC
 fyf
 uey
 hAC
-mcN
-jHQ
-bKF
+fyf
+uey
+fyf
 kGc
 unI
 qvQ
@@ -123429,9 +123879,9 @@ fyf
 uey
 fyf
 fyf
-mcN
-mcN
-mcN
+fyf
+fyf
+fyf
 kGc
 unI
 qvQ
@@ -123686,9 +124136,9 @@ fyf
 fyf
 hAC
 uey
-mcN
-mcN
-mFu
+fyf
+fyf
+fyf
 kGc
 unI
 qvQ
@@ -123943,10 +124393,10 @@ fyf
 fyf
 fyf
 fyf
-fyf
-fyf
-fyf
-kGc
+mcN
+mcN
+ewE
+psR
 unI
 qvQ
 rbi
@@ -124200,10 +124650,10 @@ gcK
 gcK
 fyf
 fyf
-fyf
-fyf
-fyf
-kGc
+mcN
+cpK
+cpK
+cpK
 unI
 qvQ
 ehN
@@ -124457,10 +124907,10 @@ gcK
 gcK
 gcK
 gcK
-gcK
-gcK
-fyf
-kGc
+vaA
+xjv
+uxI
+cpK
 unI
 qvQ
 ehN
@@ -124714,9 +125164,9 @@ gbL
 gbL
 gbL
 gcK
-gcK
-gcK
-mGC
+vaA
+vaA
+tMU
 mGC
 oZc
 uhk

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1946,7 +1946,9 @@
 /obj/structure/fence/wooden{
 	pixel_x = 14
 	},
-/obj/structure/fermenting_barrel,
+/obj/structure/fermenting_barrel{
+	anchored = 1
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aOz" = (
@@ -30637,7 +30639,10 @@
 /area/f13/building)
 "lTb" = (
 /obj/machinery/mineral/wasteland_vendor/khanchem,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "lTk" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -38962,7 +38967,9 @@
 /obj/structure/fence/wooden{
 	pixel_x = 14
 	},
-/obj/structure/fermenting_barrel,
+/obj/structure/fermenting_barrel{
+	anchored = 1
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
 	icon_state = "dirt"
@@ -109108,11 +109115,11 @@ stD
 stD
 mvv
 mvv
-mvv
-mvv
-fzN
-mvv
-mvv
+wjO
+cWG
+qQo
+cWG
+ltK
 egW
 vfU
 iqZ

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -376,16 +376,16 @@
 	},
 /area/f13/wasteland)
 "agU" = (
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_x = -15;
-	pixel_y = 6
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = -13;
+	pixel_y = 1
 	},
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_x = -15;
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/stage_bl,
+/area/f13/raiders)
 "agW" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -570,9 +570,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "akf" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = 13;
+	pixel_y = 1
+	},
+/turf/open/floor/wood/f13/stage_br,
+/area/f13/raiders)
 "akk" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -2900,11 +2907,21 @@
 	},
 /area/f13/building)
 "bhQ" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+/obj/structure/table/booth,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
 	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/raiders)
 "bia" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -15976,11 +15993,6 @@
 /turf/open/floor/carpet/blackred,
 /area/f13/ncr)
 "gpC" = (
-/obj/structure/tires/two,
-/obj/structure/tires/five,
-/obj/structure/wreck/bus/rusted/segmented1{
-	layer = 3.2
-	},
 /obj/structure/fence/wooden{
 	climbable = 0;
 	dir = 4;
@@ -24995,9 +25007,6 @@
 	},
 /area/f13/bunker)
 "jDk" = (
-/obj/structure/wreck/bus/rusted{
-	layer = 3.5
-	},
 /obj/structure/fence/corner/wooden{
 	dir = 1;
 	layer = 6.1;
@@ -25010,6 +25019,10 @@
 	layer = 6;
 	name = "awning";
 	pixel_y = -3
+	},
+/obj/structure/closet/bus{
+	pixel_x = -16;
+	pixel_y = -14
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/raiders)
@@ -25104,10 +25117,6 @@
 	},
 /area/f13/wasteland)
 "jGe" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented2{
-	layer = 3.2
-	},
 /obj/structure/fence/corner/wooden{
 	dir = 4;
 	layer = 6.1;
@@ -26598,14 +26607,8 @@
 	},
 /area/f13/wasteland)
 "kkk" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented7{
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/raiders)
 "kkD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -26717,13 +26720,18 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kmz" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented9{
-	layer = 6
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/fence/wooden{
+	pixel_x = 14
 	},
+/obj/structure/fence/wooden{
+	pixel_x = -13
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kmA" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -26907,20 +26915,10 @@
 /obj/structure/chair/booth{
 	dir = 8
 	},
-/obj/structure/fence/wooden{
-	climbable = 0;
-	density = 0;
-	dir = 1;
-	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
-	},
 /obj/structure/chair/booth{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/raiders)
 "kpW" = (
 /obj/structure/closet/cabinet,
@@ -27624,9 +27622,13 @@
 	},
 /area/f13/wasteland)
 "kGe" = (
-/obj/structure/sink/well{
-	pixel_x = -32;
-	pixel_y = -20
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fence/wooden{
+	pixel_x = 14
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -27679,12 +27681,11 @@
 	},
 /area/f13/village)
 "kHB" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented10,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/turf/open/floor/f13{
+	color = "#A47449";
+	icon_state = "rampdowntop"
 	},
-/area/f13/caves)
+/area/f13/wasteland)
 "kHC" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -28473,14 +28474,16 @@
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
 "kZp" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented11{
-	layer = 3.2
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_x = -15;
+	pixel_y = 6
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_x = -15;
+	pixel_y = 6
 	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kZz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28625,14 +28628,11 @@
 	},
 /area/f13/enclave)
 "lcl" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented12{
-	layer = 6
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lcm" = (
 /obj/effect/decal/waste{
@@ -30072,23 +30072,26 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "lGH" = (
-/obj/structure/wreck/bus/rusted/segmented3{
-	layer = 3.2
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin";
+/obj/structure/fence/wooden{
+	climbable = 0;
+	dir = 4;
 	layer = 6.1;
-	pixel_x = 2;
-	pixel_y = 13
+	pixel_x = -17
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	layer = 6.1;
-	pixel_x = 3;
-	pixel_y = 12
+/obj/structure/wreck/bus/rusted/segmented10{
+	pixel_y = 9
 	},
+/obj/structure/wreck/bus/rusted/segmented10,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/raiders)
 "lGV" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -34483,13 +34486,24 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/building)
 "nnl" = (
-/obj/structure/wreck/bus/rusted/segmented4{
-	layer = 3.2
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
+	},
+/obj/structure/fence/wooden{
+	climbable = 0;
+	dir = 4;
+	layer = 6.1;
+	pixel_x = -17
 	},
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
-/area/f13/wasteland)
+/area/f13/raiders)
 "nnB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cabinet/anchored{
@@ -35134,10 +35148,7 @@
 	pixel_x = -13;
 	pixel_y = 1
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
+/turf/open/floor/wood/f13/stage_tl,
 /area/f13/raiders)
 "nBA" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35305,15 +35316,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
-"nFA" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented8{
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "nFL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowleft"
@@ -39048,14 +39050,29 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "piw" = (
-/obj/structure/tires/two,
-/obj/structure/wreck/bus/rusted/segmented5{
-	layer = 3.2
+/obj/structure/fence/corner/wooden{
+	dir = 4;
+	layer = 6.1;
+	pixel_x = 13
+	},
+/obj/structure/fence/wooden{
+	climbable = 0;
+	dir = 4;
+	layer = 6.1;
+	pixel_x = -17
+	},
+/obj/structure/barricade/wooden/strong{
+	desc = "Provides mild weather protection.";
+	icon = 'icons/fallout/turfs/walls/tents.dmi';
+	icon_state = "cloth_edge";
+	layer = 6;
+	name = "awning";
+	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/caves)
+/area/f13/raiders)
 "pix" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/wood,
@@ -45035,12 +45052,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/village)
 "rLs" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = 13;
+	pixel_y = 1
 	},
-/area/f13/caves)
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/stage_tr,
+/area/f13/raiders)
 "rLz" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -47037,10 +47061,6 @@
 /area/f13/legion)
 "sDg" = (
 /obj/structure/table/booth,
-/obj/item/reagent_containers/food/condiment/ketchup{
-	pixel_x = -8;
-	pixel_y = 9
-	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_y = 11
 	},
@@ -47048,7 +47068,11 @@
 	pixel_x = 4;
 	pixel_y = 5
 	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/raiders)
 "sDk" = (
 /obj/structure/table/glass,
@@ -57786,14 +57810,11 @@
 	},
 /area/f13/village)
 "wXE" = (
-/obj/structure/flora/tree/cactus{
-	pixel_x = 3;
-	pixel_y = -6
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/raiders)
 "wXJ" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -112684,7 +112705,7 @@ mvv
 mvv
 mvv
 mvv
-mvv
+odZ
 mvv
 mei
 mzO
@@ -112940,7 +112961,7 @@ stD
 stD
 mvv
 mvv
-mvv
+pIn
 mvv
 mvv
 mvv
@@ -113195,10 +113216,10 @@ ekT
 eFA
 mvv
 stD
-kGe
 mvv
-agU
 mvv
+mvv
+kZp
 ttW
 mvv
 mss
@@ -113457,7 +113478,7 @@ stD
 qTe
 qTe
 qTe
-mvv
+gVp
 dCL
 mcf
 stD
@@ -113705,14 +113726,14 @@ mvv
 egy
 blv
 dEc
-kkk
+hwC
 jDk
 nBv
-xGH
+agU
+kmz
 mvv
 mvv
-gVp
-odZ
+mvv
 mvv
 dCL
 mcf
@@ -113962,12 +113983,12 @@ aLd
 fzN
 pye
 mvv
-nFA
+hwC
 gpC
 sDg
-tBN
-mvv
-mvv
+kkk
+kGe
+gVp
 qTe
 qTe
 qTe
@@ -114219,11 +114240,11 @@ jIz
 pye
 mvv
 pye
-kmz
+hwC
 jGe
 kpR
-tBN
-mvv
+kkk
+kHB
 mvv
 mvv
 xwW
@@ -114476,10 +114497,10 @@ jIz
 mvv
 mvv
 gcK
-kHB
+gcK
 lGH
 wXE
-tBN
+kkk
 iCH
 mmV
 rxE
@@ -114733,10 +114754,10 @@ htN
 tan
 gcK
 gcK
-kZp
+gcK
 nnl
 bhQ
-ltK
+kkk
 gVt
 qcC
 ach
@@ -114990,7 +115011,7 @@ mTd
 gcK
 gcK
 gcK
-lcl
+gcK
 piw
 rLs
 akf
@@ -115255,7 +115276,7 @@ gcK
 gcK
 gcK
 gcK
-ggK
+lcl
 ggK
 ggK
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -376,14 +376,6 @@
 	},
 /area/f13/wasteland)
 "agU" = (
-/obj/structure/fence/wooden{
-	climbable = 0;
-	density = 0;
-	dir = 1;
-	layer = 3.6;
-	pixel_x = -13;
-	pixel_y = 1
-	},
 /turf/open/floor/wood/f13/stage_bl,
 /area/f13/raiders)
 "agW" = (
@@ -1950,6 +1942,13 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"aOu" = (
+/obj/structure/fence/wooden{
+	pixel_x = 14
+	},
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aOz" = (
 /obj/machinery/light{
 	dir = 8
@@ -2908,10 +2907,6 @@
 /area/f13/building)
 "bhQ" = (
 /obj/structure/table/booth,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = -8;
 	pixel_y = 11
@@ -2919,6 +2914,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = 9;
 	pixel_y = 9
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 11
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/raiders)
@@ -7759,6 +7758,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -9095,10 +9097,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dHX" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/raiders)
 "dIj" = (
 /obj/structure/simple_door/bunker,
@@ -14206,6 +14211,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -14246,9 +14254,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
@@ -17801,7 +17806,6 @@
 /turf/open/floor/plating,
 /area/f13/tunnel)
 "gYA" = (
-/obj/machinery/light,
 /obj/structure/table,
 /obj/item/stack/medical/gauze,
 /turf/open/floor/f13{
@@ -18413,6 +18417,7 @@
 "hhG" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -18794,7 +18799,7 @@
 /area/f13/wasteland)
 "hnU" = (
 /obj/structure/rack/shelf_metal,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
@@ -26731,6 +26736,9 @@
 /obj/structure/fence/wooden{
 	pixel_x = -13
 	},
+/obj/structure/fence/wooden{
+	pixel_x = -18
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kmA" = (
@@ -29455,6 +29463,9 @@
 /area/f13/building)
 "lsF" = (
 /obj/machinery/workbench/forge,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "lsS" = (
@@ -35140,14 +35151,6 @@
 /obj/structure/chair/booth{
 	dir = 4
 	},
-/obj/structure/fence/wooden{
-	climbable = 0;
-	density = 0;
-	dir = 1;
-	layer = 3.6;
-	pixel_x = -13;
-	pixel_y = 1
-	},
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/raiders)
 "nBA" = (
@@ -38911,7 +38914,6 @@
 /obj/item/stack/sheet/hay/twenty,
 /obj/item/stack/sheet/cloth/five,
 /obj/structure/table,
-/obj/machinery/light/small,
 /obj/item/grenade/f13/stinger,
 /obj/item/grenade/f13/stinger,
 /turf/open/floor/f13/wood,
@@ -38953,13 +38955,19 @@
 	},
 /area/f13/wasteland)
 "pgB" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/obj/structure/fence/wooden{
+	pixel_x = 14
 	},
-/area/f13/raiders)
+/obj/structure/fermenting_barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pgD" = (
 /obj/structure/railing/handrail/end{
 	dir = 4
@@ -46652,6 +46660,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/workbench/bottler,
+/obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "stl" = (
@@ -47068,9 +47077,9 @@
 	pixel_x = 4;
 	pixel_y = 5
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
+/obj/machinery/light{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 6
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/raiders)
@@ -47595,7 +47604,6 @@
 /obj/item/melee/onehanded/machete,
 /obj/item/melee/onehanded/machete,
 /obj/structure/rack/shelf_metal,
-/obj/machinery/light/small,
 /obj/item/storage/bag/salvage,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
@@ -106781,7 +106789,7 @@ mvv
 amy
 hxt
 hMz
-dHX
+hMz
 qOn
 hnU
 gSx
@@ -107550,7 +107558,7 @@ dUS
 eyi
 cWG
 ftg
-pgB
+haw
 fRR
 fRR
 gSx
@@ -111151,7 +111159,7 @@ ogQ
 fIT
 xyT
 gez
-gez
+dHX
 tzz
 hZD
 iqZ
@@ -113471,8 +113479,8 @@ rxE
 dEc
 tDH
 jyz
-iDN
-mvv
+pgB
+aOu
 mvv
 stD
 qTe


### PR DESCRIPTION
## Screenshots
![grafik](https://user-images.githubusercontent.com/69112131/168813845-86805ada-cc92-48b6-8586-b5146b556030.png)
![grafik](https://user-images.githubusercontent.com/69112131/168813863-70b82dda-9a95-4bda-a019-aedaa866a2f6.png)
![grafik](https://user-images.githubusercontent.com/69112131/168813880-5eb3eab9-7cdb-44c3-9c65-a61ae8979d8a.png)


## About The Pull Request
Removes the Khan front the PR 439 has introduced and replaces it with one from before. Also adds a small picnic area and adds lights to a few spots that were dark. Adjusted the Followers slightly to look less like a space ship.

## Why It's Good For The Game
Looks a little better than previous PR.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
add: The old Khan front
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
