### PR TITLE
Removes the 'Climb!' Fences in NML

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -287,6 +287,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/f13/followers)
+"ase" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "nmlmutant"
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/city)
 "ast" = (
 /obj/structure/table/reinforced/brass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
@@ -328,6 +334,7 @@
 /area/f13/bunker)
 "auu" = (
 /obj/item/reagent_containers/food/snacks/salad/ricepudding,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "auD" = (
@@ -383,6 +390,7 @@
 "axt" = (
 /obj/item/reagent_containers/food/snacks/salad/desertsalad,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "axU" = (
@@ -705,6 +713,7 @@
 "aTJ" = (
 /obj/item/reagent_containers/food/snacks/salad/herbsalad,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "aUu" = (
@@ -1671,6 +1680,7 @@
 /area/f13/city)
 "cce" = (
 /obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "ccn" = (
@@ -2522,6 +2532,13 @@
 /obj/machinery/light,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
+"dhS" = (
+/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
+	health = 900;
+	loot = list(/obj/item/keycard/nml1)
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dhV" = (
 /obj/structure/timeddoor/sixtyminute,
 /obj/structure/timeddoor/sixtyminute,
@@ -3641,15 +3658,6 @@
 	icon_state = "verticalinnermain2bottom"
 	},
 /area/f13/wasteland)
-"egS" = (
-/obj/structure/fence{
-	climbable = 1;
-	cuttable = 0;
-	dir = 1;
-	resistance_flags = 64
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
 "eil" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -4611,7 +4619,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/weapons/experimental,
 /obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -4936,6 +4943,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/legion)
+"fQt" = (
+/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
+	health = 900
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/city)
 "fQz" = (
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6340,6 +6353,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"hGk" = (
+/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
+/obj/structure/table/booth,
+/turf/open/floor/wood/f13/old,
+/area/f13/city)
 "hGQ" = (
 /obj/machinery/power/rtg,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -6443,6 +6461,7 @@
 /area/f13/legion)
 "hMY" = (
 /obj/item/reagent_containers/food/snacks/salad/jungle,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "hNJ" = (
@@ -6726,6 +6745,7 @@
 "iko" = (
 /obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/salad/desertsalad,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "ilr" = (
@@ -7366,6 +7386,12 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jfi" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "jfH" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -8699,6 +8725,18 @@
 	icon_state = "dark"
 	},
 /area/f13/ncr)
+"kMp" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/mob/living/simple_animal/hostile/deathclaw/power_armor{
+	faction = list("deathclaw","supermutant")
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "kMS" = (
 /turf/open/floor/plating/f13/inside/mountain{
 	icon_state = "mountain2"
@@ -9140,15 +9178,6 @@
 	},
 /area/f13/wasteland)
 "lnQ" = (
-/obj/effect/turf_decal/climb{
-	dir = 4
-	},
-/obj/structure/fence{
-	climbable = 1;
-	cuttable = 0;
-	dir = 1;
-	resistance_flags = 64
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "lnY" = (
@@ -11226,6 +11255,7 @@
 /area/f13/bunker)
 "nwg" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "nwi" = (
@@ -11828,6 +11858,7 @@
 /area/f13/ncr)
 "oiE" = (
 /obj/item/reagent_containers/food/snacks/salad/ricepork,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "oiL" = (
@@ -12333,6 +12364,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"oKb" = (
+/mob/living/simple_animal/hostile/deathclaw/power_armor{
+	faction = list("deathclaw","supermutant");
+	health = 5000;
+	loot = list(/obj/item/keycard/nml2)
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "oKy" = (
 /mob/living/simple_animal/hostile/handy/nsb,
 /turf/open/floor/plasteel/f13{
@@ -13313,6 +13354,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "pNP" = (
+/obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "pOm" = (
@@ -14734,6 +14776,7 @@
 /area/f13/bunker)
 "roA" = (
 /obj/item/reagent_containers/food/snacks/burger/fish,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "roC" = (
@@ -15201,6 +15244,7 @@
 "rMr" = (
 /obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/salad/oatmeal,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "rMG" = (
@@ -15214,6 +15258,13 @@
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
+"rNu" = (
+/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant{
+	health = 900;
+	loot = list(/obj/item/keycard/nml1)
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/city)
 "rNv" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/desert,
@@ -15802,6 +15853,7 @@
 "svy" = (
 /obj/item/reagent_containers/food/snacks/salad/desertsalad,
 /obj/item/reagent_containers/food/drinks/bottle/brown/green,
+/obj/structure/table/booth,
 /turf/open/floor/wood/f13/old,
 /area/f13/city)
 "svO" = (
@@ -15826,6 +15878,7 @@
 /obj/structure/closet,
 /obj/item/clothing/glasses/hud/health/night,
 /obj/item/clothing/glasses/hud/health/night,
+/obj/effect/spawner/lootdrop/weapons/experimental,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -17184,8 +17237,12 @@
 	pixel_x = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/whiskey,
-/obj/item/clothing/suit/armor/f13/rangercombat/desert/whiskey,
+/obj/item/clothing/suit/armor/f13/rangercombat/desert/whiskey{
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 40, "bomb" = 55, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20, "wound" = 55)
+	},
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/whiskey{
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 40, "bomb" = 55, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20, "wound" = 55)
+	},
 /turf/open/floor/pod/light,
 /area/f13/underground/cave)
 "ujj" = (
@@ -17478,10 +17535,8 @@
 	},
 /area/f13/wasteland)
 "uDi" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Clinic Storage";
-	req_access_txt = "68"
+/obj/machinery/door/keycard{
+	puzzle_id = "nmldeathclaw"
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -27728,8 +27783,8 @@ vKV
 vKV
 vKV
 lnQ
-egS
-egS
+lnQ
+lnQ
 lnQ
 vKV
 vKV
@@ -27986,7 +28041,7 @@ vOG
 vOG
 pNP
 pNP
-pNP
+jfi
 pNP
 vOG
 vOG
@@ -28249,7 +28304,7 @@ fMG
 nFt
 qDz
 qDz
-qDz
+euN
 qDz
 gOB
 vOG
@@ -28509,7 +28564,7 @@ dXd
 pKe
 qDz
 qDz
-wus
+ase
 qDz
 vUl
 qDz
@@ -28765,7 +28820,7 @@ qDz
 ako
 pKe
 qDz
-euN
+qDz
 vOG
 qis
 vUl
@@ -29022,7 +29077,7 @@ qDz
 qDz
 uel
 aJw
-qDz
+ako
 vOG
 qis
 vUl
@@ -29267,7 +29322,7 @@ ksx
 ksx
 ksx
 ksx
-npq
+dhS
 oQq
 ksx
 ksx
@@ -29533,7 +29588,7 @@ ksx
 fMG
 sHw
 qDz
-qDz
+fQt
 uel
 vUl
 qDz
@@ -30822,7 +30877,7 @@ fMG
 blT
 qDz
 cct
-ako
+fQt
 cct
 qDz
 edV
@@ -31336,7 +31391,7 @@ fMG
 nmQ
 nmQ
 nmQ
-qDz
+rNu
 nmQ
 nmQ
 nmQ
@@ -31581,7 +31636,7 @@ wef
 obN
 qDz
 svy
-vUl
+hGk
 lWf
 ksx
 ksx
@@ -32352,7 +32407,7 @@ pFg
 aph
 qDz
 aTJ
-vUl
+hGk
 lWf
 ksx
 ksx
@@ -38532,7 +38587,7 @@ xtU
 xdM
 xdM
 xdM
-xtU
+kMp
 xdM
 kmo
 xdM
@@ -40075,7 +40130,7 @@ kPn
 xdM
 xWq
 kPn
-qhW
+oKb
 fMG
 xdM
 npi
@@ -40579,7 +40634,7 @@ vOG
 vOG
 pNP
 pNP
-pNP
+jfi
 pNP
 vOG
 vOG
@@ -40835,8 +40890,8 @@ vKV
 vKV
 vKV
 lnQ
-egS
-egS
+lnQ
+lnQ
 lnQ
 vKV
 vKV

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2341,8 +2341,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aXu" = (
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#9c9c9c"
+/turf/open/indestructible/ground/inside/dirt{
+	barefootstep = "sand";
+	clawfootstep = "sand";
+	footstep = "sand"
 	},
 /area/f13/village)
 "aXA" = (
@@ -3870,10 +3872,10 @@
 /area/f13/building)
 "bzH" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/bed,
 /obj/item/blanket{
 	pixel_x = 7
 	},
+/obj/structure/bed/old,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood1-broken"
 	},
@@ -5355,6 +5357,7 @@
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowvertical"
 	},
+/obj/structure/fence,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "cfe" = (
@@ -5438,7 +5441,7 @@
 /area/f13/village)
 "chv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/smartfridge/bottlerack/gardentool,
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "chT" = (
@@ -10436,10 +10439,7 @@
 /area/f13/wasteland)
 "ehW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/overlay/junk/sink{
-	dir = 4;
-	pixel_x = 12
-	},
+/obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -14327,7 +14327,7 @@
 /area/f13/wasteland)
 "fGh" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/table,
+/obj/structure/table/wood,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood1-broken"
 	},
@@ -17813,9 +17813,9 @@
 	},
 /area/f13/followers)
 "gRL" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
+/obj/structure/window/fulltile/ruins,
+/obj/structure/fence{
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
@@ -19028,7 +19028,10 @@
 /area/f13/wasteland)
 "hnq" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin/trashbin,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12
+	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -23878,10 +23881,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/ncr)
 "jec" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jeh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
@@ -31741,12 +31744,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"mjd" = (
-/mob/living/simple_animal/hostile/raider/legendary,
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/bunker)
 "mji" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 9;
@@ -39496,7 +39493,9 @@
 /obj/structure/chair/wood/fancy{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/raider/junker/creator,
+/mob/living/simple_animal/hostile/securitron/sentrybot{
+	faction = list("wastebot","raider")
+	},
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
@@ -42607,7 +42606,7 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "qBK" = (
-/mob/living/simple_animal/hostile/securitron/sentrybot,
+/mob/living/simple_animal/hostile/raider/junker/boss,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -53420,13 +53419,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"uVc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/bunker)
 "uVo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop3"
@@ -56600,12 +56592,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
-"wpB" = (
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
-/area/f13/building)
 "wpL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -65374,7 +65360,7 @@ sHp
 xGi
 kmT
 sHp
-wpB
+ezo
 uqa
 rpu
 sHQ
@@ -66144,7 +66130,7 @@ gGJ
 xaZ
 uqa
 yiG
-sHp
+jec
 urA
 uqa
 uqa
@@ -68450,7 +68436,7 @@ dCV
 ktB
 qbD
 qSC
-gfF
+dZy
 vKL
 gfF
 kek
@@ -68964,7 +68950,7 @@ dCV
 ktB
 qbD
 gfF
-mjd
+gfF
 pmn
 dZy
 gfF
@@ -70513,7 +70499,7 @@ mLu
 vhE
 xUW
 oaP
-uVc
+oaP
 qbD
 ktB
 uqa
@@ -82227,7 +82213,7 @@ qTY
 fyf
 fyf
 tBN
-ueA
+gRL
 aXu
 aXu
 aXu
@@ -82484,7 +82470,7 @@ uey
 fyf
 fyf
 tBN
-ueA
+gRL
 aXu
 aXu
 aXu
@@ -82741,7 +82727,7 @@ fyf
 fyf
 fyf
 cbc
-ueA
+gRL
 sXq
 dmZ
 sXq
@@ -82998,7 +82984,7 @@ fyf
 fyf
 fyf
 tBN
-ueA
+gRL
 chv
 dEk
 dHl
@@ -83263,8 +83249,8 @@ bfV
 gjP
 gjP
 gjP
-ijg
-ijg
+gjP
+gjP
 gjP
 xTK
 fyf
@@ -84550,7 +84536,7 @@ cbk
 vix
 uJd
 bzH
-ijg
+gjP
 fyf
 hAC
 hAC
@@ -84807,7 +84793,7 @@ jnX
 sXq
 uJd
 iam
-ijg
+gjP
 fyf
 uey
 hAC
@@ -85318,8 +85304,8 @@ gjP
 fVt
 gjP
 gjP
-ijg
-gRL
+gjP
+gjP
 gjP
 gjP
 fyf
@@ -116234,7 +116220,7 @@ fsm
 ubd
 fyf
 fyf
-jec
+jxH
 fyf
 fyf
 fyf

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -39,6 +39,17 @@
 	color = "#e93737"
 	puzzle_id = "vault"
 
+/obj/item/keycard/nml1
+	name = "titanic keycard"
+	desc = "There is a fat wad of glowing radioactive goo sticking to this card."
+	color = "#1cff42"
+	puzzle_id = "nmlmutant"
+
+/obj/item/keycard/nml2
+	name = "titanic keycard"
+	desc = "Smells like it was stuck in the jaw of that plated Deathclaw. Nasty!"
+	color = "#07a569"
+	puzzle_id = "nmldeathclaw"
 
 //***************
 //*****Doors*****


### PR DESCRIPTION
## About The Pull Request
Suppose my first attempt at stopping cheese has gone awry, so I resorted to the puzzle_id card method in NML as well. There are two seperate puzzle_cards given by one mutant and one deathclaw each to access the loot in Kebab.
I also edited Raider town and replaced the Sentry with the "Junker boss" mob and edited the second armor in the casino to have matching armor stats to the first piece.

## Why It's Good For The Game
You actually have to kill mob(s) now.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Two new puzzle_id cards
/:cl:
