### PR TITLE
Minor map fixes

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -12,7 +12,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "abi" = (
@@ -37,12 +37,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
-"adL" = (
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/followers)
 "aeb" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/followers)
@@ -50,19 +44,16 @@
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
 "afn" = (
-/obj/machinery/vending/medical{
-	pixel_x = -29
-	},
 /obj/structure/curtain,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "rampdowntop"
 	},
 /area/f13/followers)
 "ahl" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "ahC" = (
@@ -218,19 +209,13 @@
 	},
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "aoN" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/followers)
-"aoW" = (
-/obj/machinery/chem_heater,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
@@ -257,7 +242,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "aqU" = (
@@ -286,7 +271,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "asb" = (
@@ -299,7 +284,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "ast" = (
@@ -332,7 +317,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "atN" = (
@@ -361,7 +346,7 @@
 /obj/structure/table,
 /obj/item/storage/box/beakers,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "avu" = (
@@ -392,7 +377,7 @@
 "axj" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "axt" = (
@@ -418,14 +403,14 @@
 	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "ayK" = (
 /obj/machinery/recycler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "aze" = (
@@ -466,7 +451,7 @@
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "aAP" = (
@@ -479,7 +464,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "aDh" = (
@@ -488,7 +473,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "aDD" = (
@@ -497,8 +482,9 @@
 /area/f13/wasteland)
 "aDF" = (
 /obj/machinery/chem_master,
+/obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "aEf" = (
@@ -546,7 +532,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "aIr" = (
@@ -555,7 +541,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "aIO" = (
@@ -1254,6 +1240,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ncr)
+"bAJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/followers)
 "bBj" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -1563,7 +1557,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "bVI" = (
@@ -1823,6 +1817,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave)
+"ckt" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "clD" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/punji_sticks{
@@ -3435,7 +3435,7 @@
 /obj/machinery/chem_heater,
 /obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "dYt" = (
@@ -3644,6 +3644,7 @@
 "egS" = (
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -4674,17 +4675,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"fxB" = (
-/obj/structure/fence{
-	climbable = 1;
-	dir = 1;
-	resistance_flags = 64
-	},
-/obj/effect/turf_decal/climb{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "fxR" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -5726,7 +5716,7 @@
 "gRo" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "gRq" = (
@@ -6159,6 +6149,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"huS" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "hvg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -6771,6 +6769,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/city)
+"imR" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "ina" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -7589,8 +7593,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "jtF" = (
@@ -7911,7 +7916,7 @@
 "jQe" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "jQx" = (
@@ -8001,6 +8006,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jVa" = (
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/followers)
 "jVx" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -8150,7 +8161,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/grille,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "kdm" = (
@@ -8339,11 +8350,9 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "kpx" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
+/obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "kqh" = (
@@ -8893,7 +8902,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "laW" = (
@@ -9136,6 +9145,7 @@
 	},
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -9672,7 +9682,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "lPk" = (
@@ -10553,7 +10563,7 @@
 /obj/item/storage/box/syringes,
 /obj/structure/rack,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "mIo" = (
@@ -10990,8 +11000,9 @@
 "njW" = (
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "nma" = (
@@ -11224,6 +11235,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nwp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "nwt" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/legion)
@@ -11559,7 +11576,7 @@
 "nVM" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "nVX" = (
@@ -11907,7 +11924,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
 "olU" = (
@@ -12038,7 +12055,7 @@
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "otT" = (
@@ -12189,6 +12206,11 @@
 "oAO" = (
 /turf/open/indestructible/ground,
 /area/f13/wasteland)
+"oAV" = (
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/followers)
 "oBt" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -12467,6 +12489,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"oQI" = (
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "oRr" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -13825,7 +13852,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
 "qrF" = (
@@ -13846,6 +13873,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"qsh" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/followers)
 "qsk" = (
 /mob/living/simple_animal/hostile/venus_human_trap{
 	aggro_vision_range = 12;
@@ -14797,7 +14830,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "rso" = (
@@ -15965,7 +15998,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/followers)
 "sKp" = (
@@ -16606,7 +16639,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "tCf" = (
@@ -16642,6 +16675,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"tDV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "tEa" = (
 /obj/structure/kitchenspike,
 /obj/machinery/light{
@@ -17114,6 +17153,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker)
+"uiq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "uir" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -18664,6 +18709,15 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"wjw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "purplefull"
+	},
+/area/f13/followers)
 "wjO" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light{
@@ -18763,6 +18817,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/bunker)
+"wsV" = (
+/obj/machinery/vending/medical,
+/turf/closed/wall/mineral/concrete{
+	slicing_duration = 150
+	},
+/area/f13/followers)
 "wtb" = (
 /obj/item/candle/infinite/hugbox,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19450,6 +19510,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"xoN" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/followers)
 "xpf" = (
 /obj/machinery/light{
 	dir = 4
@@ -19958,6 +20024,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"xXL" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "xYg" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -30070,7 +30141,7 @@ anh
 jtm
 aDF
 auP
-azF
+auP
 njW
 jtm
 fzi
@@ -30325,10 +30396,10 @@ bYA
 bYA
 anh
 kpx
-arg
-aGV
-aGV
-aGV
+huS
+tDV
+tDV
+wjw
 kpx
 lfu
 lcN
@@ -30581,11 +30652,11 @@ bYA
 bYA
 bYA
 aml
-aoW
-azF
-aGV
-aGV
-azF
+dYl
+kpx
+tDV
+tDV
+kpx
 dYl
 fzi
 fge
@@ -30840,10 +30911,10 @@ gti
 anh
 mIg
 atI
-arg
-aGV
+oQI
+tDV
 atI
-arg
+oQI
 aEW
 lWa
 fge
@@ -31102,7 +31173,7 @@ tAH
 kcy
 anh
 anh
-anv
+qsh
 anh
 anh
 bYA
@@ -31349,17 +31420,17 @@ anh
 uNv
 azB
 arg
-anh
+wsV
 aiU
 dcB
 dcB
 anh
 apL
 olK
-aGV
+uiq
 anh
 sKh
-aGV
+nwp
 otG
 anh
 bYA
@@ -31611,12 +31682,12 @@ aGV
 oaH
 aGV
 anh
-anh
+xXL
 aDh
-aGV
+uiq
 ahl
 rrA
-aGV
+nwp
 otG
 anh
 bYA
@@ -31863,14 +31934,14 @@ anh
 jKW
 azB
 arg
-adL
+afn
 aGV
 oaH
 jcZ
 anh
 bVt
-aGV
-arg
+uiq
+xXL
 anh
 aBE
 aIr
@@ -32120,17 +32191,17 @@ anh
 wul
 arg
 arg
-adL
+afn
 aGV
 oaH
 aGV
-anv
-aGV
-aGV
-aaS
+ckt
+uiq
+uiq
+imR
 anh
 aAz
-aGV
+nwp
 lOU
 anh
 bYA
@@ -32382,13 +32453,13 @@ akh
 aGV
 aGV
 anh
-arg
-arg
-aGV
+xXL
+xXL
+uiq
 anh
 aAz
-aGV
-aGV
+nwp
+nwp
 anh
 bYA
 bYA
@@ -32644,7 +32715,7 @@ gRo
 jQe
 anh
 arK
-aGV
+nwp
 ayK
 anh
 bYA
@@ -33156,7 +33227,7 @@ anh
 ayq
 asb
 asb
-arg
+oAV
 qrc
 anh
 bYA
@@ -33409,11 +33480,11 @@ arg
 anv
 aGV
 aGV
-anv
-arg
-arg
-arg
-arg
+xoN
+oAV
+oAV
+oAV
+oAV
 axj
 anh
 bYA
@@ -33667,10 +33738,10 @@ anh
 rlb
 aaS
 anh
-arg
-arg
-arg
-arg
+oAV
+oAV
+oAV
+oAV
 axj
 anh
 bYA
@@ -33925,9 +33996,9 @@ aGV
 arg
 anh
 laR
-arg
-atI
-arg
+oAV
+bAJ
+oAV
 axj
 anh
 bYA
@@ -34182,9 +34253,9 @@ aGV
 arg
 anh
 anh
-adL
+jVa
 anh
-anv
+xoN
 anh
 anh
 bYA
@@ -34439,7 +34510,7 @@ aGV
 akd
 anh
 aoK
-arg
+oAV
 anh
 aHp
 anh
@@ -40766,7 +40837,7 @@ vKV
 lnQ
 egS
 egS
-fxB
+lnQ
 vKV
 vKV
 vKV

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -4009,6 +4009,11 @@
 "mn" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/raiders)
+"mo" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/blueyellow,
+/area/f13/followers)
 "mp" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -11557,7 +11562,10 @@
 	name = "Follower Admin shutters"
 	},
 /obj/structure/grille,
-/turf/open/space/basic,
+/obj/structure/grille,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "Jh" = (
 /obj/structure/chair/booth{
@@ -53353,7 +53361,7 @@ PL
 PL
 PL
 PL
-so
+mo
 tR
 yt
 Pu

--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -2950,10 +2950,10 @@
 /obj/item/toy/crayon/spraycan,
 /obj/item/canvas,
 /obj/item/canvas,
-/obj/structure/table,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "jn" = (
@@ -3387,8 +3387,8 @@
 /obj/structure/railing{
 	dir = 9
 	},
-/obj/structure/table,
 /obj/item/binoculars,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "kC" = (
@@ -9434,6 +9434,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"CF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/followers)
 "CG" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -52072,7 +52078,7 @@ Ck
 lv
 vO
 Za
-Za
+CF
 Za
 eQ
 zn

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4895,6 +4895,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"bUu" = (
+/obj/machinery/vending/hydroseeds,
+/turf/closed/wall/mineral/concrete{
+	slicing_duration = 150
+	},
+/area/f13/followers)
 "bUF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -5158,6 +5164,7 @@
 	},
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -10746,8 +10753,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/chair/f13chair2,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/followers)
 "eoc" = (
@@ -12200,6 +12206,12 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/bunker)
+"eQt" = (
+/obj/machinery/vending/hydronutrients,
+/turf/closed/wall/mineral/concrete{
+	slicing_duration = 150
+	},
+/area/f13/followers)
 "eQA" = (
 /obj/structure/dresser{
 	pixel_y = 10
@@ -13539,6 +13551,7 @@
 	},
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -14241,11 +14254,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "fFB" = (
-/obj/machinery/vending/hydronutrients{
-	pixel_y = -31
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/followers)
 "fFF" = (
 /obj/structure/rack,
@@ -20084,8 +20103,7 @@
 /area/f13/wasteland)
 "hHK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
+/obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -22641,6 +22659,15 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"iIM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/greyscale{
+	dir = 8;
+	pixel_x = -14;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
+/area/f13/followers)
 "iIY" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -35216,10 +35243,10 @@
 	},
 /area/f13/wasteland)
 "nyV" = (
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
-	dir = 4
+	dir = 1
 	},
 /area/f13/followers)
 "nza" = (
@@ -37112,11 +37139,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "ooE" = (
-/obj/machinery/vending/hydroseeds{
-	pixel_y = -31
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/followers)
 "opl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40291,6 +40316,7 @@
 "pFv" = (
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -44109,7 +44135,9 @@
 	id = "followerladder"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
 /area/f13/followers)
 "rhT" = (
 /obj/structure/simple_door/interior,
@@ -95333,7 +95361,7 @@ mfn
 enS
 sVc
 sVc
-nyV
+sVc
 sVc
 uxe
 mfn
@@ -96106,10 +96134,10 @@ xWX
 xWX
 xWX
 xWX
-wLL
+nyV
 mfn
 hiB
-omU
+iIM
 med
 omU
 hiB
@@ -96883,8 +96911,8 @@ iNL
 omU
 omU
 omU
-ooE
-mfn
+omU
+bUu
 dCV
 gts
 fyf
@@ -97140,8 +97168,8 @@ nnl
 omU
 omU
 omU
-fFB
-mfn
+omU
+eQt
 dCV
 gts
 nxY
@@ -97644,7 +97672,7 @@ nWl
 qUC
 mfn
 mfn
-rJp
+fFB
 rJp
 qyo
 qyo
@@ -98421,7 +98449,7 @@ vKZ
 vKZ
 mfn
 rhM
-nTm
+ooE
 nTm
 nTm
 jkw

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -1841,8 +1841,7 @@
 /area/f13/tunnel)
 "bdL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack/drug_storage,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/closed/mineral/random/low_chance/underground,
 /area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2732,6 +2731,7 @@
 	},
 /obj/structure/fence{
 	climbable = 1;
+	cuttable = 0;
 	dir = 1;
 	resistance_flags = 64
 	},
@@ -3114,7 +3114,7 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/machinery/biogenerator,
+/obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bKc" = (
@@ -3246,7 +3246,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3774,8 +3774,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/machinery/light/floor,
-/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/smartfridge/bottlerack/drug_storage,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "cbH" = (
@@ -5537,6 +5539,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"cYs" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6975,7 +6983,7 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/structure/chair/stool/retro/black,
+/obj/machinery/smartfridge/bottlerack/alchemy_rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "dNb" = (
@@ -7865,6 +7873,10 @@
 /obj/machinery/hydroponics/soil/pot,
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"eiz" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
@@ -9008,7 +9020,12 @@
 	},
 /area/f13/sewer)
 "eMH" = (
+/obj/machinery/light/floor,
 /obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 1;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "eMK" = (
@@ -9481,6 +9498,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"faq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9868,7 +9890,7 @@
 	},
 /area/f13/den)
 "fnc" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -10393,7 +10415,7 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/machinery/seed_extractor,
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fAi" = (
@@ -12305,7 +12327,8 @@
 	pixel_y = -31
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/effect/decal/cleanable/blood/gibs/human/body,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
@@ -13991,6 +14014,10 @@
 /obj/item/clothing/mask/cigarette/bigboss,
 /obj/item/clothing/mask/cigarette/bigboss,
 /obj/structure/rack/shelf_metal,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "hKS" = (
@@ -15602,8 +15629,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
@@ -15762,9 +15789,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/structure/legion_extractor,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -16910,6 +16936,13 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"jBt" = (
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibmid3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16972,7 +17005,7 @@
 /area/f13/bunker)
 "jEr" = (
 /obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -18023,6 +18056,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"kjh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -22178,10 +22215,9 @@
 /area/f13/building)
 "mOS" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 1;
-	pixel_y = 10
-	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "mPe" = (
@@ -22503,10 +22539,6 @@
 "mYc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
@@ -28314,6 +28346,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qxm" = (
+/obj/machinery/light/floor,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -29182,12 +29221,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"qWq" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "qXf" = (
 /obj/structure/lattice/catwalk/clockwork,
 /turf/open/floor/bronze{
@@ -34479,12 +34512,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
-"tYJ" = (
-/obj/machinery/smartfridge/bottlerack/alchemy_rack,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tYQ" = (
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
@@ -36481,12 +36508,39 @@
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36568,8 +36622,9 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/machinery/iv_drip,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
@@ -37813,7 +37868,7 @@
 /area/f13/building)
 "wam" = (
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -40133,38 +40188,9 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "xtk" = (
@@ -80037,14 +80063,14 @@ auj
 fjU
 blx
 blx
-kTJ
+cbG
 cdh
 fLy
 wpa
 wpa
 fQB
 blx
-efa
+iPX
 efa
 efa
 efa
@@ -80294,7 +80320,7 @@ auj
 fjU
 blx
 blx
-ckD
+dNa
 cdh
 ckD
 cdh
@@ -80812,7 +80838,7 @@ diR
 blx
 blx
 diR
-diR
+faq
 uLP
 blx
 ylp
@@ -81064,12 +81090,12 @@ auj
 gmI
 eZw
 blx
-qWq
-ckD
+wjM
+blx
 xsf
 ckD
-ckD
-vlM
+xtg
+wpa
 ckD
 blx
 efa
@@ -81322,8 +81348,8 @@ iDK
 ohx
 blx
 bdL
-ckD
-cbG
+blx
+eMH
 ckD
 ckD
 qfj
@@ -81578,12 +81604,12 @@ iDK
 iDK
 auj
 blx
-tYJ
-ckD
+wjM
+blx
 thm
-dNa
+iLY
 wpa
-wpa
+cYs
 ckD
 blx
 wpF
@@ -81835,12 +81861,12 @@ iDK
 iDK
 rGe
 blx
-xtg
-ckD
+blx
+blx
 ndz
-eMH
 mOS
-fLy
+eiz
+qxm
 ckD
 blx
 kTJ
@@ -82091,7 +82117,7 @@ fhe
 fUQ
 iDK
 iDK
-blx
+uLP
 ckD
 ckD
 wpF
@@ -82609,8 +82635,8 @@ kUN
 kUN
 kUN
 kUN
-iLY
-iLY
+vlM
+kjh
 fnc
 jEr
 blx
@@ -82866,9 +82892,9 @@ kUN
 wjM
 wjM
 kUN
-iPX
-fnc
 voL
+fnc
+jBt
 gFp
 blx
 jkU

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -3114,9 +3114,7 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/machinery/plantgenes,
-/obj/structure/table/glass,
-/obj/item/disk/plantgene,
+/obj/machinery/biogenerator,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bKc" = (
@@ -3183,12 +3181,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/machinery/autolathe/hacked,
+/obj/machinery/autolathe,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bMI" = (
 /obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -3244,15 +3241,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/structure/table/optable,
-/obj/machinery/light/floor,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3772,14 +3766,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "cbu" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/light/floor,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -4628,8 +4625,8 @@
 "czr" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -5175,8 +5172,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -5245,7 +5242,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/machinery/autolathe/ammo/unlocked,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cQz" = (
@@ -5361,7 +5358,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/armored/light/vest/kevlar,
 /obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5651,9 +5648,9 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	pixel_x = -28;
 	id = "denshutters";
-	name = "Den shutters"
+	name = "Den shutters";
+	pixel_x = -28
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
@@ -5813,8 +5810,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -6083,7 +6080,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dnP" = (
-/obj/machinery/workbench/advanced,
+/obj/machinery/workbench,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dnQ" = (
@@ -6182,8 +6179,8 @@
 "dqh" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -6763,8 +6760,8 @@
 "dGU" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -6978,13 +6975,8 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/machinery/hydroponics/soil/pot,
-/obj/machinery/light/small,
-/obj/machinery/vending/hydronutrients{
-	pixel_y = -31;
-	density = 0
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7560,8 +7552,8 @@
 /area/f13/bunker)
 "eay" = (
 /obj/structure/rack/shelf_metal,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/obj/effect/spawner/bundle/f13/armor/combat/dark,
+/obj/effect/spawner/bundle/f13/armor/combat/dark,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "eaB" = (
@@ -8187,11 +8179,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/bunker)
-"eqZ" = (
-/obj/item/disk/surgery/oasis,
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "erk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -8435,8 +8422,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -8600,8 +8587,7 @@
 /area/f13/tcoms)
 "eCs" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	pixel_y = 0;
+/obj/machinery/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -8964,10 +8950,6 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "eLq" = (
-/obj/machinery/vending/hydroseeds{
-	pixel_y = -31;
-	density = 0
-	},
 /obj/structure/sink/kitchen{
 	dir = 8;
 	pixel_x = 12
@@ -9026,7 +9008,7 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/closet/crate/freezer/blood,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "eMK" = (
@@ -9760,14 +9742,12 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /obj/item/grenade/empgrenade,
 /obj/item/grenade/empgrenade,
 /obj/item/grenade/empgrenade,
-/obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fjL" = (
@@ -9888,8 +9868,7 @@
 	},
 /area/f13/den)
 "fnc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -10388,7 +10367,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/armored/light/vest/kevlar,
 /obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fzD" = (
 /obj/structure/chair/sofa/corner{
@@ -11346,8 +11325,8 @@
 "gaQ" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
-	pixel_y = 6;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 6
 	},
 /obj/machinery/cell_charger{
 	pixel_y = 1
@@ -11499,7 +11478,6 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "gfu" = (
@@ -11621,8 +11599,8 @@
 "gkm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -11655,8 +11633,8 @@
 "gkY" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
@@ -12005,8 +11983,8 @@
 /area/f13/brotherhood/operations)
 "gwf" = (
 /obj/machinery/vending/hydronutrients{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -12322,12 +12300,12 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/machinery/shower{
-	dir = 1;
-	pixel_y = -2
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
@@ -12604,8 +12582,8 @@
 "gNv" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -14012,7 +13990,7 @@
 "hKN" = (
 /obj/item/clothing/mask/cigarette/bigboss,
 /obj/item/clothing/mask/cigarette/bigboss,
-/obj/machinery/mineral/wasteland_vendor/denchem,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "hKS" = (
@@ -15624,9 +15602,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
@@ -15785,8 +15762,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/iv_drip,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -16993,12 +16971,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -19761,7 +19735,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
@@ -20550,9 +20523,9 @@
 "lGH" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
-	pixel_y = 3;
+	dir = 1;
 	pixel_x = 2;
-	dir = 1
+	pixel_y = 3
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
@@ -22204,10 +22177,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 1;
+	pixel_y = 10
 	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22767,9 +22742,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/table/glass,
 /obj/machinery/light/floor,
 /obj/machinery/chem_dispenser,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
@@ -23890,14 +23865,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/operating)
-"nJB" = (
-/obj/structure/table/optable,
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "nJC" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /obj/effect/decal/cleanable/blood/gibs/human/body,
@@ -24755,8 +24722,8 @@
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -27925,8 +27892,8 @@
 "qjN" = (
 /obj/machinery/hydroponics/soil/pot,
 /obj/machinery/vending/hydroseeds{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -28652,9 +28619,8 @@
 /area/f13/den)
 "qFM" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
@@ -28723,8 +28689,8 @@
 /obj/item/clothing/head/chicken,
 /obj/machinery/light/floor,
 /obj/item/paper/crumpled/bloody/docsdeathnote{
-	name = "DEN: RULES";
-	info = "1. The Boss gets 35% of any earning. 2. Slavery should not be practiced. 3. DO NOT DRAIN CAPTURES OF BLOOD. Make sure they are indebt to the Mob. 4. Do not keep the earnings of the shop on your person, keep it in the shop itself as a stockpile. 5. The Boss has full say over things."
+	info = "1. The Boss gets 35% of any earning. 2. Slavery should not be practiced. 3. DO NOT DRAIN CAPTURES OF BLOOD. Make sure they are indebt to the Mob. 4. Do not keep the earnings of the shop on your person, keep it in the shop itself as a stockpile. 5. The Boss has full say over things.";
+	name = "DEN: RULES"
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -29103,8 +29069,6 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/item/book/granter/trait/explosives_advanced,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "qTm" = (
@@ -33069,8 +33033,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "thm" = (
-/obj/structure/table/glass,
 /obj/machinery/chem_master,
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
@@ -33504,8 +33468,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -35153,12 +35117,10 @@
 /obj/item/key,
 /obj/item/lock_construct,
 /obj/item/lock_construct,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/electropack/shockcollar/explosive,
 /obj/item/assembly/signaler/advanced,
 /obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "usp" = (
@@ -35271,11 +35233,11 @@
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/revolver/colt357/lucky{
 	armour_penetration = 0.1;
-	name = "Brass Gun";
 	desc = "The Brass Gun, a weapon made from a Vet Rangers Sequoia it seems. You feel like a true gunslinger with this.";
 	extra_damage = 38;
-	ricochet_damage_mod = 0.99;
-	flags_ricochet = 1
+	flags_ricochet = 1;
+	name = "Brass Gun";
+	ricochet_damage_mod = 0.99
 	},
 /obj/item/pda,
 /obj/item/paper_bin{
@@ -35612,7 +35574,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35693,8 +35655,8 @@
 "uLP" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	req_access_txt = "87";
-	name = "Den Airlock"
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
@@ -36520,9 +36482,11 @@
 /area/f13/sewer)
 "vlM" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/floor{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36604,9 +36568,8 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/medical,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
@@ -37849,12 +37812,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 7
-	},
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38110,11 +38069,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/machinery/iv_drip,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/closed/mineral/random/low_chance/underground,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -38209,7 +38164,6 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -40094,11 +40048,11 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/structure/table/glass,
 /obj/machinery/chem_heater,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
@@ -71590,10 +71544,10 @@ wFD
 mjG
 bzl
 blx
-bzg
+efa
+gJz
+efa
 cbu
-bzg
-dqh
 bFe
 gJz
 bFe
@@ -71847,8 +71801,8 @@ wFD
 mjG
 bzl
 blx
-bzg
-cbG
+efa
+bFe
 cTL
 wYo
 efa
@@ -72104,8 +72058,8 @@ wWB
 mjG
 agK
 blx
-vlM
-cbG
+dZO
+bFe
 fzj
 dtr
 efa
@@ -72362,8 +72316,8 @@ mjG
 aEg
 blx
 uII
-cbG
-iLY
+bFe
+dTG
 dtr
 fpD
 bFe
@@ -74440,7 +74394,7 @@ gyu
 nFt
 pJN
 uqb
-ddI
+aLf
 blx
 blx
 hRI
@@ -74954,7 +74908,7 @@ efa
 dqh
 bFe
 bFe
-voL
+ddx
 blx
 blx
 hRI
@@ -80090,7 +80044,7 @@ wpa
 wpa
 fQB
 blx
-iPX
+efa
 efa
 efa
 efa
@@ -80601,7 +80555,7 @@ mYc
 hKN
 cPI
 woj
-mOS
+wpa
 ckD
 blx
 fzY
@@ -80864,7 +80818,7 @@ blx
 ylp
 vbx
 efa
-dNa
+eiv
 blx
 tXl
 tXl
@@ -81115,7 +81069,7 @@ ckD
 xsf
 ckD
 ckD
-xsf
+vlM
 ckD
 blx
 efa
@@ -81369,7 +81323,7 @@ ohx
 blx
 bdL
 ckD
-wpF
+cbG
 ckD
 ckD
 qfj
@@ -81627,9 +81581,9 @@ blx
 tYJ
 ckD
 thm
-ckD
+dNa
 wpa
-thm
+wpa
 ckD
 blx
 wpF
@@ -81884,9 +81838,9 @@ blx
 xtg
 ckD
 ndz
-ckD
-ckD
-ndz
+eMH
+mOS
+fLy
 ckD
 blx
 kTJ
@@ -82652,12 +82606,12 @@ gmI
 gmI
 iDK
 kUN
-eMH
-ckD
-ckD
-cdh
-bAz
-ckD
+kUN
+kUN
+kUN
+iLY
+iLY
+fnc
 jEr
 blx
 kTJ
@@ -82909,12 +82863,12 @@ iDK
 iDK
 rGe
 kUN
-ckD
-ckD
-ckD
-ckD
-ckD
-ckD
+wjM
+wjM
+kUN
+iPX
+fnc
+voL
 gFp
 blx
 jkU
@@ -83167,12 +83121,12 @@ iDK
 auj
 kUN
 wjM
-nJB
-eqZ
+wjM
+kUN
 wam
 fnc
 bNV
-eqZ
+jEr
 kUN
 kUN
 kUN
@@ -83423,8 +83377,8 @@ auj
 auj
 iDK
 kUN
-kUN
-kUN
+wjM
+wjM
 kUN
 kUN
 kUN


### PR DESCRIPTION
## Screenshots
![grafik](https://user-images.githubusercontent.com/69112131/170327001-40d7602f-28b9-4860-8dfd-9a17e2b5e513.png)
![grafik](https://user-images.githubusercontent.com/69112131/170327030-ba6113cc-d9e0-47b3-ac87-125da63dd39c.png)
![grafik](https://user-images.githubusercontent.com/69112131/170327046-d77bca65-1042-46d8-91c4-32d434376bf2.png)
![grafik](https://user-images.githubusercontent.com/69112131/170327062-2e85fe38-a69b-4604-bcc4-0ca3f4833a0b.png)


## About The Pull Request
Removes a few issues of the follower base that would block pathing, such as in their botany and their spawn by moving the machines on the right turf.
Also makes the climabable fences in dungeons un-cuttable and nerfs the den's botany by removing their dna manipulator

## Why It's Good For The Game
Easier accessibility in the follower base.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
fix: A few map issues
/:cl:
