### PR TITLE
Den Shrink PR+Shop Removal

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,12 +302,9 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/f13_blue,
@@ -333,11 +330,10 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
@@ -591,9 +587,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ava" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
+	},
+/turf/open/water,
 /area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1156,9 +1156,14 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/structure/sign/poster/contraband/power,
-/obj/structure/simple_door/wood,
-/turf/open/space/basic,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "aKc" = (
 /obj/structure/cable{
@@ -1225,9 +1230,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
@@ -1349,16 +1354,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
@@ -1549,15 +1546,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/brotherhood/archives)
-"aXd" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1813,8 +1801,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -1847,14 +1841,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/fence{
-	dir = 1
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/water,
 /area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1985,11 +1977,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2117,12 +2107,6 @@
 /area/f13/enclave)
 "blx" = (
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/den)
-"blG" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2317,9 +2301,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2487,6 +2476,14 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"bup" = (
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2508,10 +2505,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/fence/corner{
+	dir = 6
 	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -2522,12 +2526,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
@@ -2621,13 +2623,8 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2711,10 +2708,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/r_wall/rust,
@@ -2907,8 +2910,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -2980,19 +2985,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHA" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bHI" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -3048,9 +3052,6 @@
 	},
 /area/f13/brotherhood/operating)
 "bIT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -3112,10 +3113,10 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3181,19 +3182,20 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bMI" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
+/turf/open/water,
 /area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
@@ -3223,13 +3225,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
-"bNI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -3238,8 +3233,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3304,26 +3299,28 @@
 	},
 /area/f13/tunnel)
 "bPA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "bPB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "bPD" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
@@ -3380,10 +3377,40 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3589,10 +3616,6 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
-"bVO" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3620,17 +3643,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "bXn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3772,9 +3787,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -3827,11 +3842,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3892,11 +3905,10 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "cdu" = (
 /obj/structure/cable{
@@ -4133,9 +4145,14 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4353,6 +4370,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"crx" = (
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/f13/wood{
@@ -4456,6 +4477,9 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"cuS" = (
+/turf/closed/wall/f13/wood/interior,
+/area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -4553,6 +4577,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"cxY" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4607,6 +4643,14 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"czr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4715,16 +4759,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -4849,9 +4885,8 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/falsewall/rust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
@@ -5027,11 +5062,22 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"cIZ" = (
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/item/fishyegg/shrimp,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush,
 /turf/open/water,
 /area/f13/den)
 "cJJ" = (
@@ -5139,10 +5185,8 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
@@ -5193,23 +5237,14 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
-"cQc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
@@ -5255,18 +5290,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = denmedshutters
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5522,6 +5553,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"cYs" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5581,24 +5621,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "daL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/caves)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5685,10 +5713,8 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5713,8 +5739,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
@@ -5753,6 +5779,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"dgO" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5780,13 +5814,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5938,15 +5970,11 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
+/turf/open/water,
 /area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6046,10 +6074,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -6093,14 +6122,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6133,18 +6157,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dpu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_y = -1;
 	pixel_x = -31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6157,20 +6189,13 @@
 /obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dpW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "dqh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
@@ -6244,11 +6269,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6471,10 +6493,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6595,20 +6614,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_y = -1;
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6655,6 +6663,13 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"dEl" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6667,9 +6682,18 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
@@ -6699,11 +6723,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/smartfridge/bottlerack/lootshelf/books,
+/turf/open/floor/f13/wood,
 /area/f13/caves)
+"dFv" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6729,26 +6759,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/area/f13/sewer)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
@@ -6756,11 +6771,11 @@
 	},
 /area/f13/bunker)
 "dHg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "dHh" = (
@@ -6768,8 +6783,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "dHw" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6781,22 +6804,17 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
-"dIm" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
+"dIq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
+/area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -6905,17 +6923,12 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
-	},
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
@@ -6955,13 +6968,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7019,8 +7034,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -7058,13 +7077,18 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7207,8 +7231,9 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/caves)
 "dTA" = (
 /obj/item/flag/bos,
@@ -7219,11 +7244,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"dTG" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -7245,14 +7265,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/water,
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7356,16 +7387,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "dWg" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/table/wood/junk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7535,9 +7562,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7794,15 +7822,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7838,14 +7861,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7855,17 +7873,9 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/structure/fence{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
@@ -7988,13 +7998,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "ekQ" = (
@@ -8059,9 +8065,18 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/fence/corner{
+	dir = 4
 	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "emN" = (
 /turf/open/floor/wood/f13/oakbroken,
@@ -8128,8 +8143,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8216,8 +8232,12 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "esg" = (
 /obj/item/flag/bos,
@@ -8313,8 +8333,21 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8365,6 +8398,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"ewe" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -8381,6 +8424,12 @@
 "exf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/grass,
+/area/f13/den)
+"exg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8430,10 +8479,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
-"exN" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8473,10 +8518,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8525,16 +8568,9 @@
 	},
 /area/f13/building)
 "eBU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "eBZ" = (
@@ -8555,12 +8591,13 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -8683,12 +8720,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8737,7 +8774,8 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/structure/flora/junglebush/large,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
 /turf/open/water,
 /area/f13/den)
 "eGX" = (
@@ -8903,14 +8941,13 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "eKY" = (
@@ -8927,15 +8964,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/carpet/green,
 /area/f13/den)
+"eLq" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/water,
+/area/f13/caves)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -8988,13 +9027,9 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9081,12 +9116,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"eOP" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9258,13 +9287,8 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
@@ -9316,8 +9340,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eVt" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "eVu" = (
@@ -9351,9 +9379,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -9455,21 +9482,15 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/table{
+	pixel_x = 6
 	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
-"faq" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9529,10 +9550,14 @@
 /turf/open/water,
 /area/f13/sewer)
 "fdw" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "fdG" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
@@ -9592,12 +9617,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9656,6 +9680,10 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
+"fhe" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9670,7 +9698,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/den)
 "fiI" = (
@@ -9688,11 +9716,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
-"fju" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fjv" = (
@@ -9718,14 +9741,12 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9788,14 +9809,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/den)
-"flP" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+"flT" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "flW" = (
 /obj/structure/wreck/trash/engine,
 /obj/structure/spider/stickyweb,
@@ -9836,16 +9853,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"fmW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "fnc" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9965,11 +9978,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"fpT" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -9991,16 +9999,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqB" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/junglebush/large,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
 /turf/open/water,
 /area/f13/den)
 "fqF" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10188,12 +10195,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
@@ -10213,23 +10218,25 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fxi" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -10246,13 +10253,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
@@ -10266,13 +10272,9 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "fym" = (
@@ -10305,15 +10307,13 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10341,14 +10341,16 @@
 "fzc" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
+"fzj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "fzD" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10366,16 +10368,8 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10552,6 +10546,12 @@
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"fGK" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -10652,6 +10652,16 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"fJp" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10707,16 +10717,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fLK" = (
 /turf/open/floor/f13{
@@ -10821,6 +10826,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"fOr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/wood/f13/oak,
@@ -10855,30 +10873,25 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fPt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fPu" = (
@@ -10916,10 +10929,10 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "fQL" = (
@@ -10933,9 +10946,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -11073,11 +11085,10 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fUv" = (
@@ -11116,16 +11127,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -11458,6 +11463,16 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
+"geR" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11571,15 +11586,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11607,14 +11615,13 @@
 /area/f13/brotherhood/rnd)
 "gkY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
@@ -11711,15 +11718,8 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/red,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11766,9 +11766,11 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "gqt" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -11938,15 +11940,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = denmedshutters
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -11956,10 +11954,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -11995,13 +11998,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"gxS" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/turf/open/water,
-/area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/enclave)
@@ -12019,11 +12015,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
-"gyu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_large,
@@ -12045,23 +12036,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"gza" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -12136,10 +12110,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/green,
-/area/f13/den)
-"gBM" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12233,10 +12203,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "gEn" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -12277,40 +12247,15 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "gFC" = (
@@ -12410,15 +12355,40 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "gHY" = (
@@ -12448,11 +12418,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gIt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
@@ -12591,8 +12563,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
@@ -12698,19 +12675,22 @@
 	},
 /area/f13/caves)
 "gQW" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "gRa" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
 	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12879,15 +12859,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13491,11 +13466,13 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"hri" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+"hqt" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13671,8 +13648,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13805,11 +13786,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -13931,8 +13911,19 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -14124,13 +14115,13 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14587,6 +14578,14 @@
 "ibY" = (
 /obj/structure/sign/poster/contraband/bountyhunters,
 /turf/closed/wall/f13/wood/interior,
+/area/f13/den)
+"ica" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15047,9 +15046,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "itB" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -15217,6 +15217,17 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ixi" = (
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -15359,9 +15370,12 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15572,6 +15586,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"iLY" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15723,8 +15743,18 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -15883,6 +15913,11 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"iUU" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "iUY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/stage_t,
@@ -15910,11 +15945,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "iVP" = (
@@ -16103,8 +16136,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16129,6 +16163,17 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jbM" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -16731,10 +16776,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jxS" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/pondlily_small,
 /turf/open/water,
 /area/f13/den)
 "jxW" = (
@@ -16848,6 +16894,16 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"jBt" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16909,12 +16965,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16955,10 +17015,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -17010,12 +17070,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/caves)
+/area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17037,16 +17097,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jIs" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17632,8 +17682,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
@@ -17712,12 +17762,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"kcf" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17962,10 +18006,8 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "kjq" = (
 /obj/structure/rack,
@@ -18760,19 +18802,6 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"kIf" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18804,17 +18833,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "kJB" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -18845,6 +18866,17 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"kKb" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -18972,8 +19004,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19069,12 +19110,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19379,12 +19419,6 @@
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
-"kZh" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -19669,11 +19703,10 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/caves)
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19819,11 +19852,19 @@
 	},
 /area/f13/bunker)
 "lmD" = (
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "lmG" = (
@@ -19990,9 +20031,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20138,14 +20184,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"lxs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20430,13 +20468,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20777,9 +20810,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -20880,13 +20913,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20963,16 +20994,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
+/area/f13/caves)
 "lWW" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -21477,8 +21505,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "mnU" = (
 /obj/structure/cable{
@@ -21820,13 +21849,6 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"mCP" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -22075,11 +22097,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "mNt" = (
 /obj/structure/rack,
@@ -22121,9 +22146,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22410,9 +22435,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mYc" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22457,9 +22482,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
@@ -22542,9 +22568,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22643,9 +22669,16 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
+/area/f13/den)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22966,17 +22999,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = denmedshutters
 	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "npf" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -23076,9 +23113,11 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -23334,14 +23373,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23378,13 +23415,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23528,15 +23563,16 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "nEP" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/tree/jungle/small,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "nFc" = (
@@ -23572,6 +23608,15 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
+"nFt" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23620,13 +23665,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nGN" = (
@@ -23670,14 +23710,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
-"nHM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
+"nHM" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23731,9 +23776,15 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24056,6 +24107,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"nUx" = (
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -24237,10 +24299,10 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -24311,12 +24373,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
 /area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24537,10 +24598,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
+	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "ohV" = (
@@ -24818,14 +24881,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25027,11 +25086,9 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
@@ -25179,14 +25236,14 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -25697,11 +25754,13 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/area/f13/sewer)
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
+/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -26102,18 +26161,12 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -26583,10 +26636,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26627,17 +26678,8 @@
 /area/f13/tunnel)
 "pCO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
-	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/turf/open/water,
+/area/f13/sewer)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt{
@@ -26813,7 +26855,7 @@
 /area/f13/building)
 "pJN" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "pJT" = (
@@ -26830,11 +26872,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -27011,11 +27052,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -27148,6 +27195,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"pSU" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable{
@@ -27548,11 +27599,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
 	density = 0
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27653,23 +27705,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
@@ -27752,10 +27796,15 @@
 	},
 /area/f13/bunker)
 "qjN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
@@ -27769,13 +27818,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "qki" = (
@@ -28064,7 +28111,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -28171,24 +28221,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
@@ -28374,11 +28416,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28409,12 +28451,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -28496,9 +28536,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -28517,19 +28559,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
 /area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28569,10 +28605,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -28710,9 +28744,12 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
 /obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "qMP" = (
@@ -29057,13 +29094,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/caves)
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29718,13 +29751,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rsi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30119,13 +30145,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30144,12 +30165,8 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30441,6 +30458,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"rGe" = (
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30498,15 +30518,18 @@
 	},
 /area/f13/brotherhood/operations)
 "rIU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/microwave{
+	pixel_x = -6
 	},
-/area/f13/caves)
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -30665,10 +30688,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
+/obj/structure/pondlily_small,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
 /turf/open/water,
 /area/f13/den)
 "rLN" = (
@@ -30842,10 +30863,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "rQO" = (
@@ -30897,12 +30920,11 @@
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
-"rSU" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+"rSO" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31153,14 +31175,11 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "saS" = (
 /obj/item/mine/shrapnel,
 /turf/open/water,
@@ -31287,11 +31306,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"sfM" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -32133,9 +32147,11 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "sIA" = (
 /obj/structure/rack,
@@ -32256,9 +32272,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -32302,20 +32317,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
@@ -32724,10 +32728,10 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -32740,33 +32744,23 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/water,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -33013,14 +33007,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "tmc" = (
@@ -33160,14 +33151,6 @@
 /obj/structure/bed/pod,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
-"tqC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -33253,15 +33236,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"tst" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -33272,14 +33246,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"tsX" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -33305,15 +33271,6 @@
 "tur" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"tus" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -33489,9 +33446,16 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/books,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33576,17 +33540,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"tCl" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "tCQ" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33731,11 +33693,11 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33970,10 +33932,29 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
 	},
-/turf/open/floor/carpet/green,
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34248,22 +34229,35 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/green,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/machinery/light/small{
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34415,10 +34409,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "ube" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -34515,15 +34511,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -34804,15 +34797,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "uqb" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
@@ -34929,8 +34923,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -35025,39 +35024,23 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
 "uvj" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
@@ -35070,10 +35053,18 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -35112,11 +35103,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "uyC" = (
-/obj/machinery/light,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35465,16 +35457,6 @@
 "uLI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"uLP" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -35725,16 +35707,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -35964,12 +35938,17 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1;
-	pixel_y = 23
+	light_color = "red"
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "vbU" = (
 /obj/structure/bed,
@@ -36159,10 +36138,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
 /area/f13/den)
 "vfU" = (
@@ -36236,12 +36216,11 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/water,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36251,10 +36230,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vjW" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -36276,12 +36256,11 @@
 	},
 /area/f13/brotherhood/mining)
 "vkj" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/water,
 /area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
@@ -36299,20 +36278,20 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "vlT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36393,21 +36372,10 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36479,11 +36447,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36529,8 +36498,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/power,
+/obj/structure/simple_door/wood,
+/turf/open/space/basic,
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -37304,13 +37274,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37337,11 +37304,12 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37356,11 +37324,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37495,9 +37467,7 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
@@ -37554,12 +37524,18 @@
 /turf/open/floor/plasteel,
 /area/f13/bunker)
 "vWZ" = (
-/obj/structure/chair/wood,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "denmedshutters
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "vXF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -37642,6 +37618,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wam" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -37857,13 +37845,9 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -37906,10 +37890,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wjM" = (
-/obj/structure/falsewall/rust,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
 	desc = "Some sort of pod. Seems this one's maintanance panel is open, someone was working on this.";
@@ -37975,6 +37955,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"wms" = (
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37998,7 +37986,10 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -38027,9 +38018,9 @@
 	},
 /area/f13/den)
 "wpc" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38090,6 +38081,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"wrg" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -38156,13 +38156,14 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
 	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/water,
 /area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -38171,7 +38172,13 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wvk" = (
@@ -38349,14 +38356,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
-"wzt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -38708,29 +38707,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "wKN" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/wood/wood_large,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -38781,6 +38763,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"wLY" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "wMb" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -38890,11 +38877,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wQb" = (
 /obj/structure/rack,
@@ -38951,6 +38938,10 @@
 /obj/item/trash/f13/steak,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wRa" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -39185,8 +39176,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -39233,12 +39228,15 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/water,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39797,15 +39795,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "xpf" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
@@ -39874,8 +39867,13 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -39953,9 +39951,8 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40166,11 +40163,16 @@
 	},
 /area/f13/bunker)
 "xzj" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/water,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
@@ -40785,13 +40787,19 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "xTm" = (
@@ -40837,14 +40845,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVD" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "xVK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41051,8 +41060,12 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "ycl" = (
 /obj/structure/closet,
@@ -41329,14 +41342,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ylp" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -41363,11 +41368,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
-"ylL" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -66484,8 +66484,8 @@ wFD
 wFD
 wFD
 wFD
-ndz
-vra
+pCO
+dnc
 wFD
 mjG
 dXE
@@ -66732,19 +66732,19 @@ wFD
 lYx
 wFD
 wFD
-ndz
-oVS
-oVS
-oVS
-oVS
-oVS
-oVS
-oVS
-oVS
-oVS
-vra
-ube
-oVS
+pCO
+ffZ
+ffZ
+ffZ
+ffZ
+ffZ
+ffZ
+ffZ
+ffZ
+ffZ
+dnc
+daE
+ffZ
 dXE
 dXE
 dXE
@@ -66993,13 +66993,13 @@ kUN
 kUN
 kUN
 kUN
-dHg
+czr
 dAO
 dAO
 dAO
 dAO
-oVS
-kTJ
+ffZ
+vQn
 wFD
 mjG
 dXE
@@ -67243,20 +67243,20 @@ hQE
 uPr
 hQE
 gMZ
-ffZ
-eMH
-ffZ
-ffZ
+tXl
+eVt
+tXl
+tXl
 auj
 auj
 auj
-bKb
-dqh
-itn
-pCO
-fQB
+fqF
+exg
+gkm
+gRa
+vjM
 mjG
-vra
+dnc
 wFD
 mjG
 fQL
@@ -67499,21 +67499,21 @@ hQE
 hQE
 uPr
 kUN
-qjN
-nJC
-itn
-itn
-itn
+fVm
+jaG
+gkm
+gkm
+gkm
 auj
-qjN
-itn
-bKb
+fVm
+gkm
+fqF
 gAy
-itn
-fju
+gkm
+aLA
 dzP
-oVS
-ube
+ffZ
+daE
 wFD
 wFD
 wFD
@@ -67756,23 +67756,23 @@ uPr
 uPr
 uPr
 kUN
-gza
-eiz
-eLg
-eLg
-eLg
-kIf
+eup
+dEL
+fJp
+fJp
+fJp
+uvI
 auj
 auj
-rsi
-dLC
-itn
-uqb
+fzj
+kQt
+gkm
+eZw
 dAO
-oVS
-oVS
-oVS
-oVS
+ffZ
+ffZ
+ffZ
+ffZ
 wFD
 wFD
 wFD
@@ -68014,23 +68014,23 @@ hQE
 hQE
 kUN
 aqh
-iPX
+ezs
 bzg
 bzg
 bzg
-fzD
+cYs
 auj
-itn
-itn
-fxX
+gkm
+gkm
+rQv
 auj
-rzy
+dpl
 wYo
 wYo
 ddv
 ddv
 mjG
-ccg
+dGU
 mjG
 mjG
 mjG
@@ -68273,21 +68273,21 @@ kUN
 aqh
 bzg
 bzg
-wvj
+fzY
 bzg
-kJu
+xzj
 auj
 auj
-lsh
-qtc
+dVW
+cuS
 bTE
-qtc
-qtc
-qtc
-qtc
+cuS
+cuS
+cuS
+cuS
 ddv
 ddv
-pPI
+tGq
 ddv
 ddv
 ddv
@@ -68530,18 +68530,18 @@ kUN
 aqh
 bzg
 bzg
-mYc
+pBk
 bzg
-wpc
-gWk
-itn
-auj
-jaG
+mOS
+ndz
 gkm
-uso
-uso
-vsF
-qtc
+auj
+dsx
+nUx
+bxH
+bxH
+pSU
+cuS
 ddv
 ddv
 jqn
@@ -68785,20 +68785,20 @@ hQE
 hQE
 kUN
 aqh
-kjh
+opa
 bzg
 bzg
-eZw
-kJu
+fws
+xzj
 auj
 auj
-itn
-jaG
-fLy
-dnc
-uso
+gkm
+dsx
+fwZ
+wpc
+bxH
 cTL
-qtc
+cuS
 ddv
 ddv
 jqn
@@ -69045,17 +69045,17 @@ aqh
 bzg
 bzg
 bzg
-gqj
-fzD
+eTS
+cYs
 auj
-itn
-itn
-cMf
 gkm
-uso
-sIa
+gkm
+nsf
+nUx
+bxH
+nGD
 cTL
-qtc
+cuS
 ddv
 ddv
 jqn
@@ -69298,21 +69298,21 @@ hQE
 qTe
 qTe
 kUN
-daE
-bdL
-bdL
-bdL
-bdL
-tco
+emK
+wvj
+wvj
+wvj
+wvj
+bve
 auj
-nJC
-itn
 jaG
-fzY
-dnc
-sIa
-ddI
-qtc
+gkm
+dsx
+uqb
+wpc
+nGD
+iLY
+cuS
 ddv
 ddv
 jqn
@@ -69551,7 +69551,7 @@ eah
 eah
 eah
 hOB
-itn
+gkm
 tiS
 auj
 tac
@@ -69562,14 +69562,14 @@ auj
 auj
 auj
 tac
-itn
-auj
-jaG
 gkm
-uso
-sIa
-gyu
-qtc
+auj
+dsx
+nUx
+bxH
+nGD
+eMH
+cuS
 ddv
 ddv
 jqn
@@ -69801,7 +69801,7 @@ fIf
 bQP
 fIf
 lBm
-ohx
+vkj
 fIf
 fIf
 fIf
@@ -69809,31 +69809,31 @@ fIf
 fIf
 auj
 auj
-itn
-itn
+gkm
+gkm
 auj
 uOX
 uOX
 uOX
 uOX
-rQv
-itn
-itn
+fjJ
+gkm
+gkm
 wYo
 wYo
 wYo
-qtc
-qtc
-qtc
+cuS
+cuS
+cuS
 yiv
-qtc
+cuS
 ddv
 ddv
 jqn
 jqn
 jqn
 jqn
-pPI
+tGq
 mjG
 wFD
 wFD
@@ -70065,25 +70065,25 @@ eFv
 eFv
 eFv
 tac
-itn
-itn
+gkm
+gkm
 auj
-nJC
-itn
-auj
-auj
-itn
+jaG
+gkm
 auj
 auj
-nJC
+gkm
+auj
+auj
+jaG
 wYo
-dCp
 dpu
-qtc
-lUs
-gkY
+wam
+cuS
+xsf
+nJC
 cTL
-qtc
+cuS
 ddv
 ddv
 jqn
@@ -70286,61 +70286,61 @@ wFD
 wFD
 mjG
 abB
-eCs
-dPc
-eCs
-eCs
-eFq
-rAd
+bPA
+nFt
+bPA
+bPA
+uhB
+ica
 fEj
-bMH
+jxS
+tda
+fEj
+uhB
+fEj
+uhB
+bdf
+bqI
 nEP
+bPA
+uhB
+bPA
+ica
 fEj
-eFq
+tda
+bPA
+wKN
 fEj
-eFq
-lFt
-vPv
-hOx
-eCs
-eFq
-eCs
-rAd
+fyC
 fEj
-nEP
-eCs
-npc
-fEj
-ehL
-fEj
-eCs
-npc
-bvs
-ocq
+bPA
+wKN
+cJI
+oVS
 fEj
 fEj
-fqB
+dqh
 fEj
 mZU
 gMZ
 auj
 auj
-itn
-itn
-itn
+gkm
+gkm
+gkm
 tac
 auj
 auj
-nJC
-nJC
+jaG
+jaG
 wYo
-fVm
-nGD
-qtc
-tst
-nGD
-gIt
-qtc
+pPI
+cRY
+cuS
+gNv
+cRY
+gvC
+cuS
 ddv
 ddv
 jqn
@@ -70543,61 +70543,61 @@ wFD
 wWB
 mjG
 abB
-tCQ
-mOS
-dpl
-tCQ
+fis
+eGQ
+rLJ
+fis
 hRI
-cJI
-tCQ
+gow
+fis
 hRI
-tCQ
-qIj
+fis
+gWk
+crx
+hRI
+hRI
 fis
 hRI
 hRI
-tCQ
-hRI
-hRI
-fdw
+mnK
+crx
 fis
-tCQ
-esc
-tCQ
-esc
-gwf
+wRa
+fis
+wRa
+liN
 hRI
-tCQ
-gDU
-esc
+fis
+dIq
+wRa
 uVE
-fis
-esc
-esc
-cCO
+crx
+wRa
+wRa
+epg
 hRI
-pJN
+fqB
 hRI
-vWZ
+esc
 fjU
 bMt
 auj
 auj
 auj
 auj
-itn
+gkm
 auj
-itn
-itn
-lsh
+gkm
+gkm
+dVW
 wYo
-bPD
+saE
 cTL
-gBM
-mnK
-ddI
-ddI
-qtc
+cQp
+cMf
+iLY
+iLY
+cuS
 ddv
 ddv
 jqn
@@ -70829,32 +70829,32 @@ kUN
 kUN
 kUN
 hRI
-eGQ
-esc
-dok
+eWL
+wRa
+ava
 uVE
 gZB
 hRI
-vbx
+nHE
 uOX
 auj
 auj
 iDK
-hxB
-cdh
-hxB
-cdh
+qXj
+ube
+qXj
+ube
 auj
-itn
-nJC
-oBq
-qEH
-bIT
-aJI
+gkm
+jaG
+fxi
+tzz
+cAU
+vsF
 cTL
 kQO
-jEr
-tXl
+dFv
+bvs
 ddv
 ddv
 ddv
@@ -70873,7 +70873,7 @@ mjG
 mjG
 mjG
 mjG
-fjJ
+oBq
 xse
 mjG
 mjG
@@ -71058,38 +71058,38 @@ wFD
 mjG
 aou
 kUN
-eay
-fRv
-fRv
-nyG
-fRv
-fRv
-fRv
-kUN
-iVF
-fRv
-fRv
-kZh
+hqt
 bIT
-fRv
-kZh
-fRv
-fRv
-iVF
+bIT
+jBt
+bIT
+bIT
+bIT
 kUN
-fRv
-fRv
-nyG
-fRv
-fRv
-tqC
-eay
+qjU
+bIT
+bIT
+fPo
+cAU
+bIT
+fPo
+bIT
+bIT
+qjU
+kUN
+bIT
+bIT
+jBt
+bIT
+bIT
+yck
+hqt
 kUN
 hRI
-gxS
+bMI
 hRI
-vjW
-esc
+pJN
+wRa
 xwm
 hRI
 fEW
@@ -71100,18 +71100,18 @@ auj
 blx
 diR
 diR
-bxH
-bxH
-tMr
-tMr
+bMH
+bMH
+eLg
+eLg
 kUN
-qtc
+cuS
 bTE
-qtc
+cuS
 yiv
-qtc
-bdf
-bdf
+cuS
+daL
+daL
 ddv
 ddv
 ddv
@@ -71315,41 +71315,41 @@ wFD
 mjG
 bzl
 kUN
-eay
-fRv
-fRv
-kUN
-fRv
-fRv
-fRv
-kUN
-qDc
-fRv
-fRv
-kUN
-fRv
+hqt
+bIT
 bIT
 kUN
-fRv
-fRv
-qDc
+bIT
+bIT
+bIT
 kUN
-fRv
-fRv
-hJy
+akT
+bIT
+bIT
+kUN
+bIT
+cAU
+kUN
+bIT
+bIT
+akT
+kUN
+bIT
+bIT
+kjh
 wYo
-fRv
-fRv
-eay
+bIT
+bIT
+hqt
 kUN
-esc
+wRa
 hRI
-esc
-rLJ
+wRa
+lUs
 rjD
-eGQ
+eWL
 hRI
-vWZ
+esc
 fjU
 bMt
 auj
@@ -71357,8 +71357,8 @@ iDK
 blx
 gKU
 aVZ
-fmW
-fmW
+dyB
+dyB
 gCa
 fjS
 wYo
@@ -71367,7 +71367,7 @@ ekQ
 dLn
 efa
 bFe
-bdf
+daL
 eLE
 eLE
 eLE
@@ -71572,38 +71572,38 @@ wFD
 mjG
 bzl
 kUN
-sOm
+xTi
 nCx
 cTL
 kUN
-fRv
-fRv
-fRv
-kUN
-fRv
-fRv
-fRv
-kUN
-fRv
 bIT
-dOg
-fRv
-fRv
-fRv
+bIT
+bIT
 kUN
-fRv
-fRv
+bIT
+bIT
+bIT
+kUN
+bIT
+cAU
+lFt
+bIT
+bIT
+bIT
+kUN
+bIT
+bIT
 kUN
 wYo
-fRv
-fRv
-eay
+bIT
+bIT
+hqt
 kUN
 hRI
-esc
-esc
-xzj
-jxS
+wRa
+wRa
+dli
+tco
 rjD
 hRI
 mZU
@@ -71618,13 +71618,13 @@ gCa
 bmJ
 gCa
 gCa
-wjM
+cCO
 xXZ
 tBY
 xbj
 gJz
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -71833,45 +71833,45 @@ dZO
 cTL
 cTL
 kUN
-fRv
-fRv
-fRv
-epg
-cAU
-cAU
-cAU
-eup
 bIT
 bIT
+bIT
+uUB
+fPt
+fPt
+fPt
+ccg
+cAU
+cAU
 cKb
-cAU
-cAU
-cAU
+fPt
+fPt
+fPt
 kUN
+bIT
+bIT
 fRv
-fRv
-xsf
 wYo
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
 kUN
 rjD
 uVE
 hRI
-esc
-wZU
-cCO
+wRa
+dLC
+epg
 hRI
-tCl
+bup
 iDK
 auj
 iDK
 auj
 kDG
-dli
+kKb
 okb
-dyB
+cIZ
 gCa
 gCa
 gCa
@@ -71881,7 +71881,7 @@ jyQ
 flC
 efa
 aLf
-nHE
+flT
 eLE
 yhT
 yhT
@@ -72085,39 +72085,39 @@ bbB
 bbB
 mjG
 aEg
-vkI
+dgg
 uII
 uII
 uII
 dtr
-bIT
-bIT
+cAU
+cAU
 nye
 lAv
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
+aqW
+cAU
+bIT
 aqW
 bIT
-fRv
+bIT
+bIT
 aqW
-fRv
-fRv
-fRv
-aqW
-fRv
-fRv
+bIT
+bIT
 kUN
 wYo
-dWg
-vlM
-nHM
+fxX
+vPv
+bKb
 kUN
 hRI
-eGQ
-esc
-esc
-esc
+eWL
+wRa
+wRa
+wRa
 oYU
 hRI
 qFJ
@@ -72125,7 +72125,7 @@ gmI
 iDK
 uDa
 iDK
-bPB
+nyG
 cjg
 auj
 cbQ
@@ -72138,7 +72138,7 @@ hlg
 bTE
 efa
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -72342,39 +72342,39 @@ bbB
 bbB
 mjG
 mjG
-wif
-fRv
-fRv
-fRv
+uso
+bIT
+bIT
+bIT
 aqW
+cAU
 bIT
-fRv
-fRv
 bIT
-fRv
-fRv
-fRv
-fRv
+cAU
+bIT
+bIT
+bIT
+bIT
 hlO
-dTG
-dTG
-dTG
-dTG
-dTG
-dTG
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
 hlO
-fRv
+bIT
 kUN
 wYo
 nCx
-flP
+eFq
 ooI
 kUN
-eGQ
+eWL
 rjD
 hRI
 uVE
-esc
+wRa
 uVE
 hRI
 bLc
@@ -72382,20 +72382,20 @@ iDK
 uDa
 tUT
 gmI
-rSU
+sIa
 wIN
 dTK
 bMt
 pxK
 gCa
-wYl
+vVu
 wYo
 wLR
 kLD
 txw
 efa
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -72599,31 +72599,31 @@ wFD
 wWB
 mjG
 bzl
-dTG
-dTG
-dTG
-dTG
-lWO
-dTG
-dTG
-dTG
-wzt
-wzt
-wzt
-dTG
-dTG
-dTG
+bhO
+bhO
+bhO
+bhO
+jbM
+bhO
+bhO
+bhO
+dHg
+dHg
+dHg
+bhO
+bhO
+bhO
 fXU
 exf
 eiS
 fXU
 exf
 fXU
-dTG
-fRv
+bhO
+bIT
 aqQ
 wYo
-bhO
+nHM
 cTL
 lVK
 kUN
@@ -72639,8 +72639,8 @@ auj
 gJA
 vBZ
 fjA
-rSU
-pjR
+sIa
+dPc
 dyu
 bMt
 bIC
@@ -72652,7 +72652,7 @@ ekQ
 dke
 efa
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -72856,39 +72856,39 @@ wFD
 wWB
 mjG
 bzl
-fRv
+bIT
 egc
-fRv
-fRv
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
+bIT
+bIT
 egc
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
 egc
-fRv
-wzt
+bIT
+dHg
 fXU
 iFg
 okH
 maO
 rvK
 fXU
-dTG
-fRv
-fRv
+bhO
+bIT
+bIT
 kUN
 vct
 vct
 vct
 kUN
-vjM
-vjM
-vjM
-vjM
-vjM
+bdL
+bdL
+bdL
+bdL
+bdL
 fsN
 gNZ
 auj
@@ -72896,20 +72896,20 @@ fUQ
 lCp
 tUT
 iDK
-rSU
+sIa
 cjg
-qia
+uvj
 dxH
 bIC
 gCa
-wYl
+vVu
 wYo
 xXZ
 wQp
 xbj
 efa
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -73118,29 +73118,29 @@ kUN
 kUN
 kUN
 kUN
-eup
+ccg
 kUN
 kUN
 kUN
 kUN
 kUN
 fpD
-fRv
-dTG
+bIT
+bhO
 aPF
 kbT
 uVE
 eyK
 ghs
-lQm
-dTG
-dTG
-dTG
+fhe
+bhO
+bhO
+bhO
 fUv
-fRv
-fRv
-fRv
-nzO
+bIT
+bIT
+bIT
+qEH
 xdj
 xdj
 xdj
@@ -73153,7 +73153,7 @@ jLx
 cAC
 gVL
 tKj
-rSU
+sIa
 wIN
 iDK
 hOB
@@ -73166,7 +73166,7 @@ bIh
 pHQ
 efa
 crb
-bdf
+daL
 eLE
 yhT
 yhT
@@ -73382,22 +73382,22 @@ kUN
 kUN
 kUN
 kUN
-fRv
+bIT
 cBZ
 fXU
 bUh
-dUk
-fpT
+wuU
+bXn
 bhu
 fXU
-dTG
-dTG
-dTG
+bhO
+bhO
+bhO
 fUv
-fRv
-fRv
-fRv
-vlM
+bIT
+bIT
+bIT
+vPv
 xdj
 xdj
 xdj
@@ -73418,12 +73418,12 @@ bmJ
 gCa
 gCa
 dAO
-qtc
-qtc
-qtc
+cuS
+cuS
+cuS
 efa
 efa
-bdf
+daL
 eLE
 yhT
 yhT
@@ -73629,8 +73629,8 @@ mjG
 vgV
 kUN
 kUN
-dGU
-nbd
+dUk
+sOm
 gCa
 gCa
 kUN
@@ -73638,23 +73638,23 @@ gCa
 gCa
 gCa
 gCa
-nyG
-fRv
-wzt
+jBt
+bIT
+dHg
 fXU
-dhF
+wrg
 uVE
 eyK
-bPA
+pjR
 fXU
-dTG
-dTG
-dTG
+bhO
+bhO
+bhO
 fUv
-fRv
-tGq
-fRv
-fRv
+bIT
+qtc
+bIT
+bIT
 xdj
 xdj
 xdj
@@ -73666,7 +73666,7 @@ iDK
 fjh
 iDK
 auj
-rSU
+sIa
 wgS
 aVZ
 gCa
@@ -73678,9 +73678,9 @@ wYo
 ibY
 gVp
 fVQ
-qtc
+cuS
 cbu
-bdf
+daL
 eLE
 yhT
 yhT
@@ -73886,27 +73886,27 @@ mjG
 vgV
 kUN
 kUN
-mZs
+hFt
 cUt
 dyH
 dLs
 kUN
-xtg
+wLY
 cXP
-eWL
+bPD
 gCa
-qFM
-fRv
-wzt
-nEK
-qGl
-vkj
-uLP
-uUB
+rAd
+bIT
+dHg
+rzy
+hJy
+wYl
+mNi
+qxm
 fXU
-dTG
-fRv
-fRv
+bhO
+bIT
+bIT
 kUN
 kUN
 kUN
@@ -73923,20 +73923,20 @@ iDK
 iDK
 iDK
 auj
-rSU
+sIa
 wgS
 aVZ
 gCa
-ava
-hri
-vVu
+nZC
+npf
+xpf
 gCa
 bmJ
 exn
 bFe
 uuD
 efa
-fws
+qfj
 hQE
 eLE
 yhT
@@ -74143,33 +74143,33 @@ aLB
 vgV
 kUN
 kUN
-ylp
+bHA
 cWc
 dyH
 gCa
 kUN
-xtg
+wLY
 cXP
-eWL
+bPD
 gCa
 kUN
-fRv
+bIT
 cBZ
 fXU
 exf
-nEK
+rzy
 fXU
 exf
 aPF
-dTG
-fRv
+bhO
+bIT
 fpD
 kUN
 kUN
 kUN
 kUN
 kUN
-bNI
+owJ
 fEj
 fEj
 fEj
@@ -74180,12 +74180,12 @@ fjh
 gmI
 iDK
 auj
-rSU
+sIa
 gBD
 aVZ
 gCa
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -74193,7 +74193,7 @@ gAy
 efa
 efa
 efa
-fPo
+rIU
 hQE
 eLE
 yhT
@@ -74400,26 +74400,26 @@ mjG
 vgV
 kUN
 kUN
-tXd
+dOg
 gCa
 gCa
-dgg
+ddI
 kUN
-bVO
-akT
-kQt
+qIj
+nzO
+kaQ
 gCa
 kUN
-fRv
+bIT
 bwq
-wzt
-dTG
-dTG
-dTG
-dTG
-dTG
+dHg
+bhO
+bhO
+bhO
+bhO
+bhO
 hlO
-fRv
+bIT
 kUN
 kUN
 kUN
@@ -74437,7 +74437,7 @@ fjh
 hOB
 iDK
 auj
-rSU
+sIa
 wgS
 aVZ
 gCa
@@ -74446,11 +74446,11 @@ gCa
 gMt
 gCa
 bmJ
-uhB
+dNa
 efa
 ucR
 efa
-fyC
+ixi
 hQE
 eLE
 yhT
@@ -74662,34 +74662,34 @@ kUN
 ohV
 kUN
 kUN
-xtg
+wLY
 cXP
-eWL
+bPD
 gCa
 kUN
-fRv
-fRv
-fRv
 bIT
+bIT
+bIT
+cAU
 nye
-fRv
-fRv
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
+bIT
+bIT
 kUN
 kUN
 ddx
-xTi
-gHU
+aJI
+cxY
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-gow
-dVW
+bAz
+wPZ
 fjh
 iDK
 tZP
@@ -74919,26 +74919,26 @@ gCa
 gCa
 eiA
 gCa
-xtg
+wLY
 cXP
-eWL
+bPD
 gCa
 cKb
+fxX
+bIT
 dWg
-fRv
-ezs
-fRv
-fRv
-fRv
-aXd
-fRv
-fRv
-vfF
-dOg
+bIT
+bIT
+bIT
+eay
+bIT
+bIT
+vra
+lFt
 kUN
-bMI
-fUu
-aLA
+fQB
+hxB
+dCp
 kUN
 kUN
 hRI
@@ -74955,12 +74955,12 @@ iDK
 eiA
 gCa
 gCa
-ava
-hri
-vVu
+nZC
+npf
+xpf
 gCa
 ibo
-owJ
+hOx
 xac
 psU
 efa
@@ -75181,28 +75181,28 @@ gCa
 gCa
 gCa
 kUN
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
 bIT
-fRv
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
+cAU
+bIT
 kUN
 kUN
-fPt
-lmD
-lxs
+iPX
+tlZ
+vfF
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-bNV
+fzD
 iDK
 iDK
 iDK
@@ -75211,9 +75211,9 @@ auj
 gmI
 eiA
 fjS
-fmW
+dyB
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -75436,23 +75436,23 @@ gCa
 gCa
 gCa
 gCa
-qfj
+fLy
 kUN
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
 nye
-fRv
+bIT
 kUN
 kUN
-voL
-faq
-faq
+lmD
+qia
+qia
 kUN
 kUN
 hRI
@@ -75695,28 +75695,28 @@ gCa
 gCa
 fOg
 kUN
-dWg
-fRv
-ezs
-fRv
-fRv
-fRv
-ezs
-fRv
+fxX
 bIT
-vfF
+dWg
+bIT
+bIT
+bIT
+dWg
+bIT
+cAU
+vra
 kUN
 kUN
-eKX
-pBk
-jFq
+bPB
+mZs
+gIt
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-eVt
+wif
 gmI
 pVU
 tac
@@ -75952,21 +75952,21 @@ gCa
 gCa
 eJq
 kUN
-fRv
-fRv
-xpf
-fRv
-fRv
-fRv
-fRv
-fRv
-fRv
+bIT
+bIT
+wZU
+bIT
+bIT
+bIT
+bIT
+bIT
+bIT
 kUN
 kUN
 kUN
 thm
-aLA
-qMr
+dCp
+fyh
 kUN
 kUN
 hRI
@@ -76199,31 +76199,31 @@ mjG
 vgV
 kUN
 kUN
-fqF
-fqF
-fqF
+aQw
+aQw
+aQw
 kUN
 kUN
 kUN
-nyG
+jBt
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-bve
-bve
+cdh
+cdh
 nfB
 kUN
 kUN
 kUN
 kUN
-xVD
-aLA
-aLA
-aLA
-fwZ
+qGl
+dCp
+dCp
+dCp
+ohx
 kUN
 kUN
 hRI
@@ -76461,26 +76461,26 @@ qTe
 qTe
 kUN
 dcd
-emK
-emK
-emK
-woj
-gRa
+nbd
+nbd
+nbd
+iVF
+eCs
 aEe
-wPZ
+ocq
 kUN
-npf
+eiz
 anK
 anK
-uII
+vWZ
 anK
 sTs
 kUN
-ekK
-aLA
-aLA
-aLA
-tsX
+ewe
+dCp
+dCp
+dCp
+dgO
 kUN
 kUN
 hRI
@@ -76717,27 +76717,27 @@ kUN
 kUN
 kUN
 kUN
-pKf
-emK
+fnc
+nbd
 lwv
-emK
+nbd
 aEe
 aEe
 aEe
-tda
+gFp
 kUN
-dNa
-anK
-anK
-uII
-anK
 bHI
+anK
+anK
+vWZ
+anK
+fUu
 kUN
-eTS
-aLA
-aLA
-aLA
-opa
+jFq
+dCp
+dCp
+dCp
+tCQ
 kUN
 kUN
 hRI
@@ -76974,27 +76974,27 @@ dDz
 gyB
 sVT
 kUN
-wuU
-emK
-emK
-fxi
-mCP
+woj
+nbd
+nbd
+eKX
+iDd
 aEe
 aEe
-aQw
+jEr
 kUN
-gQW
+eBU
 anK
 anK
-cRY
+vWZ
 anK
 anK
-ehc
-aLA
-aLA
-aLA
-aLA
-gFp
+geR
+dCp
+dCp
+dCp
+dCp
+gHU
 kUN
 kUN
 hRI
@@ -77228,35 +77228,35 @@ vgV
 kUN
 ciU
 acI
-cQp
+wms
 acI
 kUN
-eOP
-emK
-emK
-fxi
-tus
+ekK
+nbd
+nbd
+eKX
+ckD
 lwv
 aEe
-dpW
+qMr
 kUN
-vQn
+kTJ
 anK
 anK
-fyh
+vQw
 anK
 sTs
 kUN
 kUN
 kUN
 kUN
-nyG
+jBt
 kUN
 kUN
 kUN
 cSY
-uvI
-ylL
+pKf
+ehc
 xdj
 dXE
 dXE
@@ -77488,27 +77488,27 @@ lLo
 fQz
 cSN
 ltu
-emK
+nbd
 dQG
 lwv
-tlZ
+qjN
 cqu
-emK
+nbd
 aEe
-ajO
+jHj
 kUN
-uII
-uII
-uII
+vWZ
+vWZ
+vWZ
 kUN
 anK
-gvC
+npc
 kUN
-yck
+xtg
 rqX
 rqX
 rqX
-kaQ
+nEK
 kUN
 kUN
 cSY
@@ -77743,27 +77743,27 @@ kUN
 gyB
 gyB
 gyB
-bHA
+dHw
 kUN
-bXn
+vbx
 aEe
-emK
+nbd
 aEe
-emK
-emK
+nbd
+nbd
 aEe
-qjU
+gkY
 kUN
 eHr
 anK
 anK
 anK
 anK
-bHI
+fUu
 kUN
-dsx
+dhF
 rqX
-dsx
+dhF
 rqX
 rqX
 kUN
@@ -78007,10 +78007,10 @@ cqu
 cqu
 cqu
 aEe
-emK
+nbd
 lwv
 aEe
-eBU
+fOr
 anK
 anK
 anK
@@ -78028,7 +78028,7 @@ kUN
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -78256,7 +78256,7 @@ vgV
 kUN
 acI
 acI
-mNi
+dEl
 acI
 kUN
 kUN
@@ -78273,11 +78273,11 @@ anK
 anK
 anK
 anK
-uyC
+rSO
 kUN
-jIs
+lsh
 rqX
-dsx
+dhF
 rqX
 cLd
 kUN
@@ -78285,7 +78285,7 @@ kUN
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -78512,8 +78512,8 @@ mjG
 vgV
 kUN
 acI
-wKN
-tbE
+tMr
+gQW
 lyd
 kUN
 kUN
@@ -78534,9 +78534,9 @@ anK
 ltu
 rqX
 rqX
-qxm
-uvj
-gNv
+tXd
+bRm
+bNV
 kUN
 kUN
 cSY
@@ -79056,7 +79056,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -79285,10 +79285,10 @@ hQE
 hQE
 aoj
 aoj
-sMl
+itn
 aoj
 aoj
-kcf
+bEV
 vcx
 aoj
 aoj
@@ -79313,7 +79313,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -79543,7 +79543,7 @@ hQE
 aoj
 aoj
 aoj
-nsf
+ajO
 emV
 aoj
 aoj
@@ -79570,7 +79570,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -80055,10 +80055,10 @@ fQL
 hQE
 hQE
 dXE
-bAz
-bqI
-cQc
-exN
+cbG
+dok
+iUU
+ehL
 dXE
 aoj
 vcx
@@ -80312,17 +80312,17 @@ fQL
 hQE
 hQE
 dXE
-daL
-dHw
-dHw
-dHw
+qFM
+rGe
+rGe
+rGe
 dXE
 aoj
 aoj
 aoj
 aoj
 aoj
-ckD
+mYc
 hKN
 cPI
 hQE
@@ -80569,9 +80569,9 @@ fQL
 hQE
 hQE
 dXE
-iDd
-dHw
-dHw
+sMl
+rGe
+rGe
 rSB
 dXE
 aoj
@@ -80581,7 +80581,7 @@ aoj
 aoj
 uPr
 cPI
-cbG
+gDU
 hQE
 dXE
 dXE
@@ -80828,7 +80828,7 @@ hQE
 dXE
 dXE
 dXE
-bEV
+vkI
 dXE
 dXE
 hQE
@@ -80846,7 +80846,7 @@ hQE
 hQE
 hQE
 hQE
-fnc
+eLq
 hQE
 hQE
 hQE
@@ -81082,10 +81082,10 @@ mjG
 fQL
 hQE
 hQE
-jHj
-dIm
+uyC
+xVD
 sVP
-bRm
+dTr
 buN
 aoj
 aoj
@@ -81095,7 +81095,7 @@ aoj
 aoj
 aoj
 buN
-ckD
+mYc
 aoj
 aoj
 aoj
@@ -81110,9 +81110,9 @@ dii
 dii
 dii
 dii
-nZC
+voL
 dii
-nZC
+voL
 wFD
 mNE
 wFD
@@ -81339,15 +81339,15 @@ mjG
 fQL
 hQE
 hQE
-jHj
+uyC
 uuq
-bRm
-bRm
+dTr
+dTr
 hQE
 hQE
 hQE
 hQE
-fnc
+eLq
 hQE
 aoj
 dXE
@@ -81367,9 +81367,9 @@ dii
 dii
 dii
 dii
-nZC
+voL
 dii
-nZC
+voL
 wFD
 mNE
 wFD
@@ -81596,15 +81596,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-vQw
-bRm
+dTr
+dTr
+qDc
+dTr
 hQE
 hzR
-dHw
+rGe
 flj
-dHw
+rGe
 hQE
 aoj
 dXE
@@ -81617,7 +81617,7 @@ hQE
 hQE
 hQE
 hQE
-fnc
+eLq
 hQE
 buN
 hQE
@@ -81853,15 +81853,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
-bRm
+dTr
+dTr
+dTr
+dTr
 hQE
-dHw
+rGe
 flj
-dHw
-sfM
+rGe
+tbE
 hQE
 aoj
 dXE
@@ -81875,7 +81875,7 @@ aoj
 aoj
 aoj
 aoj
-fnc
+eLq
 aoj
 hQE
 cSY
@@ -81883,7 +81883,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -82110,16 +82110,16 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 uCP
-bRm
-bRm
-hQE
-flj
-dHw
-dHw
+dTr
 dTr
 hQE
+flj
+rGe
+rGe
+kJu
+hQE
 aoj
 dXE
 dXE
@@ -82140,7 +82140,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 uPr
@@ -82367,22 +82367,22 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
-bRm
+dTr
+dTr
+dTr
+dTr
 hQE
 cLS
-dHw
-dHw
-dHw
+rGe
+rGe
+rGe
 hQE
 aoj
 aoj
 aoj
 aoj
 aoj
-fnc
+eLq
 aoj
 dXE
 dXE
@@ -82397,7 +82397,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -82624,15 +82624,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 jPC
-hFt
+vjW
 jPC
 hQE
 hQE
 hQE
 hQE
-fnc
+eLq
 hQE
 hQE
 hQE
@@ -82881,10 +82881,10 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 jPC
 jzO
-tzz
+dFt
 hQE
 dXE
 dXE
@@ -83138,7 +83138,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 jPC
 lzb
 uqE
@@ -83395,7 +83395,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 jPC
 wDa
 gSS
@@ -83403,7 +83403,7 @@ hQE
 aoj
 hQE
 hQE
-fnc
+eLq
 hQE
 hQE
 hQE
@@ -83652,7 +83652,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 lQz
 uqE
 ncJ
@@ -83909,7 +83909,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 rCl
 fxD
 gSS
@@ -84166,7 +84166,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 ngX
 dXE
 dXE
@@ -84423,7 +84423,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+dTr
 lNw
 jPC
 jPC
@@ -84453,7 +84453,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 juh
@@ -84680,10 +84680,10 @@ mjG
 fQL
 hQE
 hQE
-bRm
-dFt
-bRm
-rIU
+dTr
+vlM
+dTr
+gwf
 hQE
 aoj
 hQE
@@ -84710,7 +84710,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 cSY
@@ -84937,9 +84937,9 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
+dTr
+dTr
+dTr
 nBV
 hQE
 aoj
@@ -84967,7 +84967,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 pcO
@@ -85191,15 +85191,15 @@ mjG
 wFD
 wFD
 dtk
-qXj
+lWO
 nEz
 uCP
 bSl
-bRm
-bRm
-bRm
-fnc
-ckD
+dTr
+dTr
+dTr
+eLq
+mYc
 hQE
 dXE
 aoj
@@ -85456,7 +85456,7 @@ nEz
 hQE
 hQE
 hQE
-ckD
+mYc
 hQE
 dXE
 aoj
@@ -85708,8 +85708,8 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
+dTr
+dTr
 hQE
 dXE
 dXE
@@ -85966,7 +85966,7 @@ fQL
 hQE
 hQE
 gQR
-bRm
+dTr
 hQE
 dXE
 dXE
@@ -85995,7 +85995,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -86222,8 +86222,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+dTr
+dTr
 hQE
 dXE
 dXE
@@ -86479,8 +86479,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+dTr
+dTr
 hQE
 dXE
 dXE
@@ -86736,8 +86736,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+dTr
+dTr
 hQE
 dXE
 dXE
@@ -86993,7 +86993,7 @@ mjG
 fQL
 hQE
 hQE
-fnc
+eLq
 hQE
 hQE
 dXE
@@ -87023,7 +87023,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -87280,7 +87280,7 @@ dXE
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 uPr
@@ -88279,7 +88279,7 @@ fQL
 hQE
 hQE
 hQE
-fnc
+eLq
 hQE
 hQE
 hQE
@@ -88307,8 +88307,8 @@ dXE
 dXE
 dXE
 dXE
-dEL
-liN
+lQm
+gqj
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -410,7 +410,7 @@
 /area/f13/tunnel)
 "anK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "anM" = (
@@ -483,7 +483,7 @@
 "aqh" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
+	name = "Den Auxillary Storage";
 	req_access_txt = "87"
 	},
 /turf/open/space/basic,
@@ -499,10 +499,21 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"aqQ" = (
+/obj/effect/landmark/poster_spawner/pinup,
+/turf/closed/wall/rust,
+/area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"aqW" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice/d20,
@@ -570,11 +581,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"ava" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/lattice/catwalk,
@@ -948,14 +954,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"aEe" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1135,6 +1133,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"aJI" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1199,6 +1201,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"aLA" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1297,7 +1307,7 @@
 /obj/item/ammo_box/magazine/tommygunm45/stick,
 /obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "aPG" = (
@@ -1926,12 +1936,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "bhW" = (
@@ -2426,6 +2435,21 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"bup" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2476,8 +2500,12 @@
 	},
 /area/f13/tunnel)
 "bwq" = (
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "bwt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2547,6 +2575,14 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
+"bxH" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2629,15 +2665,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "bAC" = (
@@ -2832,8 +2863,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/item/reagent_containers/pill/patch/turbo,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -2954,6 +2988,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operating)
+"bIT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3010,17 +3052,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bKb" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -3084,6 +3115,20 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"bMH" = (
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/den)
+"bMI" = (
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3118,12 +3163,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/f13/den)
-"bNV" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3187,23 +3226,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"bPB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
-"bPD" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+"bPA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
@@ -3259,14 +3285,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bRm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor{
-	density = 0;
-	pixel_x = 30
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3304,14 +3322,6 @@
 "bRV" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
-"bSl" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "bSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -3504,11 +3514,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"bXn" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3640,14 +3645,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"cbG" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3698,10 +3695,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"ccg" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3761,19 +3754,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"cdh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/den)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3943,6 +3923,17 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"cjg" = (
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/deck,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "cjA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -3995,6 +3986,12 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
+"ckD" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/den)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4177,12 +4174,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/caves)
-"cqu" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "cqC" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -4577,19 +4568,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "cAV" = (
@@ -4647,6 +4631,17 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"cBZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "cCj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4880,6 +4875,15 @@
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cKb" = (
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "cKA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -4961,6 +4965,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/enclave)
+"cLS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "cLU" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall/r_wall,
@@ -4972,13 +4982,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
+/obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "cMJ" = (
@@ -5028,19 +5034,24 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
+"cQc" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"cQp" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -5085,8 +5096,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5107,10 +5122,7 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "cSN" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
-	},
+/obj/structure/stairs/west,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "cSV" = (
@@ -5390,9 +5402,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
-"daL" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/plating/dirt,
@@ -5429,7 +5438,7 @@
 /obj/item/stack/sheet/metal/five,
 /obj/item/stack/sheet/glass/five,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dcf" = (
@@ -5471,10 +5480,10 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "ddx" = (
-/obj/machinery/chem_dispenser,
 /obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "deM" = (
@@ -5499,18 +5508,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dgg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5548,6 +5545,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"dgO" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5855,6 +5858,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dok" = (
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -5886,14 +5898,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"dpl" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "dpD" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plating/tunnel,
@@ -5902,6 +5906,18 @@
 /obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dpW" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/wiki/cit/chem_recipies,
@@ -5973,6 +5989,13 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"dsx" = (
+/obj/machinery/chem_dispenser,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6005,6 +6028,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"dtr" = (
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "dty" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6201,6 +6228,15 @@
 /obj/structure/decoration/vent/rusty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"dyH" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dyQ" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6259,6 +6295,22 @@
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"dAO" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dBj" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -6304,10 +6356,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"dCp" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
@@ -6326,6 +6374,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"dDz" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/den)
 "dDC" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/small,
@@ -6348,6 +6401,17 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"dEl" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6387,6 +6451,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"dFt" = (
+/obj/effect/landmark/poster_spawner/prewar,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
+"dFv" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
+/area/f13/den)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6412,16 +6490,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/f13/stinger,
-/obj/item/grenade/f13/stinger,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -6429,10 +6500,17 @@
 	dir = 1
 	},
 /area/f13/bunker)
+"dHg" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"dHw" = (
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6444,6 +6522,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
+"dIm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/water,
+/area/f13/den)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6451,9 +6537,10 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -6658,6 +6745,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dOg" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -6693,10 +6786,6 @@
 /obj/effect/decal/remains/human,
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
-"dPc" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -6758,7 +6847,7 @@
 "dQG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dQL" = (
@@ -6837,6 +6926,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/bunker)
+"dTr" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/grass,
+/area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -6847,12 +6940,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "dTK" = (
@@ -6875,17 +6971,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"dUk" = (
-/obj/machinery/chem_master/advanced,
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6988,18 +7073,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/structure/chair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/water,
 /area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
-/turf/open/indestructible/ground/inside/subway,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dWB" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7160,10 +7243,6 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
-"eay" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -7381,6 +7460,9 @@
 /obj/effect/light_emitter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"egc" = (
+/turf/open/floor/grass,
+/area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -7407,6 +7489,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"ehc" = (
+/obj/effect/landmark/poster_spawner,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7449,6 +7535,18 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"eiz" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -7652,10 +7750,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "emV" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "enc" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7704,10 +7799,6 @@
 /obj/item/card/id/dogtag/enclave/noncombatant,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
-"epg" = (
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 16;
@@ -7892,10 +7983,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"eup" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -7965,21 +8052,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "exf" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "exg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -8070,6 +8147,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"ezs" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13{
@@ -8144,6 +8226,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
+"eCs" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot_white,
@@ -8264,6 +8356,11 @@
 /obj/item/key,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"eFq" = (
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8456,9 +8553,6 @@
 	light_range = 4
 	},
 /area/f13/brotherhood/archives)
-"eKX" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8472,12 +8566,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"eLg" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -8615,8 +8703,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
@@ -8966,18 +9054,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"eZw" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/den)
-"faq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9102,6 +9178,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ffZ" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9160,6 +9244,17 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
+"fhe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
+/area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9173,6 +9268,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"fis" = (
+/obj/machinery/processor{
+	density = 0;
+	pixel_x = 30
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9233,9 +9335,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/green,
 /area/f13/den)
-"fjU" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
@@ -9259,6 +9358,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/old,
 /area/f13/enclave)
+"flj" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "fls" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -9273,6 +9378,14 @@
 "flG" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/den)
+"flT" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
 /turf/open/water,
 /area/f13/den)
 "flW" = (
@@ -9315,6 +9428,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"fmW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9410,12 +9527,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -9438,6 +9551,17 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"fpT" = (
+/obj/machinery/chem_master/advanced,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -9459,15 +9583,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqF" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -9654,6 +9776,12 @@
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
+"fws" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -9680,6 +9808,17 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"fxi" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -9694,15 +9833,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fxX" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/remains/human,
@@ -9714,15 +9844,6 @@
 	name = "plating"
 	},
 /area/f13/building)
-"fyh" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable{
@@ -9778,6 +9899,13 @@
 "fzc" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
+"fzD" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -9792,6 +9920,10 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustychess"
 	},
+/area/f13/den)
+"fzY" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -9965,12 +10097,6 @@
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"fGK" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -10126,11 +10252,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/structure/table,
-/obj/item/stack/medical/gauze,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "fLK" = (
@@ -10269,18 +10396,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"fPo" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
-/area/f13/den)
 "fPu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
@@ -10310,43 +10425,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"fQz" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -10358,9 +10436,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -10497,6 +10575,16 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
+"fUu" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -10532,6 +10620,10 @@
 "fVi" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
+"fVm" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 4;
@@ -10595,7 +10687,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/vest/old,
+/obj/item/clothing/suit/armor/vest/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -10975,6 +11075,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"gkm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11094,8 +11201,12 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11141,11 +11252,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"gqj" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "gqt" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -11330,11 +11436,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "gwm" = (
@@ -11372,10 +11476,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"gxS" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/enclave)
@@ -11393,16 +11493,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
-"gyu" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
-"gyB" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/den)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -11493,12 +11583,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"gBD" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+"gBM" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -11893,9 +11985,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
@@ -11992,9 +12083,25 @@
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gQR" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/den)
+"gQW" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/den)
 "gRa" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12162,6 +12269,12 @@
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
+"gWk" = (
+/obj/machinery/button/door{
+	name = "den clinic shutters"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12625,6 +12738,11 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
+"hlO" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -12753,9 +12871,11 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"hqt" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+"hri" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -12930,6 +13050,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"hxB" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hxF" = (
 /obj/machinery/light{
 	dir = 8
@@ -12985,6 +13115,10 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"hzR" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "hAk" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -13180,19 +13314,15 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -13844,12 +13974,6 @@
 "ibY" = (
 /obj/structure/sign/poster/contraband/bountyhunters,
 /turf/closed/wall/f13/wood/interior,
-/area/f13/den)
-"ica" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14624,13 +14748,6 @@
 "iCA" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
-"iDd" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -14991,6 +15108,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
+"iPX" = (
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
@@ -15363,6 +15487,17 @@
 /obj/structure/stalkeregg,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"jaG" = (
+/obj/machinery/button/door{
+	id = "densouthgate";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "jaU" = (
 /obj/structure/table,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -15896,6 +16031,12 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"juA" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -16198,12 +16339,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"jFq" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -16250,6 +16385,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"jHj" = (
+/obj/item/reagent_containers/pill/patch/turbo,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17185,6 +17324,18 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"kjh" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -17979,8 +18130,14 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_y = 29;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -18274,6 +18431,27 @@
 /obj/structure/debris/v4,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"kTJ" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -18578,6 +18756,14 @@
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
+"kZh" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -18861,6 +19047,12 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"liN" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19169,13 +19361,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -19209,6 +19398,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"ltu" = (
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ltN" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/structure/lattice/catwalk,
@@ -19301,7 +19506,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "lwU" = (
@@ -20002,6 +20207,16 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"lTs" = (
+/obj/structure/table/wood/poker,
+/obj/item/dice/d00,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "lTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20019,8 +20234,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/bed/mattress,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20066,14 +20297,10 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
 "lVK" = (
-/obj/machinery/button/door{
-	id = "densouthgate";
-	name = "South Den Gate";
-	pixel_x = 6;
-	pixel_y = -25
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "lWb" = (
@@ -20600,9 +20827,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/simple_door/room,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "mnU" = (
@@ -20946,10 +21173,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mCP" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
@@ -21246,11 +21472,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mOS" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -21530,6 +21751,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"mYc" = (
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -21573,6 +21804,19 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mZs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -21654,9 +21898,10 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -21796,9 +22041,10 @@
 	},
 /area/f13/brotherhood/operations)
 "nfB" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d00,
-/turf/open/floor/carpet/red,
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "nfW" = (
 /obj/machinery/computer/message_monitor{
@@ -22069,11 +22315,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"npf" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+"npc" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/clothing/mask/cigarette/rollie,
+/obj/item/clothing/mask/cigarette/rollie,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -22400,9 +22653,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
@@ -22420,6 +22679,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"nyG" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -22454,14 +22721,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"nzO" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/turf/open/water,
-/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22584,20 +22843,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"nEz" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
-"nEK" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/fulltile/store,
@@ -22631,15 +22876,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"nFt" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22735,6 +22971,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
+"nHM" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/drone,
@@ -22787,12 +23028,8 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23295,6 +23532,11 @@
 	dir = 4
 	},
 /area/f13/brotherhood/mining)
+"nZC" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -23582,11 +23824,6 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
-"ohx" = (
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -23840,11 +24077,14 @@
 	},
 /area/f13/brotherhood/operations)
 "ooI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	id = "densouthgate";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = -25
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "ooJ" = (
@@ -24058,12 +24298,9 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/water,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
@@ -24208,6 +24445,10 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"oBq" = (
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -24717,6 +24958,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"oVS" = (
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -25627,7 +25877,12 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -25990,12 +26245,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"pPI" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -26626,14 +26875,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
@@ -26726,6 +26969,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"qjU" = (
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -27115,13 +27362,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qxm" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -27481,13 +27721,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -27624,14 +27860,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"qMr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -27854,25 +28082,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -28361,13 +28577,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rjD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "rjM" = (
 /obj/structure/lattice{
@@ -28661,18 +28877,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rsi" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29066,11 +29270,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
-"rzy" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29377,6 +29576,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"rGe" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -29590,15 +29792,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"rLJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
@@ -29825,14 +30018,21 @@
 	},
 /area/f13/brotherhood/operating)
 "rSB" = (
+/obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
-"rSU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+"rSO" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
+/area/f13/caves)
+"rSU" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -30217,6 +30417,10 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"sfM" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -31057,6 +31261,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"sIa" = (
+/obj/structure/window/fulltile/ruins,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -31223,6 +31432,12 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"sOm" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31394,6 +31609,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"sTs" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/clothing/mask/cigarette/rollie/nicotine,
+/obj/item/clothing/mask/cigarette/rollie/nicotine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "sTW" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/water,
@@ -31453,11 +31677,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sVP" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "sWe" = (
 /obj/machinery/light{
@@ -31613,10 +31834,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"tbE" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -31628,6 +31845,14 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
+"tco" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
@@ -31735,6 +31960,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"thm" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -32103,10 +32334,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"tst" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -32142,17 +32369,6 @@
 "tur" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"tus" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -32327,6 +32543,11 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"tzz" = (
+/turf/open/floor/f13{
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -32411,26 +32632,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"tCQ" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"tCl" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32717,6 +32924,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"tKj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "tKk" = (
 /obj/structure/curtain,
 /obj/structure/lattice/catwalk,
@@ -32805,17 +33021,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"tMr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/vest/old,
-/obj/item/clothing/suit/armor/vest/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -33088,16 +33293,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"tXd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"tXl" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "tXr" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -33347,6 +33549,16 @@
 	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood/rnd)
+"uhB" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
 	dir = 8
@@ -33630,7 +33842,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "uqh" = (
@@ -33747,6 +33959,16 @@
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"uso" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -33833,6 +34055,16 @@
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
+"uvj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -33844,8 +34076,12 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -34004,6 +34240,14 @@
 /obj/item/key/bcollar,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"uCP" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/den)
 "uCR" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/showcase/machinery/cloning_pod,
@@ -34130,17 +34374,6 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"uII" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/waste{
@@ -34728,6 +34961,36 @@
 /turf/closed/wall/r_wall,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
+"vct" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
+"vcx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "vcC" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -34856,7 +35119,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/turf/closed/indestructible/f13/matrix,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -34929,9 +35197,12 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34995,15 +35266,20 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"vkI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
-"vlM" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -35083,12 +35359,6 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"voL" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35159,6 +35429,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"vra" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -35974,6 +36250,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vPv" = (
+/obj/effect/landmark/poster_spawner/pinup,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36011,15 +36291,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vQw" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36153,12 +36424,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
-"vVu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -36300,6 +36565,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wam" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -36482,6 +36750,17 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"wgS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -36611,6 +36890,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"wms" = (
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -36633,10 +36916,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
-"woj" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -36652,11 +36931,25 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
+"wpc" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -36678,6 +36971,43 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
+	},
+/area/f13/den)
+"wpF" = (
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "wqt" = (
@@ -36778,14 +37108,6 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"wuU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -37245,11 +37567,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
 "wIN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wIO" = (
 /obj/structure/cable{
@@ -37314,6 +37637,13 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"wKN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -37772,15 +38102,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices2nd)
-"wYl" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
 /area/f13/den)
@@ -38386,12 +38707,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "xpf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
@@ -38534,15 +38853,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"xtg" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
-/area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -39366,6 +39676,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"xTi" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39888,6 +40203,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ylp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -39914,6 +40238,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
+"ylL" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -65537,11 +65865,11 @@ kUN
 kUN
 kUN
 kUN
-wYo
-wYo
-wYo
-wYo
-wYo
+vgV
+vgV
+vgV
+vgV
+vgV
 wYo
 wYo
 hRI
@@ -65788,11 +66116,11 @@ dXE
 hQE
 uPr
 hQE
-kUN
-kUN
-kUN
-kUN
-kUN
+wYo
+wYo
+wYo
+wYo
+wYo
 kUN
 vgV
 vgV
@@ -66043,13 +66371,13 @@ dXE
 hQE
 hQE
 kUN
-eKX
+wam
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -66295,18 +66623,18 @@ dXE
 wFD
 wFD
 bbB
-gBD
+tCl
 uPr
 uPr
 uPr
-eKX
-eKX
+wam
+wam
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -66559,11 +66887,11 @@ hQE
 kUN
 kUN
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -66816,11 +67144,11 @@ hQE
 kUN
 kUN
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+ezs
+wYo
 kUN
 vgV
 vgV
@@ -67073,11 +67401,11 @@ wCB
 kUN
 kUN
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+ezs
+wYo
 kUN
 vgV
 vgV
@@ -67331,10 +67659,10 @@ kUN
 kUN
 kUN
 aqh
-kUN
-kUN
-kUN
-kUN
+wYo
+wYo
+wYo
+wYo
 kUN
 vgV
 vgV
@@ -67587,11 +67915,11 @@ kUN
 kUN
 kUN
 kUN
-anK
-anK
-anK
-anK
-kUN
+ezs
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -67844,11 +68172,11 @@ kUN
 kUN
 kUN
 kUN
-anK
-anK
-anK
-anK
-kUN
+jaG
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -68099,13 +68427,13 @@ vjW
 rQv
 eBU
 tiS
-ohx
+tzz
 kUN
-anK
-anK
-anK
-anK
-kUN
+jaG
+ezs
+ezs
+dgO
+wYo
 kUN
 vgV
 vgV
@@ -68356,13 +68684,13 @@ wRa
 wvj
 vgV
 dmS
-tXd
-exg
-anK
-anK
-anK
-anK
-kUN
+cLS
+wgS
+ezs
+ezs
+ezs
+ezs
+wYo
 kUN
 vgV
 vgV
@@ -68613,12 +68941,12 @@ ekK
 ajO
 sMl
 itn
-tXd
+cLS
 kUN
-bKb
-bKb
-bKb
-bKb
+dTG
+dTG
+dTG
+dTG
 hFt
 kUN
 vgV
@@ -68876,7 +69204,7 @@ vgV
 vgV
 vgV
 vgV
-nFt
+qTe
 vgV
 vgV
 vgV
@@ -69383,7 +69711,7 @@ gMZ
 iDK
 auj
 auj
-rSU
+wKN
 fIf
 fIf
 vgV
@@ -69604,32 +69932,32 @@ wFD
 mjG
 aou
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-kUN
-bPD
-anK
-anK
-mnK
-anK
-anK
-mnK
-anK
-anK
-bPD
-kUN
-anK
-anK
+dgO
+ezs
+ezs
 dZO
-anK
-anK
-anK
-anK
+ezs
+ezs
+ezs
+kUN
+bxH
+ezs
+ezs
+gwf
+bIT
+ezs
+gwf
+ezs
+ezs
+bxH
+kUN
+ezs
+ezs
+dZO
+ezs
+ezs
+ezs
+dgO
 kUN
 hRI
 hRI
@@ -69639,10 +69967,10 @@ pjR
 fEW
 iDK
 auj
+auj
 iDK
 uDa
 uDa
-auj
 blx
 diR
 diR
@@ -69861,32 +70189,32 @@ wFD
 mjG
 bzl
 kUN
-anK
-anK
-anK
+dgO
+ezs
+ezs
 kUN
-anK
-anK
-anK
+ezs
+ezs
+ezs
 kUN
-cqu
-anK
-anK
+dgO
+ezs
+ezs
 kUN
-anK
-anK
+ezs
+bIT
 kUN
-anK
-anK
-cqu
+ezs
+ezs
+dgO
+ehc
+ezs
+ezs
 kUN
-anK
-anK
-kUN
-kUN
-anK
-anK
-anK
+wYo
+ezs
+ezs
+dgO
 kUN
 hRI
 hRI
@@ -69896,15 +70224,15 @@ iDK
 vWZ
 iDK
 iDK
+auj
 gJA
 vBZ
 bVO
-auj
 blx
 gKU
 aVZ
-eOP
-eOP
+fmW
+fmW
 gCa
 gCa
 kUN
@@ -70118,32 +70446,32 @@ wFD
 mjG
 bzl
 kUN
-anK
-anK
-anK
+mYc
+ezs
+ezs
 kUN
-anK
-anK
-anK
+ezs
+ezs
+ezs
 kUN
-anK
-anK
-anK
+ezs
+ezs
+ezs
+ehc
+ezs
+bIT
 kUN
-anK
-anK
+ezs
+ezs
+ezs
 kUN
-anK
-anK
-anK
+ezs
+ezs
 kUN
-anK
-anK
-kUN
-kUN
-anK
-anK
-anK
+aqQ
+ezs
+ezs
+dgO
 kUN
 hRI
 hRI
@@ -70153,10 +70481,10 @@ iDK
 gDU
 gmI
 iDK
+auj
 lCp
 gvC
 fjA
-auj
 blx
 gKU
 aVZ
@@ -70375,32 +70703,32 @@ wWB
 mjG
 agK
 kUN
-anK
-anK
-anK
+kIf
+ezs
+ezs
 kUN
-anK
-anK
-anK
+ezs
+ezs
+ezs
 kUN
-cAU
-cAU
-cAU
+dAO
+dAO
+dAO
 kUN
-anK
-anK
+bIT
+bIT
 kUN
-cAU
-cAU
-cAU
+dAO
+dAO
+dAO
+ehc
+ezs
+ezs
 kUN
-anK
-anK
-kUN
-kUN
-anK
-anK
-anK
+wYo
+ezs
+ezs
+ezs
 kUN
 hRI
 hRI
@@ -70410,12 +70738,12 @@ gMZ
 auj
 iDK
 iDK
+auj
 lCp
 tUT
 vBZ
-auj
 kDG
-fqF
+dEl
 okb
 dyB
 gCa
@@ -70632,32 +70960,32 @@ bbB
 mjG
 aEg
 kUN
-uII
-uII
-uII
+dTG
+dTG
+dTG
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+bIT
+bIT
+nye
+bIT
+ezs
+ezs
+ezs
+ezs
+fxi
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
 kUN
-kUN
-anK
-anK
-anK
+wYo
+ezs
+ezs
+ezs
 kUN
 hRI
 hRI
@@ -70667,12 +70995,12 @@ qDc
 bMt
 iDK
 iDK
+auj
 cAC
 gVL
 gVL
-auj
-rjD
-iDK
+ylp
+vkI
 gMZ
 cbQ
 bIC
@@ -70888,33 +71216,33 @@ bbB
 bbB
 mjG
 mjG
-vQw
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-anK
+gRa
+ezs
+ezs
+ezs
+ezs
+bIT
+ezs
+ezs
+bIT
+ezs
+ezs
+ezs
+ezs
+hlO
+hlO
+hlO
+hlO
+hlO
+hlO
+hlO
+hlO
+ezs
 kUN
-kUN
-anK
-anK
-anK
+wYo
+ezs
+ezs
+ooI
 kUN
 hRI
 hRI
@@ -70928,8 +71256,8 @@ auj
 auj
 auj
 auj
-fpD
-nfB
+rSU
+lTs
 dTK
 bMt
 pxK
@@ -71145,33 +71473,33 @@ wFD
 wWB
 mjG
 bzl
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-gyu
-fXU
-fXU
+ezs
+ezs
+ezs
+ezs
+fxi
+ezs
+ezs
+ezs
+bIT
+bIT
+bIT
+ezs
+ezs
+hlO
+egc
+egc
 eiS
-fXU
-epg
-fXU
-gyu
-anK
+dTr
+wms
+egc
+hlO
+ezs
 kUN
-kUN
-anK
-anK
-lVK
+aqQ
+ezs
+ezs
+ooI
 kUN
 hRI
 hRI
@@ -71185,8 +71513,8 @@ iDK
 auj
 iDK
 iDK
-fpD
-qMr
+rSU
+vcx
 dyu
 bMt
 bIC
@@ -71402,39 +71730,39 @@ wFD
 wWB
 mjG
 bzl
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-gyu
-fXU
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+bwq
+egc
 iFg
 okH
 maO
 rvK
-fXU
-gyu
-anK
-anK
+egc
+hlO
+ezs
+ezs
+dFt
+vct
+vct
+vct
 kUN
-cAU
-cAU
-cAU
-kUN
-owJ
-owJ
-owJ
-owJ
-owJ
+dIm
+dIm
+dIm
+dIm
+dIm
 fsN
 gNZ
 auj
@@ -71442,8 +71770,8 @@ fUQ
 auj
 auj
 auj
-fpD
-eLg
+rSU
+cjg
 dyu
 dxH
 bIC
@@ -71666,27 +71994,27 @@ kUN
 kUN
 kUN
 kUN
+fpD
 kUN
 kUN
 kUN
-kUN
-kUN
-anK
-gyu
-gqj
+fpD
+ezs
+hlO
+qIj
 kbT
 uVE
 eyK
 ghs
-vlM
-gyu
-gyu
-gyu
+ylL
+hlO
+hlO
+hlO
 fUv
-anK
-anK
-anK
-exf
+ezs
+ezs
+ezs
+dyH
 xdj
 xdj
 xdj
@@ -71699,8 +72027,8 @@ jLx
 auj
 auj
 auj
-fpD
-auj
+rSU
+wIN
 vWZ
 hOB
 bIC
@@ -71923,27 +72251,27 @@ kUN
 kUN
 kUN
 kUN
+ehc
+kUN
+ehc
 kUN
 kUN
-kUN
-kUN
-kUN
-anK
-gyu
-fXU
+ezs
+cBZ
+egc
 bUh
-dVW
-nye
+dFv
+mCP
 bhu
-fXU
-gyu
-gyu
-gyu
+egc
+hlO
+bhO
+hlO
 fUv
-anK
-anK
-anK
-emV
+ezs
+ezs
+ezs
+liN
 xdj
 xdj
 xdj
@@ -71955,7 +72283,7 @@ auj
 fjh
 auj
 auj
-blx
+vPv
 qQR
 fjH
 fjH
@@ -72176,7 +72504,7 @@ vgV
 kUN
 kUN
 dzP
-nbd
+eFq
 dLs
 kUN
 gCa
@@ -72185,22 +72513,22 @@ gCa
 gCa
 gCa
 dZO
-anK
-gyu
-fXU
-xtg
+ezs
+bwq
+egc
+fqF
 uVE
 eyK
-nzO
-fXU
-gyu
-gyu
-gyu
+flT
+egc
+hlO
+hlO
+hlO
 fUv
-anK
-dQG
-anK
-anK
+ezs
+exg
+ezs
+gBM
 xdj
 xdj
 xdj
@@ -72212,12 +72540,12 @@ iDK
 fjh
 iDK
 auj
-rzy
+sIa
 gKU
 aVZ
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 blx
@@ -72225,7 +72553,7 @@ ibY
 gVp
 fVQ
 cuS
-ccg
+dHg
 hQE
 eLE
 yhT
@@ -72432,30 +72760,30 @@ mjG
 vgV
 kUN
 kUN
-tst
+exf
 cUt
 tqC
 kUN
-gow
-dIq
+sfM
+owJ
 cXP
 gCa
 gCa
 kUN
-anK
-gyu
-hqt
-hJy
-aEe
-qia
-fPo
-fXU
-gyu
-anK
-anK
+ezs
+bwq
+nJC
+bup
+tco
+uhB
+wpc
+egc
+hlO
+ezs
+ezs
+ehc
 kUN
-kUN
-kUN
+ehc
 kUN
 kUN
 xdj
@@ -72469,13 +72797,13 @@ iDK
 iDK
 iDK
 auj
-rzy
+sIa
 gKU
 aVZ
 gCa
-ava
-npf
-vVu
+nZC
+hri
+xpf
 gCa
 bmJ
 exn
@@ -72693,29 +73021,29 @@ gCa
 cWc
 dzP
 kUN
-gow
-dIq
+sfM
+owJ
 cXP
 gCa
 gCa
-kUN
-anK
-gyu
-fXU
-fXU
-hqt
-fXU
-fXU
-gqj
-gyu
-anK
-kUN
-kUN
-kUN
+ehc
+ezs
+cBZ
+egc
+egc
+nJC
+dTr
+egc
+qIj
+hlO
+ezs
+dFt
 kUN
 kUN
 kUN
-iDd
+kUN
+kUN
+bEV
 fEj
 fEj
 fEj
@@ -72726,7 +73054,7 @@ fjh
 gmI
 iDK
 auj
-rzy
+sIa
 lxs
 aVZ
 gCa
@@ -72950,27 +73278,27 @@ gCa
 gCa
 gCa
 kUN
-dPc
-sVP
+qjU
+iPX
 cXP
 gCa
 gCa
 kUN
-anK
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-anK
+ezs
+bwq
+bwq
+hlO
+bhO
+hlO
+hlO
+hlO
+hlO
+ezs
 kUN
 kUN
-ddx
-dUk
-bAz
+dsx
+fpT
+kjh
 kUN
 kUN
 hRI
@@ -72983,7 +73311,7 @@ fjh
 hOB
 iDK
 auj
-rzy
+sIa
 gKU
 aVZ
 gCa
@@ -73206,28 +73534,28 @@ kUN
 kUN
 kUN
 ohV
-kUN
-gow
-dIq
+fpD
+sfM
+owJ
 cXP
 gCa
 gCa
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+ezs
+ezs
+ezs
+bIT
+nye
+ezs
+ezs
+ezs
+ezs
+ezs
 kUN
 kUN
-wpa
-bSl
-ooI
+ddx
+aLA
+nHM
 kUN
 kUN
 hRI
@@ -73240,12 +73568,12 @@ fjh
 iDK
 tZP
 auj
-auj
-eiA
+kUN
+kUN
 gCa
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 gCa
@@ -73464,27 +73792,27 @@ gCa
 gCa
 gCa
 eiA
-gow
-dIq
+sfM
+owJ
 cXP
 gCa
 gCa
-kUN
-anK
-anK
+fpD
+ezs
+ezs
 dWg
-anK
-anK
-anK
-dWg
-anK
-anK
+ezs
+ezs
+ezs
+cKb
+ezs
+ezs
 dWg
 kUN
 kUN
-mOS
-xpf
-gwf
+fhe
+gow
+uvI
 kUN
 kUN
 hRI
@@ -73501,15 +73829,15 @@ iDK
 eiA
 gCa
 gCa
-ava
-npf
-vVu
+nZC
+hri
+xpf
 gCa
 ibo
-lsh
+dok
 xac
-bRm
-efa
+psU
+fis
 fKK
 hQE
 eLE
@@ -73727,21 +74055,21 @@ gCa
 gCa
 gCa
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+bIT
+ezs
+dFt
 kUN
-kUN
-nEz
-gNv
-gNv
+ltu
+hJy
+hJy
 kUN
 kUN
 hRI
@@ -73757,13 +74085,13 @@ auj
 gmI
 eiA
 fjS
-eOP
+fmW
 gCa
 blG
 gCa
 gCa
 gCa
-gCa
+kUN
 kUN
 kUN
 wYo
@@ -73982,23 +74310,23 @@ gCa
 gCa
 gCa
 gCa
-cSN
+aqW
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+nye
+ezs
+ehc
 kUN
-kUN
-gNv
-gNv
-gNv
+nHM
+nHM
+nHM
 kUN
 kUN
 hRI
@@ -74020,7 +74348,7 @@ qNg
 tZF
 qNg
 qNg
-qNg
+auj
 auj
 gmI
 wYo
@@ -74230,7 +74558,7 @@ wFD
 mjG
 vgV
 kUN
-kUN
+fpD
 gCa
 gCa
 gCa
@@ -74241,21 +74569,21 @@ gCa
 gCa
 fOg
 kUN
-anK
-anK
+ezs
+ezs
 dWg
-anK
-anK
-anK
+ezs
+ezs
+ezs
 dWg
-anK
-anK
+ezs
+bIT
 dWg
 kUN
 kUN
-nJC
-gNv
-gNv
+cRY
+nHM
+nHM
 kUN
 kUN
 hRI
@@ -74498,21 +74826,21 @@ gCa
 gCa
 eJq
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+ezs
+gBM
 kUN
 kUN
 kUN
-cbG
-gNv
-gNv
+vjM
+nHM
+nHM
 kUN
 kUN
 hRI
@@ -74752,24 +75080,24 @@ kUN
 kUN
 kUN
 dZO
+dFt
 kUN
 kUN
 kUN
 kUN
+ehc
+rSU
+rSU
+nfB
+nfB
+rSU
+rSU
 kUN
-kUN
-fpD
-fpD
-bNV
-bNV
-fpD
-fpD
-kUN
-dpl
-gNv
-gNv
-gNv
-fLy
+bAz
+nHM
+nHM
+nHM
+bMI
 kUN
 kUN
 hRI
@@ -75007,27 +75335,27 @@ gCa
 gCa
 kUN
 dcd
-anK
-anK
-anK
-voL
-qIj
+fRv
+fRv
+fRv
+mnK
+oVS
 uqb
-qxm
+fzD
 kUN
+dVW
 anK
 anK
 anK
 anK
-anK
-anK
+kZh
 kUN
-dTG
-gNv
-gNv
-gNv
-bhO
-cRY
+rjD
+nHM
+nHM
+nHM
+cAU
+kUN
 kUN
 hRI
 lqf
@@ -75258,32 +75586,32 @@ wFD
 mjG
 vgV
 kUN
-kUN
+fpD
 gCa
 gCa
 gCa
 kUN
-mCP
-anK
-anK
-anK
+cMf
+fRv
+fRv
+fRv
 uqb
 uqb
 uqb
-rsi
+dpW
 kUN
+dVW
 anK
 anK
 anK
 anK
-anK
-anK
+kZh
 kUN
-tus
-gNv
-gNv
-gNv
-wYl
+hxB
+thm
+nHM
+thm
+pCO
 kUN
 kUN
 hRI
@@ -75520,15 +75848,15 @@ gCa
 gCa
 gCa
 kUN
-fyh
-anK
-anK
+fLy
+fRv
+fRv
 aPF
-fxX
+lVK
 uqb
 uqb
-dGU
-kUN
+eiz
+dFt
 anK
 anK
 anK
@@ -75536,11 +75864,11 @@ anK
 anK
 anK
 kUN
-fQz
-gNv
-gNv
-gNv
-fQz
+wpF
+nHM
+nHM
+nHM
+wpF
 kUN
 kUN
 hRI
@@ -75777,21 +76105,21 @@ gCa
 gCa
 gCa
 kUN
-jFq
-anK
-anK
+lsh
+fRv
+fRv
 aPF
-tMr
+fXU
 lwv
 uqb
-rLJ
+tKj
 kUN
-dZO
-dgg
-dgg
-dgg
-dgg
-dgg
+eCs
+mZs
+mZs
+mZs
+mZs
+mZs
 kUN
 kUN
 kUN
@@ -76030,19 +76358,19 @@ mjG
 vgV
 kUN
 kUN
-eay
-eay
-eay
+cSN
+cSN
+cSN
 kUN
-anK
+fRv
 dQG
-anK
-wuU
-cQp
-anK
+fRv
+vfF
+ffZ
+fRv
 uqb
-wIN
-kUN
+gkm
+gWk
 anK
 anK
 anK
@@ -76050,11 +76378,11 @@ anK
 anK
 anK
 kUN
-woj
-pCO
-pCO
-pCO
-dCp
+fVm
+tXl
+tXl
+tXl
+aJI
 kUN
 kUN
 hRI
@@ -76287,31 +76615,31 @@ mjG
 vgV
 kUN
 kUN
-vfF
-vfF
-vfF
+gQW
+gQW
+gQW
 kUN
-bPB
-anK
-anK
-anK
-anK
-anK
+uvj
+fRv
+fRv
+fRv
+fRv
+fRv
 uqb
-cMf
+uso
 kUN
 anK
 anK
 anK
 anK
 anK
-anK
+dIq
 kUN
 cLd
-pCO
+tXl
 cLd
-pCO
-pCO
+tXl
+tXl
 kUN
 kUN
 hRI
@@ -76548,27 +76876,27 @@ kUN
 kUN
 kUN
 kUN
-cqu
-cqu
-cqu
-cqu
-anK
-anK
+nbd
+nbd
+nbd
+nbd
+fRv
+fRv
 lwv
 uqb
-cdh
+cQc
 anK
 anK
 anK
 anK
 anK
-anK
+fws
 kUN
-ica
-pCO
-pCO
-pCO
-gRa
+vra
+tXl
+tXl
+tXl
+oBq
 kUN
 kUN
 hRI
@@ -76822,9 +77150,9 @@ anK
 anK
 kUN
 cLd
-pCO
+tXl
 cLd
-pCO
+tXl
 cLd
 kUN
 kUN
@@ -77071,18 +77399,18 @@ kUN
 kUN
 kUN
 kUN
+wpa
+npc
+sTs
+fws
 anK
 anK
-anK
-anK
-anK
-anK
-dZO
-pCO
-pCO
-tCQ
-qTe
-kIf
+fUu
+tXl
+tXl
+lUs
+kTJ
+fzY
 kUN
 kUN
 hRI
@@ -77318,14 +77646,14 @@ kUN
 cPI
 cPI
 cPI
-daL
+emV
 wjM
-fjU
+rGe
 cPI
 cPI
 cPI
-fjU
-eKX
+rGe
+wam
 kUN
 kUN
 kUN
@@ -77574,16 +77902,16 @@ kUN
 kUN
 wjM
 wjM
-bwq
-daL
-daL
-bEV
+bMH
+emV
+emV
+jHj
 cPI
 cPI
-fjU
-fjU
-eKX
-eKX
+rGe
+rGe
+wam
+wam
 kUN
 kUN
 kUN
@@ -77831,28 +78159,28 @@ kUN
 kUN
 wjM
 wjM
-uvI
-daL
-daL
-pPI
+eOP
+emV
+emV
+dOg
 cPI
 cPI
-eKX
+wam
 cPI
-eKX
-eKX
-eKX
-fjU
+wam
+wam
+wam
+rGe
 lAR
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -78094,22 +78422,22 @@ iUU
 cPI
 cPI
 cPI
-eKX
+wam
 cPI
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
 kUN
-fjU
-fjU
-eKX
-eKX
-eKX
-eKX
-fjU
-eKX
-eKX
+rGe
+rGe
+wam
+wam
+wam
+wam
+rGe
+wam
+wam
 kUN
 hRI
 hRI
@@ -78351,22 +78679,22 @@ iUU
 wYo
 cPI
 cPI
-eKX
-eKX
+wam
+wam
 cPI
-eKX
-fjU
-eKX
+wam
+rGe
+wam
 kUN
-fjU
-eKX
-fjU
-fjU
-fjU
-fjU
-eKX
-eKX
-eKX
+rGe
+wam
+rGe
+rGe
+rGe
+rGe
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -78601,29 +78929,29 @@ mjG
 kUN
 kUN
 wYo
-bXn
-eup
-fRv
-tbE
+bPA
+dtr
+xTi
+qia
 wYo
-eKX
-eKX
-fjU
-eKX
+wam
+wam
+rGe
+wam
 cPI
 cPI
 cPI
-fjU
+rGe
 kUN
-eKX
-eKX
-fjU
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+rGe
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -78858,29 +79186,29 @@ mjG
 kUN
 kUN
 wYo
-faq
-rSB
-rSB
-rSB
+sOm
+dHw
+dHw
+dHw
 wYo
-fjU
-eKX
-fjU
-fjU
-eKX
-eKX
-fjU
+rGe
+wam
+rGe
+rGe
+wam
+wam
+rGe
 cPI
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -79115,29 +79443,29 @@ mjG
 kUN
 kUN
 wYo
-gxS
+gNv
+dHw
+dHw
 rSB
-rSB
-lUs
 wYo
-fjU
-eKX
-eKX
-eKX
-fjU
-fjU
-eKX
-eKX
+rGe
+wam
+wam
+wam
+rGe
+rGe
+wam
+wam
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -79374,12 +79702,12 @@ kUN
 wYo
 wYo
 wYo
-nEK
+sVP
 wYo
 wYo
 kUN
 kUN
-eZw
+ckD
 kUN
 kUN
 kUN
@@ -79628,37 +79956,37 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
-eZw
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eZw
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+dDz
+gQR
+dDz
+dDz
+ckD
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+ckD
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 xdj
 xdj
 xdj
 xdj
-vjM
+dGU
 xdj
-vjM
+dGU
 wFD
 mNE
 wFD
@@ -79885,37 +80213,37 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
 kUN
 kUN
 kUN
 qEH
 kUN
-eKX
-eKX
+wam
+wam
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 xdj
 xdj
 xdj
 xdj
-vjM
+dGU
 xdj
-vjM
+dGU
 wFD
 mNE
 wFD
@@ -80142,18 +80470,18 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
+hzR
+dHw
+flj
+dHw
 kUN
-eKX
-eKX
+wam
+wam
 kUN
 kUN
 kUN
@@ -80165,7 +80493,7 @@ kUN
 kUN
 qEH
 kUN
-eZw
+ckD
 kUN
 hRI
 hRI
@@ -80399,30 +80727,30 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
+dHw
+flj
+dHw
+hzR
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 qEH
-eKX
+wam
 kUN
 hRI
 hRI
@@ -80656,30 +80984,30 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+uCP
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
+flj
+dHw
+dHw
+hzR
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
+wam
 kUN
 hRI
 hRI
@@ -80913,30 +81241,30 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
+dHw
+dHw
+dHw
+dHw
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
 qEH
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
+wam
 kUN
 hRI
 hRI
@@ -81170,10 +81498,10 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+nyG
+dDz
 kUN
 kUN
 kUN
@@ -81193,7 +81521,7 @@ kUN
 kUN
 kUN
 kUN
-eKX
+wam
 kUN
 hRI
 hRI
@@ -81427,30 +81755,30 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -81684,30 +82012,30 @@ mjG
 mjG
 kUN
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
 hRI
 hRI
@@ -81941,12 +82269,12 @@ mjG
 mjG
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+gQR
+dDz
 kUN
-eKX
+wam
 kUN
 kUN
 qEH
@@ -82198,15 +82526,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 dXE
 dXE
@@ -82455,15 +82783,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -82712,15 +83040,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 fLU
 eCe
 pYd
@@ -82969,15 +83297,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 fLU
 pYd
 eEt
@@ -83226,15 +83554,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 fLU
 pYd
 eFi
@@ -83483,15 +83811,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-gyB
-gyB
-gyB
+dDz
+dDz
+dDz
+dDz
 kUN
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 fLU
 pYd
 eHs
@@ -83738,17 +84066,17 @@ wFD
 wFD
 dtk
 fQL
-uPr
-eKX
-eKX
-eKX
-eKX
-eKX
+rSO
+dDz
+dDz
+dDz
+dDz
+dDz
 qEH
-eKX
+wam
 kUN
-eKX
-eKX
+wam
+wam
 fLU
 pYd
 pYd
@@ -83998,14 +84326,14 @@ fQL
 hQE
 kUN
 kUN
+dDz
 kUN
 kUN
 kUN
+wam
 kUN
-eKX
-kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -84254,15 +84582,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -84511,15 +84839,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
+gQR
+dDz
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -84768,15 +85096,15 @@ bbB
 fQL
 hQE
 kUN
-eKX
-eKX
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -85025,15 +85353,15 @@ bbB
 mjG
 hQE
 kUN
-eKX
-eKX
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 pYd
@@ -85282,15 +85610,15 @@ bbB
 fQL
 hQE
 kUN
-eKX
-eKX
+dDz
+dDz
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 gFC
 eCe
@@ -85542,12 +85870,12 @@ kUN
 qEH
 kUN
 kUN
-eKX
-eKX
-eKX
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 hQE
 dXE
@@ -85796,15 +86124,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 hQE
 dXE
@@ -86053,15 +86381,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 hQE
 dXE
@@ -86310,15 +86638,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 hQE
 dXE
@@ -86567,15 +86895,15 @@ mjG
 fQL
 hQE
 kUN
-eKX
-eKX
-eKX
-eKX
-eKX
-eKX
+wam
+wam
+wam
+wam
+wam
+wam
 kUN
-eKX
-eKX
+wam
+wam
 hQE
 hQE
 dXE
@@ -86831,8 +87159,8 @@ kUN
 kUN
 kUN
 kUN
-eKX
-eKX
+wam
+wam
 snI
 hQE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,13 +302,11 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -335,13 +333,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
@@ -418,7 +414,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
-/obj/structure/simple_door/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -595,6 +590,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ava" = (
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/lattice/catwalk,
@@ -968,6 +968,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"aEe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1147,6 +1155,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"aJI" = (
+/obj/structure/sign/poster/contraband/power,
+/obj/structure/simple_door/wood,
+/turf/open/space/basic,
+/area/f13/den)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1211,6 +1224,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"aLA" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1303,14 +1321,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "aPG" = (
 /obj/structure/cable{
@@ -1336,11 +1349,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
@@ -1532,10 +1550,14 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1791,11 +1813,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -1831,12 +1850,9 @@
 /obj/structure/fence{
 	dir = 1
 	},
-/obj/structure/fence{
-	dir = 1
-	},
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	dir = 4;
+	pixel_x = 20
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -1969,9 +1985,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2299,9 +2317,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2469,10 +2487,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bup" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2493,6 +2507,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"bve" = (
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2501,6 +2521,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
+"bvs" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -2555,13 +2583,6 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bwW" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/barber{
@@ -2600,15 +2621,13 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2692,7 +2711,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2886,11 +2907,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -2960,10 +2979,22 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"bHA" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "bHI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "bIa" = (
@@ -3017,10 +3048,13 @@
 	},
 /area/f13/brotherhood/operating)
 "bIT" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3078,8 +3112,10 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3145,27 +3181,19 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
+"bMI" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/den)
-"bMI" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
@@ -3195,11 +3223,22 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
+"bNI" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/den)
+"bNV" = (
+/obj/machinery/vending/cigarette,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bOp" = (
@@ -3264,9 +3303,27 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"bPA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/den)
 "bPB" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"bPD" = (
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
@@ -3322,6 +3379,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bRm" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3360,14 +3422,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
 "bSl" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/area/f13/caves)
 "bSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -3529,10 +3590,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
@@ -3562,7 +3621,13 @@
 /area/f13/sewer)
 "bXn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -3662,12 +3727,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"caw" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3712,6 +3771,11 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
+"cbG" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3763,15 +3827,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/area/f13/sewer)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3831,6 +3891,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"cdh" = (
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4005,9 +4072,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "cjg" = (
-/obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/deck,
 /obj/structure/curtain{
 	color = "#363636";
 	pixel_x = 2;
@@ -4067,6 +4132,10 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
+"ckD" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4284,15 +4353,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"crx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/f13/wood{
@@ -4396,9 +4456,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"cuS" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -4550,14 +4607,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"czr" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4799,6 +4848,11 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"cCO" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -4973,24 +5027,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"cIZ" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
@@ -5097,13 +5139,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
@@ -5139,6 +5178,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"cPI" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "cPP" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/mineral/random/low_chance,
@@ -5149,13 +5193,19 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
+"cQc" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
 	},
@@ -5205,8 +5255,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = denmedshutters
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5265,17 +5325,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "cTL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5441,11 +5491,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5474,20 +5522,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"cYs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5547,10 +5581,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
+"daL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/plating/dirt,
@@ -5636,21 +5685,10 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/structure/fence{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5674,6 +5712,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dgg" = (
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5711,13 +5753,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
-"dgO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5745,10 +5780,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5899,8 +5938,15 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6000,24 +6046,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6062,9 +6093,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
+	},
+/turf/open/water,
 /area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -6098,12 +6133,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "dpu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dpD" = (
 /obj/effect/mob_spawn/human/corpse/vault,
@@ -6114,29 +6158,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dqh" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
@@ -6210,7 +6244,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/structure/sink/well,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dsz" = (
@@ -6500,23 +6537,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "dzP" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/rust,
 /area/f13/den)
 "dAp" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "dAO" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/rust,
 /area/f13/den)
 "dBj" = (
 /turf/open/floor/plating/tunnel{
@@ -6564,12 +6595,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet/red,
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_y = -1;
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6616,15 +6655,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"dEl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6637,16 +6667,9 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
@@ -6676,21 +6699,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
-"dFv" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/area/f13/caves)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6716,8 +6729,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -6726,11 +6756,11 @@
 	},
 /area/f13/bunker)
 "dHg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "dHh" = (
@@ -6752,31 +6782,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
-"dIq" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -6885,11 +6905,17 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
@@ -6929,10 +6955,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -6988,6 +7018,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dOg" = (
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -7024,13 +7058,12 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "dPo" = (
@@ -7174,10 +7207,9 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/sewer)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7187,6 +7219,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"dTG" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -7208,10 +7245,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7230,13 +7271,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"dUO" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -7322,10 +7356,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dWg" = (
 /obj/machinery/light{
 	dir = 1
@@ -7449,9 +7485,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7492,12 +7535,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7750,6 +7793,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"ehc" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7785,25 +7838,13 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
@@ -7813,6 +7854,19 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"eiz" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -7934,12 +7988,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "ekQ" = (
 /obj/structure/chair/sofa/right{
@@ -8003,12 +8059,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "emN" = (
 /turf/open/floor/wood/f13/oakbroken,
@@ -8074,6 +8127,10 @@
 /obj/item/card/id/dogtag/enclave/noncombatant,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
+"epg" = (
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 16;
@@ -8159,9 +8216,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "esg" = (
 /obj/item/flag/bos,
 /obj/structure/fence/handrail_end/non_dense{
@@ -8255,6 +8312,10 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"eup" = (
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -8304,10 +8365,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"ewe" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -8321,6 +8378,10 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"exf" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/grass,
+/area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -8369,6 +8430,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"exN" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8408,10 +8473,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/table/wood/junk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8459,6 +8524,19 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
+"eBU" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "eBZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -8477,11 +8555,12 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -8604,9 +8683,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8654,6 +8736,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"eGQ" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant,
@@ -8816,6 +8902,17 @@
 	light_range = 4
 	},
 /area/f13/brotherhood/archives)
+"eKX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8830,16 +8927,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/fence{
+	dir = 1
 	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
-"eLq" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/water,
-/area/f13/caves)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -8892,13 +8988,13 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8985,6 +9081,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"eOP" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9156,8 +9258,12 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "eUi" = (
@@ -9209,6 +9315,11 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"eVt" = (
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9240,13 +9351,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -9347,14 +9454,22 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"faq" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+"eZw" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
+"faq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9413,6 +9528,11 @@
 /obj/structure/decoration/rag,
 /turf/open/water,
 /area/f13/sewer)
+"fdw" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "fdG" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
@@ -9472,12 +9592,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
@@ -9537,12 +9656,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
-"fhe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9557,8 +9670,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
@@ -9578,8 +9691,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9603,6 +9717,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
+"fjJ" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9666,21 +9789,12 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
-"flT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9727,16 +9841,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/turf/open/water,
+/area/f13/caves)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9832,16 +9941,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -9864,6 +9965,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"fpT" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -9884,14 +9990,17 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"fqB" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "fqF" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10078,6 +10187,14 @@
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
+"fws" = (
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -10096,38 +10213,23 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fxi" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -10144,10 +10246,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
@@ -10160,6 +10265,16 @@
 	name = "plating"
 	},
 /area/f13/building)
+"fyh" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable{
@@ -10190,10 +10305,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/structure/table{
+	pixel_x = 6
 	},
-/turf/open/floor/carpet/green,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10221,12 +10341,14 @@
 "fzc" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
-"fzj" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "fzD" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10242,6 +10364,18 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustychess"
 	},
+/area/f13/den)
+"fzY" = (
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10391,14 +10525,12 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/operations)
 "fEW" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fFv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10420,13 +10552,6 @@
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"fGK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -10527,11 +10652,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"fJp" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10587,13 +10707,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
@@ -10700,16 +10821,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"fOr" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/wood/f13/oak,
@@ -10744,27 +10855,31 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/obj/machinery/microwave{
+	pixel_x = -6
+	},
+/obj/structure/table{
+	pixel_x = 14
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fPt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "fPu" = (
 /obj/structure/closet,
@@ -10800,6 +10915,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
+"fQB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -10811,9 +10933,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -10951,13 +11073,11 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "floordirty"
 	},
 /area/f13/den)
 "fUv" = (
@@ -10996,11 +11116,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 4;
@@ -11332,13 +11458,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
-"geR" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11452,8 +11571,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/sewer)
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11478,6 +11605,17 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/rnd)
+"gkY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11573,13 +11711,15 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11625,6 +11765,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"gqj" = (
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "gqt" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -11794,10 +11938,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = denmedshutters
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -11807,13 +11956,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -11851,12 +11996,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
@@ -11876,19 +12020,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
@@ -11911,6 +12045,23 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"gza" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -11987,8 +12138,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/grass,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12082,16 +12233,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
@@ -12132,6 +12276,43 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"gFp" = (
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -12229,14 +12410,16 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d00,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
@@ -12264,6 +12447,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"gIt" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12400,6 +12590,10 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"gNv" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 1;
@@ -12503,6 +12697,21 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"gQW" = (
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
+"gRa" = (
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
@@ -12674,7 +12883,11 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -12817,6 +13030,11 @@
 	dir = 8
 	},
 /area/f13/bunker)
+"gZB" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "gZF" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
@@ -13273,10 +13491,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"hqt" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "hri" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/trash,
@@ -13457,8 +13671,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13591,11 +13805,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/falsewall/rust,
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
+/turf/closed/wall/f13/wood,
 /area/f13/caves)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13717,6 +13930,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
+"hJy" = (
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -13762,14 +13979,11 @@
 	},
 /area/f13/bunker)
 "hKN" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "hKS" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -13910,11 +14124,14 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/sewer)
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -14830,7 +15047,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
@@ -14999,14 +15217,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"ixi" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -15149,40 +15359,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15544,15 +15723,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -15711,19 +15883,6 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"iUU" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/stage_t,
@@ -15751,9 +15910,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -15944,9 +16103,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16383,11 +16541,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "jqn" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "jqE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -16575,6 +16730,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jxS" = (
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/water,
+/area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Canteen"
@@ -16686,15 +16848,6 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"jBt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16756,14 +16909,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16803,6 +16954,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"jFq" = (
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -16850,9 +17010,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16874,6 +17037,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jIs" = (
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17458,6 +17631,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"kaQ" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17536,15 +17713,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17789,9 +17962,11 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18586,9 +18761,17 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -18621,16 +18804,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -18662,11 +18845,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
-"kKb" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -18794,9 +18972,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18811,13 +18988,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kQU" = (
@@ -18892,6 +19068,13 @@
 /obj/structure/debris/v4,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"kTJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19197,7 +19380,7 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/structure/table/wood/junk,
+/obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -19485,6 +19668,12 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"liN" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19630,12 +19819,12 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/structure/chair/wood,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "lmG" = (
 /obj/structure/rack,
@@ -19800,6 +19989,11 @@
 /obj/effect/landmark/start/f13/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"lsh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Sheriff's Quarters";
@@ -19944,6 +20138,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"lxs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
+/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20228,8 +20430,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20570,14 +20777,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "lQs" = (
 /obj/structure/fans/tiny{
@@ -20678,6 +20879,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"lUs" = (
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -20752,6 +20962,17 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lWO" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -21256,9 +21477,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "mnU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21599,6 +21820,13 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"mCP" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -21846,6 +22074,13 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mNi" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "mNt" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -21885,6 +22120,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mOS" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -22006,10 +22246,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
-/area/f13/den)
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -22169,6 +22409,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"mYc" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22212,6 +22456,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mZs" = (
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -22293,9 +22542,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22394,10 +22643,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22439,6 +22687,15 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"nfB" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "nfW" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -22708,12 +22965,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"npf" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+"npc" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
+/area/f13/den)
+"npf" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -22813,13 +23076,9 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -23047,6 +23306,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
+"nye" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt{
@@ -23064,11 +23334,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23104,6 +23377,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"nzO" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23178,6 +23460,13 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"nBV" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "nCl" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
@@ -23239,21 +23528,16 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "nEP" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
@@ -23336,8 +23620,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
 /obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nGN" = (
 /obj/machinery/light/small{
@@ -23380,27 +23670,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "nHM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23454,12 +23731,9 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23782,16 +24056,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"nUx" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -23973,10 +24237,10 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -24046,6 +24310,14 @@
 /obj/machinery/workbench/advanced,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"ocq" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
+/area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24264,6 +24536,13 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
+"ohx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -24538,6 +24817,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"opa" = (
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
@@ -24737,6 +25026,15 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"owJ" = (
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -24881,9 +25179,13 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
@@ -25395,16 +25697,11 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/area/f13/sewer)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -25463,6 +25760,14 @@
 "oYG" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"oYU" = (
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 21
+	},
+/turf/open/water,
+/area/f13/den)
 "oZx" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt{
@@ -25797,8 +26102,18 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -26268,12 +26583,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26313,11 +26626,17 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -26493,8 +26812,9 @@
 /turf/closed/wall/rust,
 /area/f13/building)
 "pJN" = (
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
@@ -26510,8 +26830,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
@@ -26689,9 +27011,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -26824,11 +27148,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"pSU" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable{
@@ -27228,6 +27547,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
+"qfj" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -27326,6 +27652,25 @@
 /obj/item/stack/sheet/prewar,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"qia" = (
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -27406,6 +27751,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"qjN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -27417,6 +27768,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"qjU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -27703,11 +28064,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -27813,6 +28170,26 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qxm" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -27996,6 +28373,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qDc" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28025,6 +28408,17 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
+"qEH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/structure/spider/stickyweb,
@@ -28102,9 +28496,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -28123,12 +28517,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28168,13 +28569,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -28312,14 +28710,10 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
 /area/f13/den)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
@@ -28663,10 +29057,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/caves)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29032,6 +29429,10 @@
 "rjz" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"rjD" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
+/area/f13/den)
 "rjM" = (
 /obj/structure/lattice{
 	layer = 3
@@ -29317,6 +29718,13 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rsi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29711,10 +30119,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/falsewall/rust,
-/obj/structure/decoration/vent/rusty,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29730,6 +30142,14 @@
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
+/area/f13/den)
+"rAd" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30021,12 +30441,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"rGe" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30084,42 +30498,15 @@
 	},
 /area/f13/brotherhood/operations)
 "rIU" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -30278,10 +30665,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
@@ -30453,12 +30842,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/fence/pole_t,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
@@ -30509,25 +30897,12 @@
 /obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
-"rSO" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "rSU" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -30912,6 +31287,11 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"sfM" = (
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -31753,10 +32133,9 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "sIA" = (
 /obj/structure/rack,
@@ -31877,11 +32256,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -31924,11 +32302,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29
 	},
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32164,6 +32552,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sVP" = (
+/obj/structure/rack,
+/obj/item/book/granter/trait/bigleagues,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "sVT" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs/cable/random,
@@ -32329,10 +32724,10 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -32345,23 +32740,32 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/fence/corner{
+	dir = 6
 	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "tdv" = (
@@ -32467,6 +32871,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"thm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -32520,6 +32932,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"tiS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "tjf" = (
 /obj/structure/decoration/vent/rusty{
 	pixel_x = -8;
@@ -32596,9 +33013,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32738,12 +33161,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tqC" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
@@ -32831,17 +33254,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
@@ -32854,9 +33273,11 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "tte" = (
@@ -32885,12 +33306,13 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/water,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
@@ -33066,6 +33488,10 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"tzz" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/books,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33149,6 +33575,18 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"tCl" = (
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/den)
+"tCQ" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33293,9 +33731,9 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "tGL" = (
@@ -33436,6 +33874,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"tKj" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "tKk" = (
 /obj/structure/curtain,
 /obj/structure/lattice/catwalk,
@@ -33524,6 +33969,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"tMr" = (
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -33797,13 +34248,23 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"tXl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/interior,
+/area/f13/den)
 "tXr" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -33953,6 +34414,11 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"ube" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -34048,6 +34514,17 @@
 	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood/rnd)
+"uhB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
 	dir = 8
@@ -34327,12 +34804,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "uqb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table{
+	pixel_x = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
@@ -34449,8 +34929,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red,
+/obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "usp" = (
@@ -34508,8 +34987,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "uuq" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/mob/living/simple_animal/hostile/raider/ranged/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/caves)
 "uur" = (
 /turf/open/floor/f13/wood{
@@ -34543,6 +35024,41 @@
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
+"uvj" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -34554,11 +35070,10 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -34596,6 +35111,12 @@
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
+"uyC" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -34945,14 +35466,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
@@ -35203,6 +35724,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"uUB" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
+/area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -35430,6 +35963,14 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"vbx" = (
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "vbU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
@@ -35485,9 +36026,11 @@
 	},
 /area/f13/den)
 "vcx" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper{
+	health = 400
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "vcC" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -35616,9 +36159,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -35690,6 +36235,14 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/dorms)
+"vjM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/water,
+/area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/pinup_shower{
@@ -35698,12 +36251,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vjW" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -35725,6 +36275,14 @@
 	dir = 1
 	},
 /area/f13/brotherhood/mining)
+"vkj" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -35741,17 +36299,20 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
+"vlM" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -35831,6 +36392,22 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"voL" = (
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35902,13 +36479,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -35954,10 +36529,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -36731,14 +37304,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -36765,9 +37337,9 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/structure/rack/shelf_metal,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "vQs" = (
@@ -36784,12 +37356,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36924,15 +37495,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -36988,10 +37554,11 @@
 /turf/open/floor/plasteel,
 /area/f13/bunker)
 "vWZ" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "vXF" = (
@@ -37258,11 +37825,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -37287,16 +37857,12 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "wir" = (
@@ -37341,12 +37907,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/falsewall/rust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -37413,11 +37975,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
-"wms" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/booth,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37440,6 +37997,12 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
+"woj" = (
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -37464,15 +38027,9 @@
 	},
 /area/f13/den)
 "wpc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -37497,18 +38054,9 @@
 	},
 /area/f13/den)
 "wpF" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
-	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "wqt" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -37542,15 +38090,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"wrg" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -37617,16 +38156,13 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
 /area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -37814,8 +38350,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wzt" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38047,9 +38587,13 @@
 	},
 /area/f13/den)
 "wGF" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "wGG" = (
 /obj/structure/wreck/trash/engine{
 	pixel_x = 9
@@ -38163,6 +38707,31 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"wKN" = (
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
+	},
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -38212,10 +38781,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"wLY" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/rust,
-/area/f13/den)
 "wMb" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -38325,18 +38890,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
-	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "wQb" = (
@@ -38394,13 +38951,6 @@
 /obj/item/trash/f13/steak,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"wRa" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -38635,14 +39185,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -38689,10 +39233,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/water,
 /area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39251,10 +39797,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "xpf" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
@@ -39323,15 +39874,8 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -39409,7 +39953,8 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/machinery/photocopier,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "xtk" = (
@@ -39553,11 +40098,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xwm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "xwr" = (
 /obj/structure/spider/stickyweb,
@@ -39622,6 +40165,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"xzj" = (
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
+	},
+/turf/open/water,
+/area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40235,11 +40785,14 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40284,16 +40837,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVD" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "xVK" = (
 /obj/structure/cable{
@@ -40501,10 +41051,8 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "ycl" = (
 /obj/structure/closet,
@@ -40781,6 +41329,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ylp" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
+	},
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -40808,14 +41364,10 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
 "ylL" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -60819,7 +61371,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 lnr
 lnr
 lnr
@@ -61076,7 +61628,7 @@ vPg
 aoj
 aoj
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -61327,12 +61879,12 @@ lnr
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 aoj
 aoj
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -61585,15 +62137,15 @@ vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 aoj
 aoj
+aoj
 vPg
-vPg
-vPg
-vPg
-vPg
+aoj
+aoj
+aoj
 vPg
 lnr
 lnr
@@ -61846,10 +62398,10 @@ vPg
 vPg
 aoj
 aoj
+aoj
 vPg
 vPg
-vPg
-vPg
+aoj
 aoj
 aoj
 lnr
@@ -62100,13 +62652,13 @@ aoj
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+vPg
 vPg
 aoj
 aoj
-vPg
-vPg
-vPg
-vPg
 aoj
 aoj
 lnr
@@ -62361,8 +62913,8 @@ vPg
 aoj
 aoj
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 aoj
 aoj
@@ -62614,12 +63166,12 @@ vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
 vPg
 aoj
 aoj
-vPg
-vPg
-vPg
 vPg
 aoj
 aoj
@@ -62871,12 +63423,12 @@ vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
 vPg
 aoj
 aoj
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -63132,7 +63684,7 @@ vPg
 aoj
 aoj
 vPg
-vPg
+aoj
 vPg
 aoj
 aoj
@@ -63642,7 +64194,7 @@ lnr
 vPg
 aoj
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -64905,10 +65457,10 @@ dXE
 dXE
 vPg
 vPg
+aoj
+aoj
 vPg
-vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -65167,9 +65719,9 @@ vPg
 vPg
 aoj
 aoj
-vPg
-vPg
-vPg
+aoj
+aoj
+aoj
 aoj
 aoj
 aoj
@@ -65420,11 +65972,11 @@ dXE
 dXE
 dXE
 dXE
+dXE
+dXE
+dXE
 vPg
-vPg
-vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 aoj
@@ -65666,26 +66218,26 @@ dXE
 dXE
 wFD
 wFD
+wFD
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
+mjG
 dXE
-vlu
-vlu
-hFt
-clb
-clb
-dTr
-rzy
-clb
-clb
-dXE
-dXE
-dXE
-dXE
-vPg
-vPg
-vPg
 vPg
 aoj
 aoj
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -65924,27 +66476,27 @@ wFD
 wFD
 wFD
 wFD
-vlu
-vlu
-qGX
-dTr
-dTr
-dTr
-qGX
-pSU
-vsF
-dpu
-wzt
-geR
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+ndz
+vra
+wFD
+mjG
 dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
+aoj
+aoj
+aoj
+aoj
 vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -66180,19 +66732,19 @@ wFD
 lYx
 wFD
 wFD
-wFD
-snI
-snI
-snI
-snI
-snI
-snI
-snI
-wYo
-dpu
-dpu
-jaG
-dpu
+ndz
+oVS
+oVS
+oVS
+oVS
+oVS
+oVS
+oVS
+oVS
+oVS
+vra
+ube
+oVS
 dXE
 dXE
 dXE
@@ -66441,15 +66993,15 @@ kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-wYo
-wYo
-dpu
-jaG
-wzt
-geR
+dHg
+dAO
+dAO
+dAO
+dAO
+oVS
+kTJ
+wFD
+mjG
 dXE
 dXE
 dXE
@@ -66459,7 +67011,7 @@ dXE
 dXE
 dXE
 aoj
-vPg
+dXE
 vPg
 vPg
 vPg
@@ -66691,32 +67243,32 @@ hQE
 uPr
 hQE
 gMZ
-dUO
-bSl
-dUO
-dUO
+ffZ
+eMH
+ffZ
+ffZ
 auj
 auj
 auj
-jaG
-dpu
-auj
-auj
-auj
-auj
-dpu
-auj
-dpu
+bKb
+dqh
+itn
+pCO
+fQB
+mjG
+vra
+wFD
+mjG
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
 dXE
-fQL
-fQL
-fQL
-fQL
-fQL
-fQL
-fQL
-fQL
-vPg
 vPg
 vPg
 vPg
@@ -66944,36 +67496,36 @@ dXE
 dXE
 hQE
 hQE
+hQE
+uPr
 kUN
+qjN
+nJC
 itn
-kUN
-jaG
-jaG
-dpu
-dpu
-dpu
+itn
+itn
 auj
-jaG
-dpu
-jaG
-auj
-dpu
-dpu
-dpu
-dpu
-dpu
-auj
-auj
-rzy
-cSY
-cSY
-cSY
-cSY
-cSY
-cSY
-cSY
-fQL
-vPg
+qjN
+itn
+bKb
+gAy
+itn
+fju
+dzP
+oVS
+ube
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+mjG
+dXE
 mNY
 mNY
 mNY
@@ -67197,39 +67749,39 @@ dXE
 wFD
 wFD
 bbB
-fVm
+buN
 uPr
 uPr
 uPr
-itn
-itn
+uPr
+uPr
 kUN
-ddI
-bdL
-jEr
-jEr
-jEr
-iUU
-auj
-dpu
-dgO
-auj
-dpu
+gza
+eiz
+eLg
+eLg
+eLg
+kIf
 auj
 auj
-auj
-auj
-dpu
-auj
-rzy
-cSY
-cSY
-cSY
-cSY
-cSY
-cSY
-cSY
-fQL
+rsi
+dLC
+itn
+uqb
+dAO
+oVS
+oVS
+oVS
+oVS
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+wFD
+mjG
 mNY
 mNY
 vPg
@@ -67458,35 +68010,35 @@ dXE
 dXE
 hQE
 hQE
-kUN
-kUN
+hQE
+hQE
 kUN
 aqh
-hqt
+iPX
 bzg
 bzg
 bzg
-gwf
+fzD
 auj
-dpu
-dpu
+itn
+itn
+fxX
 auj
-auj
-dpu
-auj
-wzt
-geR
-wzt
-geR
-dXE
-fQL
-fQL
-fQL
-fQL
-miI
-cSY
-cSY
-fQL
+rzy
+wYo
+wYo
+ddv
+ddv
+mjG
+ccg
+mjG
+mjG
+mjG
+mjG
+mjG
+wFD
+wFD
+mjG
 mNY
 vPg
 vPg
@@ -67715,36 +68267,36 @@ dXE
 hQE
 hQE
 hQE
-kUN
-kUN
+hQE
+hQE
 kUN
 aqh
 bzg
 bzg
 wvj
 bzg
-xVD
+kJu
 auj
 auj
-dpu
-dpu
-dpu
-auj
-wYo
-wYo
-wYo
-wYo
-wYo
+lsh
+qtc
+bTE
+qtc
+qtc
+qtc
+qtc
+ddv
+ddv
+pPI
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-aoj
 aoj
 vPg
 xyk
@@ -67972,36 +68524,36 @@ dXE
 hQE
 hQE
 wCB
-kUN
-kUN
+hQE
+hQE
 kUN
 aqh
 bzg
 bzg
+mYc
 bzg
-bzg
-tlZ
-bxH
+wpc
+gWk
+itn
 auj
-auj
-auj
-dpu
-auj
-nGD
-wRa
-pKf
-pKf
-fzj
-bAz
+jaG
+gkm
+uso
+uso
+vsF
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-vPg
 aoj
 vPg
 xyk
@@ -68229,36 +68781,36 @@ dXE
 hQE
 hQE
 hQE
-kUN
-kUN
+hQE
+hQE
 kUN
 aqh
-ezs
+kjh
 bzg
 bzg
-uvI
-xVD
+eZw
+kJu
 auj
 auj
-dpu
+itn
 jaG
-auj
-dpu
-nGD
-qGl
-oBq
-pKf
-fzj
-bAz
+fLy
+dnc
+uso
+cTL
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-dXE
-miI
-dDp
-cSY
-fQL
-aoj
 vPg
 vPg
 xyk
@@ -68479,43 +69031,43 @@ hQE
 hQE
 hQE
 hQE
-kUN
-kUN
-kUN
-wYo
-wYo
-kUN
-kUN
-kUN
-kUN
+snI
+snI
+jqn
+dXE
+dXE
+hQE
+hQE
+hQE
+hQE
 kUN
 aqh
 bzg
 bzg
 bzg
-jHj
-gwf
+gqj
+fzD
 auj
-auj
-dgO
-jaG
-dpu
-dpu
-dUk
-wRa
-pKf
-kIf
-fzj
-bAz
+itn
+itn
+cMf
+gkm
+uso
+sIa
+cTL
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-aoj
 vPg
 vPg
 xyk
@@ -68736,43 +69288,43 @@ dXE
 dXE
 dXE
 dXE
-wYo
-wYo
-wYo
-wLY
+ddv
+ddv
+vlu
+afb
+hQE
+hQE
+hQE
+qTe
+qTe
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-bMI
-fOr
-fOr
-fOr
-fOr
-tst
+daE
+bdL
+bdL
+bdL
+bdL
+tco
 auj
-dpu
+nJC
+itn
 jaG
-dpu
-jaG
-dpu
-nGD
-rQv
-oBq
-kIf
-wZU
-bAz
+fzY
+dnc
+sIa
+ddI
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-aoj
 aoj
 vPg
 xyk
@@ -68992,44 +69544,44 @@ eah
 eah
 eah
 eah
-wYo
-wYo
+eah
+eah
+eah
+eah
+eah
+eah
 hOB
-gMZ
-iDK
+itn
+tiS
 auj
-hOB
-gMZ
-iDK
+tac
 auj
 auj
 auj
 auj
 auj
 auj
+tac
+itn
 auj
-auj
-auj
-dpu
-auj
-dpu
-dpu
-auj
-nGD
-wRa
-pKf
-kIf
+jaG
+gkm
 uso
-bAz
+sIa
+gyu
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-vPg
 aoj
 vPg
 xyk
@@ -69249,44 +69801,44 @@ fIf
 bQP
 fIf
 lBm
-ddg
+ohx
+fIf
+fIf
+fIf
+fIf
+fIf
+auj
+auj
+itn
+itn
+auj
+uOX
+uOX
+uOX
+uOX
+rQv
+itn
+itn
 wYo
-ewe
-fjU
-bMt
-auj
-ewe
-fjU
-bMt
-iDK
-auj
-uOX
-uOX
-uOX
-uOX
-nyG
-dpu
-dpu
-dpu
+wYo
+wYo
 qtc
-geR
-wYo
-wYo
-wYo
-cuS
-cuS
-cuS
+qtc
+qtc
 yiv
-bAz
+qtc
+ddv
+ddv
+jqn
+jqn
+jqn
+jqn
+pPI
+mjG
+wFD
+wFD
+mjG
 dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-fQL
-vPg
 vPg
 vPg
 vPg
@@ -69506,43 +70058,43 @@ eFv
 eFv
 eFv
 eFv
+eFv
+eFv
+eFv
+eFv
+eFv
+eFv
+tac
+itn
+itn
+auj
+nJC
+itn
+auj
+auj
+itn
+auj
+auj
+nJC
 wYo
-wYo
-auj
-uOX
-auj
-auj
-auj
-uOX
-auj
-auj
-jaG
+dCp
 dpu
-auj
-auj
-dpu
-auj
-auj
-jaG
-auj
-dpu
-auj
-wYo
-akT
-dZO
-cuS
-faq
-fLy
-fzj
-bAz
-dXE
-dXE
-dXE
-tur
-miI
-dDp
-dDp
-dXE
+qtc
+lUs
+gkY
+cTL
+qtc
+ddv
+ddv
+jqn
+ddv
+ddv
+ddv
+ddv
+mjG
+wFD
+wFD
+mjG
 dXE
 dXE
 dXE
@@ -69734,64 +70286,64 @@ wFD
 wFD
 mjG
 abB
+eCs
+dPc
+eCs
+eCs
+eFq
+rAd
+fEj
+bMH
+nEP
+fEj
+eFq
+fEj
+eFq
+lFt
+vPv
+hOx
+eCs
+eFq
+eCs
+rAd
+fEj
+nEP
+eCs
+npc
+fEj
+ehL
+fEj
+eCs
+npc
+bvs
+ocq
 fEj
 fEj
+fqB
 fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-hRI
-hRI
 mZU
 gMZ
 auj
 auj
-iDK
-gMZ
-iDK
+itn
+itn
+itn
+tac
 auj
 auj
-gMZ
-xTi
-xTi
-fGK
-fGK
-jaG
-jaG
-auj
-qtc
-geR
+nJC
+nJC
 wYo
-faq
-fLy
-cuS
-gow
-kQO
-wZU
-gkm
+fVm
+nGD
+qtc
+tst
+nGD
+gIt
+qtc
+ddv
+ddv
+jqn
 ddv
 ddv
 ddv
@@ -69991,64 +70543,64 @@ wFD
 wWB
 mjG
 abB
+tCQ
+mOS
+dpl
+tCQ
+hRI
+cJI
+tCQ
+hRI
+tCQ
+qIj
+fis
 hRI
 hRI
+tCQ
 hRI
 hRI
+fdw
+fis
+tCQ
+esc
+tCQ
+esc
+gwf
 hRI
+tCQ
+gDU
+esc
+uVE
+fis
+esc
+esc
+cCO
 hRI
+pJN
 hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-lmD
+vWZ
 fjU
 bMt
 auj
-ewe
-fjU
-bMt
-auj
-auj
-fjU
-fjU
-fjU
-wms
-fjU
 auj
 auj
 auj
-jaG
+itn
 auj
+itn
+itn
+lsh
 wYo
-gow
-kQO
-yiv
-cRY
-wZU
-wZU
-gkm
+bPD
+cTL
+gBM
+mnK
+ddI
+ddI
+qtc
+ddv
+ddv
+jqn
 ddv
 ddv
 ddv
@@ -70120,7 +70672,7 @@ dDp
 dDp
 dDp
 dDp
-eLE
+gtS
 eLE
 "}
 (115,1,1) = {"
@@ -70277,35 +70829,35 @@ kUN
 kUN
 kUN
 hRI
+eGQ
+esc
+dok
+uVE
+gZB
 hRI
-hRI
-gxS
+vbx
 uOX
 auj
 auj
-tac
-uOX
 iDK
-iDK
-iDK
-uOX
-uOX
-uOX
-uOX
-uOX
+hxB
+cdh
+hxB
+cdh
 auj
-auj
-dpu
-dpu
-auj
-wgS
-vVu
-dZO
-fju
-fxi
-dFv
-cRY
-hOx
+itn
+nJC
+oBq
+qEH
+bIT
+aJI
+cTL
+kQO
+jEr
+tXl
+ddv
+ddv
+ddv
 ddv
 ddv
 ddv
@@ -70321,7 +70873,7 @@ mjG
 mjG
 mjG
 mjG
-ylL
+fjJ
 xse
 mjG
 mjG
@@ -70506,97 +71058,97 @@ wFD
 mjG
 aou
 kUN
-nsf
-eTS
-eTS
-nUx
-eTS
-eTS
-eTS
+eay
+fRv
+fRv
+nyG
+fRv
+fRv
+fRv
 kUN
-nJC
-eTS
-eTS
-tsX
-dZO
-eTS
-tsX
-eTS
-eTS
-nJC
-kUN
-eTS
-eTS
-nUx
-eTS
-eTS
 iVF
-nsf
+fRv
+fRv
+kZh
+bIT
+fRv
+kZh
+fRv
+fRv
+iVF
+kUN
+fRv
+fRv
+nyG
+fRv
+fRv
+tqC
+eay
 kUN
 hRI
+gxS
 hRI
+vjW
+esc
+xwm
 hRI
-dCp
+fEW
 gMZ
 iDK
 auj
-iDK
-gMZ
-iDK
-iDK
 auj
 blx
 diR
 diR
-dEl
-dEl
-fyC
-fyC
+bxH
+bxH
+tMr
+tMr
 kUN
-kUN
-kUN
-kUN
-kUN
-kQt
-bAz
-bAz
-bAz
-bAz
-bAz
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
-dXE
+qtc
+bTE
+qtc
+yiv
+qtc
+bdf
+bdf
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
+ddv
 agf
 agf
 cnh
@@ -70763,44 +71315,44 @@ wFD
 mjG
 bzl
 kUN
-nsf
-eTS
-eTS
+eay
+fRv
+fRv
 kUN
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 kUN
-vQn
-eTS
-eTS
+qDc
+fRv
+fRv
 kUN
-eTS
-dZO
+fRv
+bIT
 kUN
-eTS
-eTS
-vQn
+fRv
+fRv
+qDc
 kUN
-eTS
-eTS
-vcx
+fRv
+fRv
+hJy
 wYo
-eTS
-eTS
-nsf
+fRv
+fRv
+eay
 kUN
+esc
 hRI
+esc
+rLJ
+rjD
+eGQ
 hRI
-hRI
-lmD
+vWZ
 fjU
 bMt
 auj
-ewe
-fjU
-bMt
-iDK
 iDK
 blx
 gKU
@@ -70809,13 +71361,13 @@ fmW
 fmW
 gCa
 fjS
-kUN
+wYo
 dPt
 ekQ
 dLn
 efa
 bFe
-hQE
+bdf
 eLE
 eLE
 eLE
@@ -71020,44 +71572,44 @@ wFD
 mjG
 bzl
 kUN
-dIm
+sOm
 nCx
-fzj
+cTL
 kUN
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 kUN
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 kUN
-eTS
-dZO
-pPI
-eTS
-eTS
-eTS
+fRv
+bIT
+dOg
+fRv
+fRv
+fRv
 kUN
-eTS
-eTS
+fRv
+fRv
 kUN
 wYo
-eTS
-eTS
-nsf
+fRv
+fRv
+eay
 kUN
 hRI
-hRI
+esc
+esc
+xzj
+jxS
+rjD
 hRI
 mZU
 uOX
 auj
 auj
-iDK
-uOX
-auj
-iDK
 iDK
 blx
 gKU
@@ -71066,13 +71618,13 @@ gCa
 bmJ
 gCa
 gCa
-blx
+wjM
 xXZ
 tBY
 xbj
 gJz
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -71277,59 +71829,59 @@ wWB
 mjG
 agK
 kUN
-wPZ
-fzj
-fzj
+dZO
+cTL
+cTL
 kUN
-eTS
-eTS
-eTS
-pjR
+fRv
+fRv
+fRv
+epg
 cAU
 cAU
 cAU
-dAO
-dZO
-dZO
+eup
+bIT
+bIT
 cKb
 cAU
 cAU
 cAU
 kUN
-eTS
-eTS
-lFt
+fRv
+fRv
+xsf
 wYo
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 kUN
+rjD
+uVE
 hRI
+esc
+wZU
+cCO
 hRI
-hRI
-mZU
-auj
+tCl
+iDK
 auj
 iDK
 auj
-auj
-auj
-auj
-auj
 kDG
-oVS
+dli
 okb
 dyB
 gCa
 gCa
 gCa
-blx
+wYo
 mbT
 jyQ
 flC
 efa
 aLf
-mnK
+nHE
 eLE
 yhT
 yhT
@@ -71533,60 +72085,60 @@ bbB
 bbB
 mjG
 aEg
-bqI
+vkI
 uII
 uII
 uII
 dtr
-dZO
-dZO
-wpc
+bIT
+bIT
+nye
 lAv
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 aqW
-dZO
-eTS
+bIT
+fRv
 aqW
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 aqW
-eTS
-eTS
+fRv
+fRv
 kUN
 wYo
 dWg
-sMl
-caw
+vlM
+nHM
 kUN
 hRI
-hRI
+eGQ
+esc
+esc
+esc
+oYU
 hRI
 qFJ
-auj
-auj
+gmI
 iDK
+uDa
 iDK
+bPB
+cjg
 auj
-auj
-uDa
-uDa
-ekK
-jBt
-gMZ
 cbQ
 bIC
 gCa
 gCa
-blx
+wYo
 cij
 hlg
 bTE
 efa
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -71790,60 +72342,60 @@ bbB
 bbB
 mjG
 mjG
-tda
-eTS
-eTS
-eTS
+wif
+fRv
+fRv
+fRv
 aqW
-dZO
-eTS
-eTS
-dZO
-eTS
-eTS
-eTS
-eTS
+bIT
+fRv
+fRv
+bIT
+fRv
+fRv
+fRv
+fRv
 hlO
-bhO
-bhO
-bhO
-bhO
-bhO
-bhO
+dTG
+dTG
+dTG
+dTG
+dTG
+dTG
 hlO
-eTS
+fRv
 kUN
 wYo
 nCx
-pBk
+flP
 ooI
 kUN
+eGQ
+rjD
 hRI
-hRI
+uVE
+esc
+uVE
 hRI
 bLc
-auj
-auj
-auj
 iDK
-auj
-gJA
-vBZ
-bVO
-pCO
-gHU
+uDa
+tUT
+gmI
+rSU
+wIN
 dTK
 bMt
 pxK
 gCa
-gCa
-blx
+wYl
+wYo
 wLR
 kLD
 txw
 efa
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -72047,60 +72599,60 @@ wFD
 wWB
 mjG
 bzl
-bhO
-bhO
-bhO
-bhO
-nEK
-bhO
-bhO
-bhO
-dHg
-dHg
-dHg
-bhO
-bhO
-bhO
+dTG
+dTG
+dTG
+dTG
+lWO
+dTG
+dTG
+dTG
+wzt
+wzt
+wzt
+dTG
+dTG
+dTG
 fXU
-fXU
+exf
 eiS
-gBM
-dGU
 fXU
-bhO
-eTS
+exf
+fXU
+dTG
+fRv
 aqQ
 wYo
-aQw
-fzj
+bhO
+cTL
 lVK
 kUN
+hRI
+rjD
+hRI
+hRI
 hRI
 hRI
 hRI
 mZU
 auj
-auj
-iDK
-auj
-iDK
-lCp
-gvC
+gJA
+vBZ
 fjA
-pCO
-fPt
+rSU
+pjR
 dyu
 bMt
 bIC
 gCa
 kNM
-blx
+wYo
 kOS
 ekQ
 dke
 efa
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -72304,60 +72856,60 @@ wFD
 wWB
 mjG
 bzl
-eTS
+fRv
 egc
-eTS
-eTS
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
+fRv
+fRv
 egc
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
 egc
-eTS
-dHg
+fRv
+wzt
 fXU
 iFg
 okH
 maO
 rvK
 fXU
-bhO
-eTS
-eTS
+dTG
+fRv
+fRv
 kUN
 vct
 vct
 vct
 kUN
-tus
-tus
-tus
-tus
-tus
+vjM
+vjM
+vjM
+vjM
+vjM
 fsN
 gNZ
 auj
 fUQ
 lCp
 tUT
-vBZ
-pCO
+iDK
+rSU
 cjg
-dyu
+qia
 dxH
 bIC
 gCa
-gCa
-blx
+wYl
+wYo
 xXZ
 wQp
 xbj
 efa
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -72566,29 +73118,29 @@ kUN
 kUN
 kUN
 kUN
-dAO
+eup
 kUN
 kUN
 kUN
 kUN
 kUN
-pJN
-eTS
-bhO
-ndz
+fpD
+fRv
+dTG
+aPF
 kbT
 uVE
 eyK
 ghs
-bKb
-bhO
-bhO
-bhO
+lQm
+dTG
+dTG
+dTG
 fUv
-eTS
-eTS
-eTS
-dqh
+fRv
+fRv
+fRv
+nzO
 xdj
 xdj
 xdj
@@ -72600,21 +73152,21 @@ iDK
 jLx
 cAC
 gVL
-gVL
-pCO
+tKj
+rSU
 wIN
-vWZ
+iDK
 hOB
 bIC
 gCa
 gCa
-blx
+wYo
 mbT
 bIh
 pHQ
 efa
 crb
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -72830,22 +73382,22 @@ kUN
 kUN
 kUN
 kUN
-eTS
+fRv
 cBZ
 fXU
 bUh
-dPc
-vfF
+dUk
+fpT
 bhu
 fXU
-bhO
-bhO
-bhO
+dTG
+dTG
+dTG
 fUv
-eTS
-eTS
-eTS
-sMl
+fRv
+fRv
+fRv
+vlM
 xdj
 xdj
 xdj
@@ -72859,19 +73411,19 @@ auj
 auj
 blx
 qQR
-fjH
+wGF
 fjH
 fjH
 bmJ
 gCa
 gCa
-qQR
-cuS
-cuS
-cuS
+dAO
+qtc
+qtc
+qtc
 efa
 efa
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -73077,8 +73629,8 @@ mjG
 vgV
 kUN
 kUN
-ehL
-dok
+dGU
+nbd
 gCa
 gCa
 kUN
@@ -73086,23 +73638,23 @@ gCa
 gCa
 gCa
 gCa
-nUx
-eTS
-dHg
+nyG
+fRv
+wzt
 fXU
-ajO
+dhF
 uVE
 eyK
-tqC
+bPA
 fXU
-bhO
-bhO
-bhO
+dTG
+dTG
+dTG
 fUv
-eTS
-bHI
-eTS
-eTS
+fRv
+tGq
+fRv
+fRv
 xdj
 xdj
 xdj
@@ -73114,21 +73666,21 @@ iDK
 fjh
 iDK
 auj
-pCO
-kJu
+rSU
+wgS
 aVZ
 gCa
 gCa
 juA
 gCa
 gCa
-blx
+wYo
 ibY
 gVp
 fVQ
-cuS
+qtc
 cbu
-hQE
+bdf
 eLE
 yhT
 yhT
@@ -73334,27 +73886,27 @@ mjG
 vgV
 kUN
 kUN
-qXj
+mZs
 cUt
 dyH
 dLs
 kUN
-dFt
-fRv
-kKb
+xtg
+cXP
+eWL
 gCa
-hxB
-eTS
-dHg
-dli
-gyu
-ixi
-qMr
-wuU
+qFM
+fRv
+wzt
+nEK
+qGl
+vkj
+uLP
+uUB
 fXU
-bhO
-eTS
-eTS
+dTG
+fRv
+fRv
 kUN
 kUN
 kUN
@@ -73371,20 +73923,20 @@ iDK
 iDK
 iDK
 auj
-pCO
-kJu
+rSU
+wgS
 aVZ
 gCa
-nZC
+ava
 hri
-xpf
+vVu
 gCa
 bmJ
 exn
 bFe
 uuD
 efa
-emK
+fws
 hQE
 eLE
 yhT
@@ -73591,33 +74143,33 @@ aLB
 vgV
 kUN
 kUN
-vjW
+ylp
 cWc
 dyH
 gCa
 kUN
-dFt
-fRv
-kKb
+xtg
+cXP
+eWL
 gCa
 kUN
-eTS
+fRv
 cBZ
 fXU
+exf
+nEK
 fXU
-dli
-gBM
-fXU
-ndz
-bhO
-eTS
-pJN
+exf
+aPF
+dTG
+fRv
+fpD
 kUN
 kUN
 kUN
 kUN
 kUN
-gWk
+bNI
 fEj
 fEj
 fEj
@@ -73628,7 +74180,7 @@ fjh
 gmI
 iDK
 auj
-pCO
+rSU
 gBD
 aVZ
 gCa
@@ -73641,7 +74193,7 @@ gAy
 efa
 efa
 efa
-wpF
+fPo
 hQE
 eLE
 yhT
@@ -73848,26 +74400,26 @@ mjG
 vgV
 kUN
 kUN
-wjM
+tXd
 gCa
 gCa
-xtg
+dgg
 kUN
-dpl
-eCs
-dIq
+bVO
+akT
+kQt
 gCa
 kUN
-eTS
+fRv
 bwq
-dHg
-bhO
-bhO
-bhO
-bhO
-bhO
+wzt
+dTG
+dTG
+dTG
+dTG
+dTG
 hlO
-eTS
+fRv
 kUN
 kUN
 kUN
@@ -73885,8 +74437,8 @@ fjh
 hOB
 iDK
 auj
-pCO
-kJu
+rSU
+wgS
 aVZ
 gCa
 gCa
@@ -73894,11 +74446,11 @@ gCa
 gMt
 gCa
 bmJ
-nHM
+uhB
 efa
 ucR
 efa
-fPo
+fyC
 hQE
 eLE
 yhT
@@ -74110,34 +74662,34 @@ kUN
 ohV
 kUN
 kUN
-dFt
-fRv
-kKb
+xtg
+cXP
+eWL
 gCa
 kUN
-eTS
-eTS
-eTS
-dZO
-wpc
-eTS
-eTS
-eTS
-eTS
-eTS
+fRv
+fRv
+fRv
+bIT
+nye
+fRv
+fRv
+fRv
+fRv
+fRv
 kUN
 kUN
 ddx
-uLP
-nHE
+xTi
+gHU
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-dEL
-xwm
+gow
+dVW
 fjh
 iDK
 tZP
@@ -74367,26 +74919,26 @@ gCa
 gCa
 eiA
 gCa
-dFt
-fRv
-kKb
+xtg
+cXP
+eWL
 gCa
 cKb
 dWg
-eTS
-kZh
-eTS
-eTS
-eTS
-wrg
-eTS
-eTS
-dLC
-pPI
+fRv
+ezs
+fRv
+fRv
+fRv
+aXd
+fRv
+fRv
+vfF
+dOg
 kUN
-bwW
-czr
-eFq
+bMI
+fUu
+aLA
 kUN
 kUN
 hRI
@@ -74403,12 +74955,12 @@ iDK
 eiA
 gCa
 gCa
-nZC
+ava
 hri
-xpf
+vVu
 gCa
 ibo
-eMH
+owJ
 xac
 psU
 efa
@@ -74629,28 +75181,28 @@ gCa
 gCa
 gCa
 kUN
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-dZO
-eTS
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+bIT
+fRv
 kUN
 kUN
-cYs
-flT
-cJI
+fPt
+lmD
+lxs
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-fis
+bNV
 iDK
 iDK
 iDK
@@ -74671,7 +75223,7 @@ kUN
 wYo
 wYo
 dXE
-hQE
+eLE
 eLE
 eLE
 eLE
@@ -74884,23 +75436,23 @@ gCa
 gCa
 gCa
 gCa
-vkI
+qfj
 kUN
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
-wpc
-eTS
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
+nye
+fRv
 kUN
 kUN
-dpW
-xsf
-xsf
+voL
+faq
+faq
 kUN
 kUN
 hRI
@@ -75144,27 +75696,27 @@ gCa
 fOg
 kUN
 dWg
-eTS
-kZh
-eTS
-eTS
-eTS
-kZh
-eTS
-dZO
-dLC
+fRv
+ezs
+fRv
+fRv
+fRv
+ezs
+fRv
+bIT
+vfF
 kUN
 kUN
-iPX
-yck
-flP
+eKX
+pBk
+jFq
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-tac
+eVt
 gmI
 pVU
 tac
@@ -75400,21 +75952,21 @@ gCa
 gCa
 eJq
 kUN
-eTS
-eTS
-dzP
-eTS
-eTS
-eTS
-eTS
-eTS
-eTS
+fRv
+fRv
+xpf
+fRv
+fRv
+fRv
+fRv
+fRv
+fRv
 kUN
 kUN
 kUN
-vra
-eFq
-nEP
+thm
+aLA
+qMr
 kUN
 kUN
 hRI
@@ -75647,31 +76199,31 @@ mjG
 vgV
 kUN
 kUN
-bPB
-bPB
-bPB
+fqF
+fqF
+fqF
 kUN
 kUN
 kUN
-nUx
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-anK
-anK
+nyG
 kUN
 kUN
 kUN
 kUN
 kUN
-rSO
-eFq
-eFq
-eFq
-hKN
+kUN
+bve
+bve
+nfB
+kUN
+kUN
+kUN
+kUN
+xVD
+aLA
+aLA
+aLA
+fwZ
 kUN
 kUN
 hRI
@@ -75909,26 +76461,26 @@ qTe
 qTe
 kUN
 dcd
-nbd
-nbd
-nbd
-rGe
-qIj
-uqb
-tco
+emK
+emK
+emK
+woj
+gRa
+aEe
+wPZ
 kUN
-mSP
-eLg
-eLg
+npf
+anK
+anK
 uII
-eLg
+anK
 sTs
 kUN
-fEW
-eFq
-eFq
-eFq
-ffZ
+ekK
+aLA
+aLA
+aLA
+tsX
 kUN
 kUN
 hRI
@@ -76165,27 +76717,27 @@ kUN
 kUN
 kUN
 kUN
-bdf
-nbd
+pKf
+emK
 lwv
-nbd
-uqb
-uqb
-uqb
-fpD
+emK
+aEe
+aEe
+aEe
+tda
 kUN
-fqF
-eLg
-eLg
+dNa
+anK
+anK
 uII
-eLg
-vQw
+anK
+bHI
 kUN
-bMH
-eFq
-eFq
-eFq
-kcf
+eTS
+aLA
+aLA
+aLA
+opa
 kUN
 kUN
 hRI
@@ -76422,27 +76974,27 @@ dDz
 gyB
 sVT
 kUN
-cMf
-nbd
-nbd
-aPF
-cXP
-uqb
-uqb
-gDU
+wuU
+emK
+emK
+fxi
+mCP
+aEe
+aEe
+aQw
 kUN
-bEV
-eLg
-eLg
-uII
-eLg
-eLg
-fUu
-eFq
-eFq
-eFq
-eFq
-rIU
+gQW
+anK
+anK
+cRY
+anK
+anK
+ehc
+aLA
+aLA
+aLA
+aLA
+gFp
 kUN
 kUN
 hRI
@@ -76676,35 +77228,35 @@ vgV
 kUN
 ciU
 acI
-eay
+cQp
 acI
 kUN
-sIa
-nbd
-nbd
-aPF
-eWL
+eOP
+emK
+emK
+fxi
+tus
 lwv
-uqb
-crx
+aEe
+dpW
 kUN
-tGq
-eLg
-eLg
-vPv
-eLg
+vQn
+anK
+anK
+fyh
+anK
 sTs
 kUN
 kUN
 kUN
 kUN
-nUx
+nyG
 kUN
 kUN
 kUN
 cSY
-rLJ
-aXd
+uvI
+ylL
 xdj
 dXE
 dXE
@@ -76936,27 +77488,27 @@ lLo
 fQz
 cSN
 ltu
-nbd
+emK
 dQG
 lwv
-fnc
+tlZ
 cqu
-nbd
-uqb
-bXn
+emK
+aEe
+ajO
 kUN
 uII
 uII
 uII
 kUN
-eLg
-wYl
+anK
+gvC
 kUN
-bup
+yck
 rqX
 rqX
 rqX
-dsx
+kaQ
 kUN
 kUN
 cSY
@@ -77191,27 +77743,27 @@ kUN
 gyB
 gyB
 gyB
-rSU
+bHA
 kUN
-cTL
-uqb
-nbd
-uqb
-nbd
-nbd
-uqb
-ccg
+bXn
+aEe
+emK
+aEe
+emK
+emK
+aEe
+qjU
 kUN
 eHr
-eLg
-eLg
-eLg
-eLg
-vQw
+anK
+anK
+anK
+anK
+bHI
 kUN
-npf
+dsx
 rqX
-npf
+dsx
 rqX
 rqX
 kUN
@@ -77454,17 +78006,17 @@ cqu
 cqu
 cqu
 cqu
-uqb
-nbd
+aEe
+emK
 lwv
-uqb
-wif
-eLg
-eLg
-eLg
-eLg
-eLg
-eLg
+aEe
+eBU
+anK
+anK
+anK
+anK
+anK
+anK
 kUN
 rqX
 rqX
@@ -77704,7 +78256,7 @@ vgV
 kUN
 acI
 acI
-cQp
+mNi
 acI
 kUN
 kUN
@@ -77717,15 +78269,15 @@ kUN
 kUN
 kUN
 eHr
-eLg
-eLg
-eLg
-eLg
-fxX
+anK
+anK
+anK
+anK
+uyC
 kUN
-lQm
+jIs
 rqX
-npf
+dsx
 rqX
 cLd
 kUN
@@ -77960,8 +78512,8 @@ mjG
 vgV
 kUN
 acI
-fwZ
-daE
+wKN
+tbE
 lyd
 kUN
 kUN
@@ -77977,14 +78529,14 @@ wpa
 sTs
 sTs
 sTs
-eLg
-eLg
+anK
+anK
 ltu
 rqX
 rqX
-dnc
-iDd
-fzD
+qxm
+uvj
+gNv
 kUN
 kUN
 cSY
@@ -78522,7 +79074,7 @@ gSS
 vWd
 dXE
 eLE
-vPg
+aoj
 hYZ
 hkn
 fka
@@ -78733,26 +79285,26 @@ hQE
 hQE
 aoj
 aoj
-bIT
+sMl
 aoj
 aoj
-jqn
+kcf
+vcx
 aoj
 aoj
-aoj
-aoj
+vcx
 aoj
 aoj
 aoj
 aoj
 lAR
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 dXE
 dXE
 hQE
@@ -78779,7 +79331,7 @@ omD
 rtG
 dXE
 eLE
-vPg
+aoj
 hYZ
 jSy
 fka
@@ -78991,13 +79543,13 @@ hQE
 aoj
 aoj
 aoj
+nsf
 emV
-emV
 aoj
 aoj
 aoj
 aoj
-aoj
+uPr
 aoj
 aoj
 aoj
@@ -79009,7 +79561,7 @@ dXE
 dXE
 dXE
 dXE
-mNY
+aoj
 dXE
 dXE
 hQE
@@ -79036,7 +79588,7 @@ omD
 ngX
 dXE
 eLE
-vPg
+aoj
 hYZ
 jSy
 fka
@@ -79248,7 +79800,7 @@ hQE
 dXE
 dXE
 dXE
-dXE
+uPr
 dXE
 dXE
 aoj
@@ -79266,7 +79818,7 @@ dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 dXE
 dXE
 hQE
@@ -79293,7 +79845,7 @@ dXE
 dXE
 dXE
 eLE
-vPg
+aoj
 hYZ
 hkn
 fka
@@ -79503,19 +80055,19 @@ fQL
 hQE
 hQE
 dXE
-dVW
-kjh
-fJp
-uuq
+bAz
+bqI
+cQc
+exN
 dXE
 aoj
+vcx
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
+uPr
+uPr
+wpF
 hQE
 dXE
 dXE
@@ -79523,7 +80075,7 @@ dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 dXE
 dXE
 hQE
@@ -79550,7 +80102,7 @@ uPr
 dXE
 dXE
 eLE
-vPg
+aoj
 hYZ
 hkn
 fka
@@ -79760,7 +80312,7 @@ fQL
 hQE
 hQE
 dXE
-fhe
+daL
 dHw
 dHw
 dHw
@@ -79770,9 +80322,9 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
+ckD
+hKN
+cPI
 hQE
 dXE
 dXE
@@ -79780,7 +80332,7 @@ dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 dXE
 dXE
 hQE
@@ -79807,7 +80359,7 @@ uPr
 dXE
 dXE
 eLE
-vPg
+aoj
 hYZ
 jSy
 fka
@@ -80017,7 +80569,7 @@ fQL
 hQE
 hQE
 dXE
-tXd
+iDd
 dHw
 dHw
 rSB
@@ -80027,9 +80579,9 @@ aoj
 aoj
 aoj
 aoj
-aoj
-aoj
-aoj
+uPr
+cPI
+cbG
 hQE
 dXE
 dXE
@@ -80037,7 +80589,7 @@ dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 dXE
 dXE
 hQE
@@ -80276,7 +80828,7 @@ hQE
 dXE
 dXE
 dXE
-esc
+bEV
 dXE
 dXE
 hQE
@@ -80294,7 +80846,7 @@ hQE
 hQE
 hQE
 hQE
-eLq
+fnc
 hQE
 hQE
 hQE
@@ -80530,37 +81082,37 @@ mjG
 fQL
 hQE
 hQE
-tbE
-gQR
-tbE
-tbE
+jHj
+dIm
+sVP
+bRm
 buN
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 buN
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+ckD
+aoj
+aoj
+aoj
+mSP
+mSP
+mSP
+aoj
+aoj
+aoj
+aoj
 dii
 dii
 dii
 dii
-dNa
+nZC
 dii
-dNa
+nZC
 wFD
 mNE
 wFD
@@ -80581,7 +81133,7 @@ eLE
 vPg
 vPg
 vPg
-vPg
+aoj
 iel
 fka
 iUK
@@ -80787,37 +81339,37 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+jHj
+uuq
+bRm
+bRm
 hQE
 hQE
 hQE
 hQE
-eLq
+fnc
 hQE
-uPr
+aoj
 dXE
 hQE
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
+mSP
+wpF
+mSP
+aoj
+aoj
+aoj
+aoj
 dii
 dii
 dii
 dii
-dNa
+nZC
 dii
-dNa
+nZC
 wFD
 mNE
 wFD
@@ -80837,7 +81389,7 @@ dXE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 wHf
 fka
@@ -81044,17 +81596,17 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+bRm
+vQw
+bRm
 hQE
 hzR
 dHw
 flj
 dHw
 hQE
-uPr
+aoj
 dXE
 hQE
 hQE
@@ -81065,7 +81617,7 @@ hQE
 hQE
 hQE
 hQE
-eLq
+fnc
 hQE
 buN
 hQE
@@ -81301,30 +81853,30 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+bRm
+bRm
+bRm
 hQE
 dHw
 flj
 dHw
-dhF
+sfM
 hQE
-uPr
+aoj
 dXE
 dXE
 dXE
 dXE
 hQE
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-eLq
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+fnc
+aoj
 hQE
 cSY
 cSY
@@ -81558,30 +82110,30 @@ mjG
 fQL
 hQE
 hQE
-tbE
+bRm
 uCP
-tbE
-tbE
+bRm
+bRm
 hQE
 flj
 dHw
 dHw
-qFM
+dTr
 hQE
-uPr
-dXE
-dXE
-dXE
-dXE
-hQE
-uPr
-dXE
+aoj
 dXE
 dXE
 dXE
 dXE
 hQE
-uPr
+aoj
+dXE
+dXE
+dXE
+dXE
+dXE
+hQE
+aoj
 hQE
 cSY
 cSY
@@ -81815,30 +82367,30 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+bRm
+bRm
+bRm
 hQE
 cLS
 dHw
 dHw
 dHw
 hQE
-uPr
-uPr
-uPr
-uPr
-uPr
-eLq
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+fnc
+aoj
 dXE
 dXE
 dXE
 dXE
 dXE
 hQE
-uPr
+aoj
 hQE
 cSY
 cSY
@@ -82072,20 +82624,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-cIZ
-tbE
+bRm
+jPC
+hFt
+jPC
 hQE
 hQE
 hQE
 hQE
-eLq
-hQE
-hQE
-hQE
-hQE
-hQE
+fnc
 hQE
 hQE
 hQE
@@ -82095,7 +82642,12 @@ hQE
 hQE
 hQE
 hQE
-uPr
+hQE
+hQE
+hQE
+hQE
+hQE
+aoj
 hQE
 cSY
 cSY
@@ -82122,7 +82674,7 @@ dXE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 jSy
@@ -82329,30 +82881,30 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+jPC
+jzO
+tzz
 hQE
 dXE
 dXE
 dXE
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 hQE
 cSY
 cSY
@@ -82379,7 +82931,7 @@ dXE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 jSy
@@ -82586,15 +83138,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+jPC
+lzb
+uqE
 hQE
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
 dXE
 dXE
 dXE
@@ -82637,7 +83189,7 @@ eLE
 aoj
 vPg
 vPg
-vPg
+aoj
 vPg
 jSy
 jSy
@@ -82843,15 +83395,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-gQR
-tbE
+bRm
+jPC
+wDa
+gSS
 hQE
-uPr
+aoj
 hQE
 hQE
-eLq
+fnc
 hQE
 hQE
 hQE
@@ -82894,7 +83446,7 @@ eLE
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 yhT
 jSy
@@ -83100,15 +83652,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+lQz
+uqE
+ncJ
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 dXE
 dXE
@@ -83150,8 +83702,8 @@ dXE
 eLE
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 yhT
 yhT
@@ -83357,15 +83909,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+rCl
+fxD
+gSS
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -83614,15 +84166,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+ngX
+dXE
+dXE
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 fLU
 eCe
 pYd
@@ -83664,7 +84216,7 @@ dXE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 yhT
@@ -83871,15 +84423,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+lNw
+jPC
+jPC
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 fLU
 pYd
 eEt
@@ -83921,7 +84473,7 @@ dXE
 eLE
 aoj
 vPg
-vPg
+aoj
 vPg
 vPg
 yhT
@@ -84128,15 +84680,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+dFt
+bRm
+rIU
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 fLU
 pYd
 eFi
@@ -84179,8 +84731,8 @@ eLE
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 yhT
 yhT
 yhT
@@ -84385,15 +84937,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
-tbE
-tbE
+bRm
+bRm
+bRm
+nBV
 hQE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 fLU
 pYd
 eHs
@@ -84435,10 +84987,10 @@ dXE
 eLE
 vPg
 vPg
+aoj
+aoj
 vPg
-vPg
-vPg
-yhT
+aoj
 yhT
 yhT
 yhT
@@ -84639,18 +85191,18 @@ mjG
 wFD
 wFD
 dtk
-fQL
+qXj
 nEz
-tbE
-tbE
-tbE
-tbE
-tbE
-eLq
-uPr
+uCP
+bSl
+bRm
+bRm
+bRm
+fnc
+ckD
 hQE
 dXE
-uPr
+aoj
 fLU
 pYd
 pYd
@@ -84692,11 +85244,11 @@ dXE
 eLE
 vPg
 vPg
+aoj
+aoj
 vPg
-vPg
-vPg
-yhT
-yhT
+aoj
+aoj
 yhT
 yhT
 yhT
@@ -84904,10 +85456,10 @@ nEz
 hQE
 hQE
 hQE
-uPr
+ckD
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -84949,11 +85501,11 @@ dXE
 eLE
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 yhT
 yhT
@@ -85156,15 +85708,15 @@ mjG
 fQL
 hQE
 hQE
-tbE
-tbE
+bRm
+bRm
 hQE
 dXE
 dXE
 uPr
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -85206,12 +85758,12 @@ dXE
 eLE
 vPg
 aoj
-vPg
+aoj
 yhT
 yhT
 vPg
 vPg
-vPg
+aoj
 yhT
 yhT
 vxs
@@ -85414,14 +85966,14 @@ fQL
 hQE
 hQE
 gQR
-tbE
+bRm
 hQE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -85464,12 +86016,12 @@ eLE
 vPg
 vPg
 vPg
-yhT
+aoj
 yhT
 vPg
 vPg
-vPg
-yhT
+aoj
+aoj
 yhT
 vxs
 vxs
@@ -85670,15 +86222,15 @@ bbB
 fQL
 hQE
 hQE
-tbE
-tbE
+bRm
+bRm
 hQE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -85721,12 +86273,12 @@ eLE
 vPg
 aoj
 vPg
-yhT
+aoj
 yhT
 vPg
 vPg
-vPg
-yhT
+aoj
+aoj
 yhT
 yhT
 yhT
@@ -85927,15 +86479,15 @@ bbB
 fQL
 hQE
 hQE
-tbE
-tbE
+bRm
+bRm
 hQE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 pYd
@@ -85978,13 +86530,13 @@ eLE
 vPg
 vPg
 vPg
-yhT
+aoj
 yhT
 vPg
 vPg
-vPg
+aoj
 yhT
-yhT
+aoj
 yhT
 yhT
 vxs
@@ -86184,15 +86736,15 @@ bbB
 fQL
 hQE
 hQE
-tbE
-tbE
+bRm
+bRm
 hQE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 gFC
 eCe
@@ -86235,13 +86787,13 @@ eLE
 vPg
 aoj
 aoj
-yhT
+aoj
 yhT
 vPg
 vPg
-vPg
+aoj
 yhT
-yhT
+aoj
 yhT
 yhT
 vxs
@@ -86441,15 +86993,15 @@ mjG
 fQL
 hQE
 hQE
-eLq
+fnc
 hQE
 hQE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 hQE
 dXE
@@ -86496,7 +87048,7 @@ yhT
 yhT
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -86698,15 +87250,15 @@ mjG
 fQL
 hQE
 hQE
-uPr
+aoj
 dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 hQE
 dXE
@@ -86753,9 +87305,9 @@ yhT
 yhT
 vPg
 vPg
-vPg
-vPg
-vPg
+aoj
+aoj
+aoj
 vPg
 dXE
 vxs
@@ -86955,15 +87507,15 @@ mjG
 fQL
 hQE
 hQE
-uPr
+aoj
 dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 hQE
 dXE
@@ -87212,15 +87764,15 @@ mjG
 fQL
 hQE
 hQE
-uPr
+aoj
 dXE
 dXE
 dXE
 dXE
-uPr
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 hQE
 dXE
@@ -87469,15 +88021,15 @@ mjG
 fQL
 hQE
 hQE
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 hQE
 dXE
-uPr
+aoj
 hQE
 hQE
 dXE
@@ -87727,7 +88279,7 @@ fQL
 hQE
 hQE
 hQE
-eLq
+fnc
 hQE
 hQE
 hQE
@@ -87755,8 +88307,8 @@ dXE
 dXE
 dXE
 dXE
-wGF
-sOm
+dEL
+liN
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,13 +302,12 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -335,16 +334,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
@@ -421,7 +416,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
-/obj/structure/simple_door/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -515,47 +509,24 @@
 	},
 /area/f13/brotherhood/rnd)
 "aqQ" = (
-/obj/structure/sign/poster/official/build,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -1003,8 +974,14 @@
 	},
 /area/f13/tunnel)
 "aEe" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1185,10 +1162,12 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "aKc" = (
@@ -1255,6 +1234,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"aLA" = (
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1347,13 +1335,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
 /area/f13/den)
 "aPG" = (
@@ -1380,9 +1366,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "aQU" = (
@@ -1575,8 +1560,11 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
@@ -1833,10 +1821,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
-/turf/open/floor/carpet/green,
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1870,7 +1865,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
+/obj/structure/sign/poster/contraband/pinup_pink,
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bdY" = (
@@ -2002,11 +1997,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2136,14 +2128,10 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2338,8 +2326,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -2512,12 +2501,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
 	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -2540,8 +2528,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -2552,12 +2545,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
@@ -2613,6 +2604,19 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bwW" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/barber{
@@ -2651,11 +2655,9 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2738,16 +2740,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
+/obj/structure/fence{
 	dir = 1
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2941,11 +2941,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -3016,23 +3017,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHA" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
 	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "bHI" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
@@ -3088,6 +3091,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -3148,6 +3152,23 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bKb" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -3211,15 +3232,25 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"bMH" = (
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = "denmedshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "bMI" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
 	dir = 8;
-	pixel_x = -20
+	pixel_y = -7
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
@@ -3250,9 +3281,8 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "bNI" = (
-/obj/structure/sign/poster/contraband/power,
-/obj/structure/simple_door/wood,
-/turf/open/space/basic,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
@@ -3265,7 +3295,12 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3329,6 +3364,30 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"bPA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
+"bPB" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
+"bPD" = (
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3383,6 +3442,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bRm" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3589,8 +3653,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
@@ -3618,6 +3688,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"bXn" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3714,17 +3788,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "caw" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3770,12 +3837,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -3795,11 +3864,10 @@
 /area/f13/tunnel)
 "cbQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "cbX" = (
 /obj/structure/lattice{
@@ -3828,11 +3896,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
+/obj/structure/barricade/bars,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -3894,10 +3962,10 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4063,9 +4131,9 @@
 	},
 /area/f13/bunker)
 "ciU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "cjc" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/stripes/white/line,
@@ -4133,10 +4201,11 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/water,
+/area/f13/caves)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4355,8 +4424,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4462,11 +4531,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4566,11 +4634,10 @@
 	},
 /area/f13/tunnel)
 "cxY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4625,6 +4692,11 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"czr" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4733,14 +4805,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4861,9 +4931,9 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/item/clothing/gloves/boxing,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
@@ -5039,9 +5109,19 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"cIZ" = (
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"cJI" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
@@ -5147,8 +5227,12 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/caves)
 "cMJ" = (
 /obj/structure/table/wood/settler,
@@ -5200,19 +5284,17 @@
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
 "cQc" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/machinery/microwave{
+	pixel_x = -6
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
@@ -5220,12 +5302,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
@@ -5336,18 +5417,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "cTL" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5513,10 +5583,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5546,8 +5616,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/caves)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5608,18 +5680,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "daL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5706,8 +5778,12 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5732,12 +5808,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
@@ -5776,6 +5855,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"dgO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5803,8 +5887,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5956,13 +6044,33 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6062,21 +6170,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6121,13 +6216,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6160,21 +6251,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/sign/poster/official/build,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dpu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_y = -1;
 	pixel_x = -31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6188,14 +6279,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dqh" = (
 /obj/structure/spider/stickyweb,
@@ -6274,10 +6362,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6499,10 +6587,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6623,11 +6708,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6675,9 +6762,14 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6690,13 +6782,16 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
@@ -6727,15 +6822,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/books,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/caves)
 "dFv" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/area/f13/sewer)
+/turf/open/water,
+/area/f13/den)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6760,6 +6859,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"dGU" = (
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
+	},
+/turf/open/water,
+/area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
@@ -6767,12 +6873,10 @@
 	},
 /area/f13/bunker)
 "dHg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
@@ -6793,12 +6897,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "dIo" = (
 /obj/structure/cable{
@@ -6807,10 +6908,17 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
+/obj/machinery/door/poddoor/shutters{
+	id = "denmedshutters"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "dII" = (
@@ -6921,18 +7029,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/turf/open/water,
 /area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
@@ -6972,11 +7073,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
 /area/f13/den)
 "dNb" = (
@@ -7036,14 +7137,10 @@
 /area/f13/bunker)
 "dOg" = (
 /obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	pixel_y = -16
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -7083,40 +7180,9 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "dPo" = (
@@ -7260,12 +7326,19 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 1;
-	pixel_y = 23
+	layer = 3.1
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
@@ -7277,18 +7350,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "dennorthshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
@@ -7311,10 +7375,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7334,17 +7398,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dUO" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
@@ -7431,14 +7490,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7558,16 +7620,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7608,13 +7665,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7834,7 +7890,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
-/turf/open/floor/grass,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
@@ -7863,13 +7924,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "ehe" = (
@@ -7907,16 +7964,10 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7926,12 +7977,13 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -8053,11 +8105,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirty"
+	dir = 8;
+	icon_state = "greenrusty"
 	},
 /area/f13/den)
 "ekQ" = (
@@ -8190,6 +8245,14 @@
 /obj/item/card/id/dogtag/enclave/noncombatant,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
+"epg" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 16;
@@ -8275,12 +8338,8 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/chair/wood,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "esg" = (
 /obj/item/flag/bos,
@@ -8376,8 +8435,14 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8429,10 +8494,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "ewe" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -8451,20 +8516,12 @@
 /turf/open/floor/grass,
 /area/f13/den)
 "exg" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8514,6 +8571,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"exN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8553,14 +8616,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8609,15 +8671,11 @@
 	},
 /area/f13/building)
 "eBU" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "eBZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8638,13 +8696,8 @@
 /area/f13/tcoms)
 "eCs" = (
 /obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
@@ -8769,8 +8822,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/structure/falsewall/rust,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8819,10 +8874,8 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
@@ -8945,6 +8998,9 @@
 "eJq" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/f13/dendoctor,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
@@ -8985,14 +9041,12 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -9008,17 +9062,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
-"eLq" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
-/turf/open/floor/carpet/green,
+/area/f13/den)
+"eLq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9072,8 +9130,9 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9161,12 +9220,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "ePe" = (
@@ -9340,8 +9400,8 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
@@ -9392,6 +9452,14 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"eVt" = (
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9422,6 +9490,10 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"eWL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -9522,26 +9594,13 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
-	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "faq" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9601,12 +9660,13 @@
 /area/f13/sewer)
 "fdw" = (
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "fdG" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
@@ -9666,13 +9726,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9732,17 +9794,12 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
@@ -9758,11 +9815,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/caves)
+/area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9781,12 +9839,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9811,7 +9869,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/turf/closed/indestructible/f13/matrix,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "fjL" = (
 /obj/structure/grille,
@@ -9876,17 +9935,14 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/barricade/bars,
+/turf/open/water,
 /area/f13/caves)
 "flT" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9929,19 +9985,12 @@
 	},
 /area/f13/clinic)
 "fmW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fnc" = (
-/obj/structure/table{
-	pixel_x = 6
-	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -10038,8 +10087,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -10062,6 +10115,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"fpT" = (
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -10082,25 +10140,12 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"fqB" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "fqF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10288,13 +10333,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
 /area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
@@ -10314,9 +10358,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
+"fxi" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -10332,7 +10382,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
@@ -10348,16 +10399,15 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/area/f13/caves)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable{
@@ -10388,9 +10438,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10419,14 +10471,31 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fzD" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "fzP" = (
@@ -10445,13 +10514,10 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/water,
-/area/f13/den)
+/area/f13/sewer)
 "fAi" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -10629,7 +10695,7 @@
 /area/f13/tunnel)
 "fGK" = (
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -10734,11 +10800,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10794,6 +10862,23 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"fLy" = (
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fLK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -10898,15 +10983,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -10942,8 +11020,13 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fPt" = (
 /obj/structure/barricade/bars{
@@ -10996,9 +11079,13 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -11151,11 +11238,8 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -11193,12 +11277,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "fVA" = (
@@ -11264,9 +11351,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -11535,9 +11620,16 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "geR" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
@@ -11682,11 +11774,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
@@ -11783,8 +11874,10 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11832,9 +11925,9 @@
 /area/f13/bunker)
 "gqj" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "gqt" = (
@@ -12006,12 +12099,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floordirty"
 	},
 /area/f13/den)
 "gvL" = (
@@ -12022,8 +12114,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -12061,14 +12156,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
+/obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "gxY" = (
@@ -12089,10 +12179,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/area/f13/den)
+/area/f13/sewer)
 "gyB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_large,
@@ -12115,12 +12206,15 @@
 	},
 /area/f13/bunker)
 "gza" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
@@ -12195,13 +12289,21 @@
 	pixel_x = 2;
 	pixel_y = 32
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12294,6 +12396,12 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"gDU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -12334,11 +12442,9 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -12436,9 +12542,15 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -12466,15 +12578,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gIt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12500,10 +12608,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "gJz" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "gJA" = (
 /obj/structure/chair/stool/retro/black,
@@ -12575,10 +12688,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gMt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "gMw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -12612,13 +12726,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/water,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
@@ -12724,17 +12835,22 @@
 	},
 /area/f13/caves)
 "gQW" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light/floor{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "gRa" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12903,10 +13019,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13377,10 +13494,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "hlO" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13511,21 +13627,18 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/caves)
-"hri" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
 /area/f13/den)
+"hri" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "hrM" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -13700,10 +13813,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13836,8 +13952,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13959,6 +14077,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
+"hJy" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -14149,17 +14271,12 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14618,17 +14735,11 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -15088,10 +15199,42 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -15260,8 +15403,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
 /turf/open/water,
 /area/f13/den)
 "ixD" = (
@@ -15406,10 +15549,14 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15621,9 +15768,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
@@ -15776,10 +15929,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
@@ -15937,10 +16091,6 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"iUU" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/stage_t,
@@ -15968,10 +16118,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
@@ -16159,8 +16310,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16185,6 +16336,16 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jbM" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -16695,10 +16856,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "juA" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
@@ -16787,17 +16948,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jxS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
@@ -16910,6 +17068,11 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"jBt" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16971,13 +17134,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17018,11 +17178,40 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -17070,11 +17259,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "jHI" = (
 /obj/structure/bookcase/random,
@@ -17097,6 +17283,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jIs" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17682,11 +17879,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "kbf" = (
@@ -17767,14 +17964,26 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
 	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18019,6 +18228,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"kjh" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18813,12 +19030,13 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
 	},
@@ -18854,9 +19072,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
-/turf/open/floor/carpet/red,
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -18889,12 +19114,9 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "kKs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -19022,13 +19244,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -19042,13 +19260,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kQU" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -19123,7 +19341,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
 /turf/open/water,
 /area/f13/den)
 "kTO" = (
@@ -19431,12 +19650,10 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
 /area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
@@ -19722,12 +19939,10 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
@@ -19874,13 +20089,13 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "lmG" = (
 /obj/structure/rack,
@@ -20046,14 +20261,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20182,12 +20396,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -20199,6 +20413,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"lxs" = (
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20218,6 +20437,7 @@
 /area/f13/brotherhood/operations)
 "lyd" = (
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/floor,
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "lyh" = (
@@ -20483,11 +20703,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20827,6 +21047,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"lQm" = (
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -20927,29 +21155,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21026,10 +21241,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -21534,12 +21748,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "mnU" = (
@@ -21882,6 +22093,10 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"mCP" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -22130,12 +22345,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "mNt" = (
@@ -22178,9 +22391,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "mPe" = (
@@ -22304,20 +22520,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_y = -1;
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
@@ -22479,9 +22683,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mYc" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22526,11 +22730,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
@@ -22613,9 +22818,14 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22714,10 +22924,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23044,12 +23257,14 @@
 	name = "strong metal bars";
 	obj_integrity = 800
 	},
-/turf/open/floor/carpet/red,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "npf" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -23148,16 +23363,11 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
@@ -23387,10 +23597,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt{
@@ -23408,7 +23624,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -23448,13 +23664,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/obj/machinery/light{
+/obj/structure/fence{
 	dir = 1
 	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23597,27 +23814,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"nEP" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
+"nEK" = (
+/obj/structure/stairs/west,
 /turf/open/floor/carpet/green,
 /area/f13/den)
+"nEP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "nFc" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/fulltile/store,
@@ -23652,9 +23858,10 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23704,7 +23911,6 @@
 /area/f13/enclave)
 "nGD" = (
 /obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nGN" = (
@@ -23748,20 +23954,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "nHM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/area/f13/sewer)
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/drone,
@@ -23814,11 +24030,12 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24142,11 +24359,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
@@ -24329,15 +24550,11 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = "denmedshutters"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -24409,12 +24626,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24635,17 +24852,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
@@ -24922,9 +25130,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25126,18 +25339,10 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
@@ -25283,9 +25488,9 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
@@ -25797,10 +26002,10 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
+/obj/structure/chair/wood{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "oWc" = (
@@ -26203,11 +26408,15 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -26677,15 +26886,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26725,9 +26930,13 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood,
+/obj/item/pda,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -26902,6 +27111,10 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
 /area/f13/building)
+"pJN" = (
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -26917,9 +27130,17 @@
 /area/f13/building)
 "pKf" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -27096,12 +27317,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/water,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -27236,22 +27457,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "pTC" = (
@@ -27654,9 +27865,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27757,16 +27972,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
@@ -27849,15 +28060,9 @@
 	},
 /area/f13/bunker)
 "qjN" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
@@ -27871,9 +28076,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
@@ -28268,9 +28476,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
@@ -28456,12 +28667,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qDw" = (
 /obj/structure/window/reinforced,
@@ -28493,11 +28710,16 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/structure/spider/stickyweb,
@@ -28575,11 +28797,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/water,
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
@@ -28599,14 +28826,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/barricade/wooden/strong,
@@ -28645,13 +28868,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -28789,6 +29012,7 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -29015,9 +29239,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/tunnel,
@@ -29136,10 +29359,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29795,13 +30021,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rsi" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
@@ -30197,11 +30423,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30220,24 +30445,17 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30530,11 +30748,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
@@ -30592,6 +30812,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"rIU" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -30750,8 +30975,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -30924,11 +31157,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
 	},
-/area/f13/caves)
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -30979,20 +31225,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rSU" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31243,14 +31487,11 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "saS" = (
 /obj/item/mine/shrapnel,
 /turf/open/water,
@@ -31378,9 +31619,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "sfM" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32222,6 +32463,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"sIa" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -32341,8 +32590,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -32385,6 +32641,11 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"sOm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32558,6 +32819,9 @@
 /area/f13/tunnel)
 "sTs" = (
 /obj/structure/rack/shelf_metal,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -32792,14 +33056,13 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "tbT" = (
@@ -32814,25 +33077,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/machinery/light/floor,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -32938,8 +33197,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "thm" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
@@ -33074,6 +33337,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tlZ" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -33211,6 +33481,11 @@
 /obj/structure/bed/pod,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"tqC" = (
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -33297,12 +33572,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustyfull"
 	},
-/area/f13/den)
+/area/f13/sewer)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -33314,11 +33588,12 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -3
 	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -33345,14 +33620,9 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -33528,9 +33798,16 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33616,21 +33893,17 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
-"tCQ" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
+/obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33774,21 +34047,11 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29;
-	id = "dennorthshutters"
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34024,11 +34287,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34303,17 +34572,16 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
 /obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34465,12 +34733,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "ube" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
@@ -34568,8 +34836,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -34850,12 +35119,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "uqb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
@@ -34972,12 +35237,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
 	density = 0
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -35072,14 +35339,9 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
 "uvj" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -35091,8 +35353,10 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35132,9 +35396,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "uyC" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35396,10 +35663,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "dennorthshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35478,10 +35753,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
+/obj/machinery/smartfridge/bottlerack/lootshelf/books,
+/turf/open/floor/f13/wood,
 /area/f13/caves)
 "uLR" = (
 /obj/structure/simple_door/room,
@@ -35733,8 +36006,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -35964,9 +36240,11 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "vbU" = (
@@ -36157,11 +36435,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "vfU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -36233,14 +36511,24 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36250,8 +36538,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vjW" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "greenrusty"
+	},
 /area/f13/den)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -36274,11 +36569,9 @@
 	},
 /area/f13/brotherhood/mining)
 "vkj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
@@ -36295,19 +36588,32 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"vkI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/fence/corner{
+	dir = 4
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36389,16 +36695,14 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/area/f13/sewer)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36470,10 +36774,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "vrx" = (
 /obj/structure/sink{
@@ -36520,11 +36829,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "vsI" = (
@@ -37299,13 +37608,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/caves)
+/area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37331,16 +37645,8 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37356,8 +37662,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37493,8 +37804,8 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -37550,18 +37861,12 @@
 /turf/open/floor/plasteel,
 /area/f13/bunker)
 "vWZ" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "denmedshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "vXF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -37644,6 +37949,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wam" = (
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -37827,16 +38141,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
+/turf/open/water,
 /area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
@@ -37859,8 +38169,10 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -37904,8 +38216,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -37973,12 +38292,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/f13foldupchair,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "wmL" = (
@@ -38004,14 +38326,8 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
-	},
-/turf/open/water,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38032,20 +38348,16 @@
 	pixel_x = 30;
 	density = 0
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wpc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38107,9 +38419,9 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38177,12 +38489,15 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "wvi" = (
@@ -38192,15 +38507,8 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -38378,9 +38686,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wzt" = (
-/obj/structure/chair/f13foldupchair,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "wzH" = (
@@ -38733,6 +39043,11 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"wKN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -38783,11 +39098,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "wMb" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -38897,8 +39209,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "wQb" = (
 /obj/structure/rack,
@@ -38956,15 +39268,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wRa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
@@ -39201,9 +39508,7 @@
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -39250,8 +39555,14 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39881,6 +40192,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"xsf" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6;
@@ -39957,8 +40277,17 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40168,6 +40497,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"xzj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40781,17 +41119,15 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41050,10 +41386,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ycl" = (
 /obj/structure/closet,
@@ -41331,12 +41668,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -41365,10 +41707,18 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
 "ylL" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
+	},
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "ymg" = (
@@ -66487,8 +66837,8 @@ wFD
 wFD
 wFD
 wFD
-gHU
-bEV
+bxH
+nEP
 wFD
 mjG
 dXE
@@ -66735,19 +67085,19 @@ wFD
 lYx
 wFD
 wFD
-gHU
-nHM
-nHM
-nHM
-nHM
-nHM
-nHM
-nHM
-nHM
-nHM
-bEV
-pKf
-nHM
+bxH
+tst
+tst
+tst
+tst
+tst
+tst
+tst
+tst
+tst
+nEP
+fzY
+tst
 dXE
 dXE
 dXE
@@ -66996,13 +67346,13 @@ kUN
 kUN
 kUN
 kUN
-vsF
+vkI
 dAO
 dAO
 dAO
 dAO
-nHM
-eiz
+tst
+hri
 wFD
 mjG
 dXE
@@ -67246,20 +67596,20 @@ hQE
 uPr
 hQE
 gMZ
-dCp
-lmD
-dCp
-dCp
-auj
-auj
-auj
-vra
-tda
-sMl
-eZw
 lFt
+ezs
+lFt
+lFt
+auj
+auj
+auj
+wpc
+mnK
+jaG
+bdf
+gRa
 mjG
-bEV
+nEP
 wFD
 mjG
 fQL
@@ -67503,20 +67853,20 @@ hQE
 uPr
 kUN
 gkm
-qfj
-sMl
-sMl
-sMl
+rSO
+jaG
+jaG
+jaG
 auj
 gkm
-sMl
-vra
+jaG
+wpc
 gAy
-sMl
-kJu
+jaG
+hlO
 dzP
-nHM
-pKf
+tst
+fzY
 wFD
 wFD
 wFD
@@ -67759,23 +68109,23 @@ uPr
 uPr
 uPr
 kUN
-dnc
-dOg
-bMI
-bMI
-bMI
-hOx
+bKb
+bwW
+nzO
+nzO
+nzO
+rAd
 auj
 auj
-fJp
-jxS
-sMl
-voL
+gwf
+pKf
+jaG
+bPD
 dAO
-nHM
-nHM
-nHM
-nHM
+tst
+tst
+tst
+tst
 wFD
 wFD
 wFD
@@ -68017,23 +68367,23 @@ hQE
 hQE
 kUN
 aqh
-aXd
+fwZ
 bzg
 bzg
-bzg
-fqB
+mCP
+dOg
 auj
-sMl
-sMl
-npc
+jaG
+jaG
+rGe
 auj
-mnK
+pSU
 wYo
 wYo
 ddv
 ddv
 mjG
-dFv
+gyu
 mjG
 mjG
 mjG
@@ -68276,12 +68626,12 @@ kUN
 aqh
 bzg
 bzg
-uUB
+wvj
 bzg
-akT
+tCl
 auj
 auj
-cCO
+dgO
 qtc
 bTE
 qtc
@@ -68290,7 +68640,7 @@ qtc
 qtc
 ddv
 ddv
-gFp
+gMt
 ddv
 ddv
 ddv
@@ -68533,17 +68883,17 @@ kUN
 aqh
 bzg
 bzg
-iUU
+mCP
 bzg
-gRa
-eBU
-sMl
-auj
+tqC
+pjR
 jaG
-wvj
-hFt
-hFt
-uhB
+auj
+mSP
+sMl
+tGq
+nGD
+cTL
 qtc
 ddv
 ddv
@@ -68788,19 +69138,19 @@ hQE
 hQE
 kUN
 aqh
-iVF
+dHg
 bzg
 bzg
-uII
-akT
+juA
+tCl
 auj
 auj
-sMl
 jaG
-bAz
-opa
-hFt
-fzj
+mSP
+dEL
+lxs
+nGD
+cTL
 qtc
 ddv
 ddv
@@ -69045,19 +69395,19 @@ hQE
 hQE
 kUN
 aqh
+mCP
 bzg
 bzg
-bzg
-wPZ
-fqB
+cCO
+dOg
 auj
+jaG
+jaG
+liN
 sMl
-sMl
-bxH
-wvj
-hFt
 nGD
-fzj
+wrg
+ohx
 qtc
 ddv
 ddv
@@ -69298,23 +69648,23 @@ afb
 hQE
 hQE
 hQE
-fjJ
-fjJ
+qTe
+qTe
 kUN
-cTL
-vjM
-vjM
-vjM
-vjM
-fhe
+vlM
+bAz
+bAz
+bAz
+bAz
+ylp
 auj
-qfj
-sMl
+rSO
 jaG
-qia
-opa
-nGD
-bNV
+mSP
+fzj
+lxs
+wrg
+bPA
 qtc
 ddv
 ddv
@@ -69552,12 +69902,12 @@ eah
 eah
 eah
 eah
-eah
+vjW
 hOB
-sMl
+eBU
 tiS
 auj
-tac
+gWk
 auj
 auj
 auj
@@ -69565,13 +69915,13 @@ auj
 auj
 auj
 tac
-sMl
-auj
 jaG
-wvj
-hFt
-nGD
-cdh
+auj
+mSP
+sMl
+eCs
+wrg
+eWL
 qtc
 ddv
 ddv
@@ -69804,24 +70154,24 @@ fIf
 bQP
 fIf
 lBm
-pjR
+uUB
 fIf
 fIf
 fIf
 fIf
-fIf
+wRa
 auj
 auj
-sMl
-sMl
+jaG
+jaG
 auj
 uOX
 uOX
 uOX
 uOX
-kKb
-sMl
-sMl
+oVS
+jaG
+jaG
 wYo
 wYo
 wYo
@@ -69836,7 +70186,7 @@ jqn
 jqn
 jqn
 jqn
-gFp
+gMt
 mjG
 wFD
 wFD
@@ -70066,26 +70416,26 @@ eFv
 eFv
 eFv
 eFv
-eFv
+ekK
 tac
-sMl
-sMl
+jaG
+jaG
 auj
-qfj
-sMl
-auj
-auj
-sMl
+rSO
+jaG
 auj
 auj
-qfj
+jaG
+auj
+auj
+rSO
 wYo
-mSP
 dpu
+eLq
 qtc
-jEr
-fyh
-fzj
+wam
+gBM
+cTL
 qtc
 ddv
 ddv
@@ -70289,60 +70639,60 @@ wFD
 wFD
 mjG
 abB
-gQW
-vlM
-gQW
-gQW
-bvs
-fdw
+thm
+vQw
+thm
+thm
+eay
+ocq
 fEj
-dgg
-qDc
+qXj
+kjh
 fEj
-bvs
+eay
 fEj
-bvs
-bHA
-dli
-qIj
-gQW
-bvs
-gQW
-fdw
+eay
+lsh
+aqW
+xsf
+thm
+eay
+thm
+ocq
 fEj
-qDc
-gQW
-ffZ
+kjh
+thm
+ajO
 fEj
-daL
+hxB
 fEj
-gQW
-ffZ
-kZh
-rSU
+thm
+ajO
+hOx
+nJC
 fEj
 fEj
-kQt
+qxm
 fEj
 mZU
 gMZ
 auj
 auj
-sMl
-sMl
-sMl
+uhB
+jaG
+jaG
 tac
 auj
 auj
-qfj
-qfj
+gkm
+rSO
 wYo
-eCs
-eKX
+qFM
+gHU
 qtc
 xVD
-eKX
-fUu
+gHU
+dpW
 qtc
 ddv
 ddv
@@ -70546,60 +70896,60 @@ wFD
 wWB
 mjG
 abB
-kTJ
-iPX
+bNI
+dTG
+fpT
+bNI
+hRI
+wPZ
+bNI
+hRI
+bNI
 fxX
-kTJ
-hRI
-dhF
-kTJ
-hRI
-kTJ
-gBM
-eTS
+gFp
 hRI
 hRI
-kTJ
+bNI
 hRI
 hRI
-fyC
-eTS
-kTJ
-fPo
-kTJ
-fPo
-dsx
-hRI
-kTJ
-ixi
-fPo
-uVE
-eTS
-fPo
-fPo
-wrg
-hRI
-daE
-hRI
+czr
+gFp
+bNI
 esc
+bNI
+esc
+ixi
+hRI
+bNI
+kTJ
+esc
+uVE
+gFp
+esc
+esc
+rIU
+hRI
+vkj
+hRI
+vWZ
 fjU
 bMt
 auj
 auj
 auj
 auj
-sMl
+jaG
 auj
-sMl
-sMl
-cCO
+jaG
+jaG
+dgO
 wYo
-wLY
-fzj
-wjM
-crx
-bNV
-bNV
+saE
+cTL
+tXl
+eWL
+bPA
+bPA
 qtc
 ddv
 ddv
@@ -70832,32 +71182,32 @@ kUN
 kUN
 kUN
 hRI
-bVO
-fPo
-gNv
+fjJ
+esc
+rsi
 uVE
 gZB
 hRI
-dTr
+eVt
 uOX
 auj
 auj
 iDK
-thm
-oVS
-thm
-oVS
+eZw
+bup
+eZw
+bup
 auj
-sMl
-qfj
+jaG
+rSO
+iDd
+nUx
+cAU
+yiv
+cTL
 kQO
-fOr
-bIT
-bNI
-fzj
-uvj
-cQp
-dUk
+pPI
+qtc
 ddv
 ddv
 ddv
@@ -70876,7 +71226,7 @@ mjG
 mjG
 mjG
 mjG
-tus
+voL
 xse
 mjG
 mjG
@@ -71061,38 +71411,38 @@ wFD
 mjG
 aou
 kUN
-fzD
-fXU
-fXU
-blG
-fXU
-fXU
-fXU
+eiz
+cRY
+fxi
+dZO
+fxi
+cRY
+fxi
 kUN
-faq
-fXU
-fXU
-vfF
-bIT
-fXU
-vfF
-fXU
-fXU
-faq
+ube
+bMI
+fxi
+rzy
+cAU
+fxi
+rzy
+fxi
+bMI
+ube
 kUN
-fXU
-fXU
-blG
-fXU
-fXU
-liN
-fzD
+cRY
+fxi
+dZO
+fxi
+fxi
+qjU
+eiz
 kUN
 hRI
-ccg
+dLC
 hRI
-fQB
-fPo
+eMH
+esc
 xwm
 hRI
 fEW
@@ -71103,18 +71453,18 @@ auj
 blx
 diR
 diR
-ajO
-ajO
-bdf
-bdf
+bve
+bve
+gkY
+gkY
 kUN
 qtc
 bTE
 qtc
 yiv
 qtc
-aEe
-aEe
+wLY
+wLY
 ddv
 ddv
 ddv
@@ -71318,41 +71668,41 @@ wFD
 mjG
 bzl
 kUN
-fzD
-fXU
-fXU
+eiz
+fxi
+fxi
 kUN
-fXU
-fXU
-fXU
+fxi
+nyG
+fxi
 kUN
-hxB
-fXU
-fXU
+hFt
+fxi
+fxi
 kUN
-fXU
+bqI
 bIT
 kUN
-fXU
-fXU
-hxB
+fxi
+fxi
+hFt
 kUN
-fXU
-fXU
-rLJ
+fxi
+fxi
+vQn
 wYo
-fXU
-fXU
-fzD
+fxi
+nyG
+eiz
 kUN
-fPo
-hRI
-fPo
-gkY
-rjD
-bVO
+esc
 hRI
 esc
+iVF
+rjD
+fjJ
+hRI
+vWZ
 fjU
 bMt
 auj
@@ -71360,8 +71710,8 @@ iDK
 blx
 gKU
 aVZ
-fmW
-fmW
+dyB
+dyB
 gCa
 fjS
 wYo
@@ -71370,7 +71720,7 @@ ekQ
 dLn
 efa
 bFe
-aEe
+wLY
 eLE
 eLE
 eLE
@@ -71575,38 +71925,38 @@ wFD
 mjG
 bzl
 kUN
-tGq
+fLy
 nCx
-fzj
+cTL
 kUN
-fXU
-fXU
-fXU
+fxi
+fxi
+fxi
 kUN
-fXU
-fXU
-fXU
+fxi
+nyG
+fxi
 kUN
-fXU
-bIT
-bdL
-fXU
-fXU
-fXU
+fxi
+cAU
+vVu
+fxi
+nyG
+fxi
 kUN
-fXU
-fXU
+fxi
+fxi
 kUN
 wYo
-fXU
-fXU
-fzD
+fxi
+fxi
+eiz
 kUN
 hRI
-fPo
-fPo
-tMr
-qFM
+esc
+esc
+dGU
+bHA
 rjD
 hRI
 mZU
@@ -71621,13 +71971,13 @@ gCa
 bmJ
 gCa
 gCa
-eFq
+wYo
 xXZ
 tBY
 xbj
-gJz
 efa
-aEe
+efa
+wLY
 eLE
 yhT
 yhT
@@ -71832,49 +72182,49 @@ wWB
 mjG
 agK
 kUN
-dZO
-fzj
-fzj
+ylL
+cTL
+cTL
 kUN
-fXU
-fXU
-fXU
-vQw
+bqI
+fxi
+jEr
+bdL
 fPt
 fPt
 fPt
-tXl
-bIT
-bIT
+woj
+cAU
+cAU
 cKb
 fPt
 fPt
 fPt
 kUN
-fXU
-fXU
-uvI
+fxi
+fxi
+fOr
 wYo
-fXU
-fXU
-fXU
+fxi
+fxi
+fxi
 kUN
 rjD
 uVE
 hRI
-fPo
-dok
-wrg
+esc
+wgS
+rIU
 hRI
-dpl
+dUO
 iDK
 auj
 iDK
 auj
 kDG
-ehL
+gza
 okb
-dyB
+yck
 gCa
 gCa
 gCa
@@ -71884,7 +72234,7 @@ jyQ
 flC
 efa
 aLf
-flP
+wLY
 eLE
 yhT
 yhT
@@ -72088,39 +72438,39 @@ bbB
 bbB
 mjG
 aEg
-uyC
-dTG
-dTG
-dTG
+dnc
+uII
+uII
+uII
 dtr
-bIT
-bIT
-wpc
+cAU
+cAU
+nye
 lAv
-fXU
-fXU
-fXU
+fxi
+fxi
+fxi
 cRY
-bIT
-fXU
+cAU
+fxi
 cRY
-fXU
-fXU
-fXU
+fxi
+fxi
+fxi
 cRY
-fXU
-fXU
+fxi
+fxi
 kUN
 wYo
-dNa
-aQw
-mOS
+bqI
+nyG
+jEr
 kUN
 hRI
-bVO
-fPo
-fPo
-fPo
+fjJ
+esc
+esc
+esc
 oYU
 hRI
 qFJ
@@ -72128,10 +72478,10 @@ gmI
 iDK
 uDa
 iDK
-ube
+ddI
 cjg
 auj
-cbQ
+hOB
 bIC
 gCa
 gCa
@@ -72141,7 +72491,7 @@ hlg
 bTE
 efa
 efa
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -72345,39 +72695,39 @@ bbB
 bbB
 mjG
 mjG
-gvC
-fXU
-fXU
-fXU
+fQB
+fxi
+fxi
+fxi
 cRY
-bIT
-fXU
-fXU
-bIT
-fXU
-fXU
-fXU
-fXU
-hlO
-gyu
-gyu
-gyu
-gyu
-gyu
-gyu
-hlO
-fXU
+cAU
+fxi
+fxi
+cAU
+fxi
+fxi
+fxi
+fxi
+ehc
+dIm
+dIm
+dIm
+ehc
+dIm
+dIm
+ehc
+fxi
 kUN
 wYo
 nCx
-dIm
+epg
 ooI
 kUN
-bVO
+fjJ
 rjD
 hRI
 uVE
-fPo
+esc
 uVE
 hRI
 bLc
@@ -72385,20 +72735,20 @@ iDK
 uDa
 tUT
 gmI
-rzy
+pBk
 wIN
 dTK
 bMt
 pxK
 gCa
-vVu
+wYl
 wYo
 wLR
 kLD
 txw
 efa
 efa
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -72577,8 +72927,8 @@ dXE
 dXE
 dXE
 dXE
-myy
-myy
+agf
+agf
 dXE
 dXE
 dXE
@@ -72602,32 +72952,32 @@ wFD
 wWB
 mjG
 bzl
-gyu
-gyu
-gyu
-gyu
-kIf
-gyu
-gyu
-gyu
-dHg
-dHg
-dHg
-gyu
-gyu
-gyu
-egc
+dIm
+dIm
+dIm
+dIm
+jIs
+dIm
+ehc
+dIm
+wzt
+wzt
+wzt
+dIm
+dIm
+dIm
+fXU
 exf
 eiS
-egc
-exf
-egc
-gyu
 fXU
-aqQ
+exf
+fXU
+dIm
+fxi
+dpl
 wYo
-nUx
-fzj
+aqQ
+cTL
 lVK
 kUN
 hRI
@@ -72642,8 +72992,8 @@ auj
 gJA
 vBZ
 fjA
-rzy
-owJ
+pBk
+qDc
 dyu
 bMt
 bIC
@@ -72655,7 +73005,7 @@ ekQ
 dke
 efa
 efa
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -72859,39 +73209,39 @@ wFD
 wWB
 mjG
 bzl
-fXU
-kaQ
-fXU
-fXU
-fXU
-fXU
-fXU
-kaQ
-fXU
-fXU
-fXU
-kaQ
-fXU
-dHg
+fxi
 egc
+fxi
+fxi
+fxi
+fxi
+fxi
+egc
+fxi
+fxi
+fxi
+egc
+fxi
+wzt
+fXU
 iFg
 okH
 maO
 rvK
-egc
-gyu
 fXU
-fXU
+dIm
+fxi
+fxi
 kUN
 vct
 vct
 vct
 kUN
-pPI
-pPI
-pPI
-pPI
-pPI
+dFv
+dFv
+dFv
+dFv
+dFv
 fsN
 gNZ
 auj
@@ -72899,20 +73249,20 @@ fUQ
 lCp
 tUT
 iDK
-rzy
+pBk
 cjg
-pSU
+rQv
 dxH
 bIC
 gCa
-vVu
+wYl
 wYo
 xXZ
 wQp
 xbj
 efa
 efa
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -73121,29 +73471,29 @@ kUN
 kUN
 kUN
 kUN
-tXl
+woj
 kUN
 kUN
 kUN
 kUN
 kUN
-fpD
-fXU
-gyu
-iLY
+pJN
+fxi
+dIm
+oBq
 kbT
 uVE
 eyK
 ghs
-eup
-gyu
-gyu
-gyu
-fUv
-fXU
-fXU
-fXU
-fVm
+eGQ
+dIm
+dIm
+dIm
+aPF
+fxi
+fxi
+fxi
+aJI
 xdj
 xdj
 xdj
@@ -73156,7 +73506,7 @@ jLx
 cAC
 gVL
 tKj
-rzy
+pBk
 wIN
 iDK
 hOB
@@ -73169,7 +73519,7 @@ bIh
 pHQ
 efa
 crb
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -73385,22 +73735,22 @@ kUN
 kUN
 kUN
 kUN
+fxi
+kIf
 fXU
-cBZ
-egc
 bUh
-woj
-oBq
+eup
+jBt
 bhu
-egc
-gyu
-gyu
-gyu
+fXU
+ehc
+dIm
+dIm
 fUv
-fXU
-fXU
-fXU
-aQw
+fxi
+fxi
+fxi
+nyG
 xdj
 xdj
 xdj
@@ -73426,7 +73776,7 @@ qtc
 qtc
 efa
 efa
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -73632,32 +73982,32 @@ mjG
 vgV
 kUN
 kUN
-nEP
-nbd
+kcf
+pCO
 gCa
-gCa
+fjS
 kUN
 gCa
+tda
 gCa
 gCa
-gCa
-blG
+dZO
+fxi
+wzt
 fXU
-dHg
-egc
-fws
+qfj
 uVE
 eyK
-fzY
-egc
-gyu
-gyu
-gyu
+exg
+fXU
+dIm
+dIm
+dIm
 fUv
-fXU
-nyG
-fXU
-fXU
+fxi
+dUk
+fxi
+fxi
 xdj
 xdj
 xdj
@@ -73669,12 +74019,12 @@ iDK
 fjh
 iDK
 auj
-rzy
-wgS
+pBk
+kJu
 aVZ
 gCa
 gCa
-juA
+fGK
 gCa
 gCa
 wYo
@@ -73683,7 +74033,7 @@ gVp
 fVQ
 qtc
 cbu
-aEe
+wLY
 eLE
 yhT
 yhT
@@ -73889,27 +74239,27 @@ mjG
 vgV
 kUN
 kUN
-qjU
+cxY
 cUt
 dyH
 dLs
 kUN
 eJq
 fRv
-sfM
+cIZ
 gCa
-wZU
+lWO
+fxi
+wzt
+hJy
+dTr
+sIa
+cbG
+geR
 fXU
-dHg
-gow
-cQc
-ylp
-cAU
-ica
-egc
-gyu
-fXU
-fXU
+dIm
+fxi
+fxi
 kUN
 kUN
 kUN
@@ -73926,12 +74276,12 @@ iDK
 iDK
 iDK
 auj
-rzy
-wgS
+pBk
+kJu
 aVZ
 gCa
 ava
-hri
+npf
 xpf
 gCa
 bmJ
@@ -73939,7 +74289,7 @@ exn
 bFe
 uuD
 efa
-uso
+akT
 hQE
 eLE
 yhT
@@ -74146,33 +74496,33 @@ aLB
 vgV
 kUN
 kUN
-bup
+fhe
 cWc
 dyH
-gCa
+fjS
 kUN
-eJq
+qjN
 fRv
-sfM
-gCa
+cIZ
+mYc
 kUN
-fXU
+bqI
 cBZ
-egc
-exf
-gow
-egc
-exf
-iLY
-gyu
 fXU
-fpD
+exf
+hJy
+fXU
+exf
+oBq
+dIm
+fxi
+pJN
 kUN
 kUN
 kUN
 kUN
 kUN
-vkj
+nZC
 fEj
 fEj
 fEj
@@ -74183,12 +74533,12 @@ fjh
 gmI
 iDK
 auj
-rzy
+pBk
 gBD
 aVZ
 gCa
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -74196,7 +74546,7 @@ gAy
 efa
 efa
 efa
-dUO
+cQc
 hQE
 eLE
 yhT
@@ -74403,26 +74753,26 @@ mjG
 vgV
 kUN
 kUN
-eLq
+lmD
+bEV
 gCa
-gCa
-gwf
+tXd
 kUN
-wif
-bhO
-xtg
+uqb
+daE
+fUu
 gCa
 kUN
-fXU
+fxi
 bwq
-dHg
-gyu
-gyu
-gyu
-gyu
-gyu
-hlO
-fXU
+wzt
+dIm
+dIm
+ehc
+dIm
+dIm
+ehc
+fxi
 kUN
 kUN
 kUN
@@ -74440,20 +74790,20 @@ fjh
 hOB
 iDK
 auj
-rzy
-wgS
-aVZ
+pBk
+kJu
+gQW
 gCa
+fjS
 gCa
+exN
 gCa
-gMt
-gCa
-bmJ
-wRa
+wKN
+xTi
 efa
 ucR
 efa
-fnc
+wjM
 hQE
 eLE
 yhT
@@ -74667,32 +75017,32 @@ kUN
 kUN
 eJq
 fRv
-sfM
+cIZ
 gCa
 kUN
-fXU
-fXU
-fXU
-bIT
-wpc
-fXU
-fXU
-fXU
-fXU
-fXU
+fxi
+fxi
+fxi
+cAU
+nye
+fxi
+fxi
+fxi
+fxi
+fxi
 kUN
 kUN
 ddx
-lsh
-vQn
+jbM
+wuU
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-qjN
-mZs
+qEH
+fqF
 fjh
 iDK
 tZP
@@ -74702,7 +75052,7 @@ kUN
 gCa
 gCa
 gCa
-juA
+fGK
 gCa
 gCa
 gCa
@@ -74921,27 +75271,27 @@ gCa
 gCa
 gCa
 eiA
-gCa
-eJq
-fRv
-sfM
-gCa
+tco
+qjN
+cXP
+cIZ
+mYc
 cKb
-dNa
-fXU
-dWg
-fXU
-fXU
-fXU
-wuU
-fXU
-fXU
 bqI
-bdL
+fxi
+dWg
+fxi
+fxi
+fxi
+opa
+fxi
+fxi
+ndz
+vVu
 kUN
-tst
-ekK
-qxm
+tlZ
+gvC
+aQw
 kUN
 kUN
 hRI
@@ -74959,13 +75309,13 @@ eiA
 gCa
 gCa
 ava
-hri
+npf
 xpf
 gCa
 ibo
-flT
+npc
 xac
-psU
+aXd
 efa
 fKK
 hQE
@@ -75184,28 +75534,28 @@ gCa
 gCa
 gCa
 kUN
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-bIT
-fXU
+fxi
+fxi
+fxi
+fxi
+nyG
+fxi
+fxi
+fxi
+cAU
+fxi
 kUN
 kUN
-dLC
-ocq
-gza
+bHI
+vsF
+dNa
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-vjW
+bhO
 iDK
 iDK
 iDK
@@ -75214,9 +75564,9 @@ auj
 gmI
 eiA
 fjS
-fmW
+dyB
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -75431,31 +75781,31 @@ aLB
 vgV
 kUN
 kUN
-gCa
-gCa
+gDU
+fjS
 gCa
 eiA
 gCa
 gCa
+fjS
 gCa
-gCa
-cuS
+mZs
 kUN
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-wpc
-fXU
+fxi
+fxi
+fxi
+fxi
+fxi
+fxi
+fxi
+fxi
+nye
+fxi
 kUN
 kUN
-exg
-tco
-tco
+fzD
+gJz
+gJz
 kUN
 kUN
 hRI
@@ -75698,28 +76048,28 @@ gCa
 gCa
 fOg
 kUN
-dNa
-fXU
-dWg
-fXU
-fXU
-fXU
-dWg
-fXU
-bIT
 bqI
+fxi
+dWg
+fxi
+fxi
+fxi
+dWg
+fxi
+cAU
+ndz
 kUN
 kUN
-tbE
-yck
-eay
+vra
+daL
+rSU
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-pCO
+ewe
 gmI
 pVU
 tac
@@ -75950,26 +76300,26 @@ gCa
 gCa
 eiA
 gCa
+eFq
 gCa
 gCa
-gCa
-nJC
+fju
 kUN
-fXU
-fXU
-gxS
-fXU
-fXU
-fXU
-fXU
-fXU
-fXU
-kUN
+fxi
+fxi
+tzz
+fxi
+nyG
+fxi
+fxi
+fxi
+fxi
 kUN
 kUN
-cbG
-qxm
-eGQ
+kUN
+qia
+aQw
+gow
 kUN
 kUN
 hRI
@@ -76202,31 +76552,31 @@ mjG
 vgV
 kUN
 kUN
-ddI
-ddI
-ddI
+nEK
+nEK
+nEK
 kUN
 kUN
 kUN
-blG
+dZO
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-anK
-anK
+kZh
+nfB
 nfB
 kUN
 kUN
 kUN
 kUN
-qGl
-qxm
-qxm
-qxm
-rsi
+aLA
+kaQ
+aQw
+aQw
+dVW
 kUN
 kUN
 hRI
@@ -76459,31 +76809,31 @@ mjG
 vgV
 kUN
 kUN
-fjJ
-fjJ
-fjJ
+qTe
+qTe
+qTe
 kUN
 dcd
+eKX
 emK
 emK
-emK
-gWk
-dEL
-uqb
+hqt
+dCp
+fpD
+mNi
+kUN
+eLg
+anK
+qMr
 dIq
+qMr
+fis
 kUN
-geR
-qMr
-qMr
-vWZ
-qMr
-sTs
-kUN
-kcf
-qxm
-qxm
-qxm
-fju
+jxS
+aQw
+cuS
+aQw
+vbx
 kUN
 kUN
 hRI
@@ -76720,27 +77070,27 @@ kUN
 kUN
 kUN
 kUN
-tCl
+gxS
 emK
-fqF
+fVm
 emK
-uqb
-uqb
-uqb
-caw
+fpD
+aEe
+fpD
+lUs
 kUN
-wms
-qMr
-qMr
-vWZ
-qMr
-ylL
+xzj
+anK
+anK
+dIq
+anK
+fws
 kUN
-mNi
-qxm
-qxm
-qxm
-ehc
+fJp
+aQw
+aQw
+aQw
+eOP
 kUN
 kUN
 hRI
@@ -76974,30 +77324,30 @@ vgV
 kUN
 dnP
 dDz
-gyB
+ccg
 sVT
 kUN
-nzO
+fPo
 emK
 emK
-aPF
-gqj
-uqb
-uqb
-nsf
+tbE
+bPB
+fpD
+fpD
+wms
 kUN
-wzt
-qMr
-qMr
-vWZ
-qMr
-qMr
-dpW
-qxm
-qxm
-qxm
-qxm
-dPc
+uvI
+anK
+anK
+dIq
+anK
+anK
+wZU
+aQw
+qIj
+aQw
+aQw
+itn
 kUN
 kUN
 hRI
@@ -77229,37 +77579,37 @@ wFD
 mjG
 vgV
 kUN
-ciU
+cQp
 acI
-rSO
+dhF
 acI
 kUN
-vbx
+wif
 emK
 emK
-aPF
+tbE
+bNV
+lwv
+fpD
+dEl
+kUN
+dPc
+anK
+anK
 nHE
-fqF
-uqb
-eOP
-kUN
-wYl
-qMr
-qMr
-ezs
-qMr
-sTs
+anK
+anK
 kUN
 kUN
 kUN
 kUN
-blG
+dZO
 kUN
 kUN
 kUN
 cSY
-ewe
-nye
+ehL
+nFt
 xdj
 dXE
 dXE
@@ -77491,27 +77841,27 @@ lLo
 fQz
 cSN
 ltu
-emK
+flT
 dQG
-fqF
 lwv
+iLY
 cqu
 emK
-uqb
-aJI
+fpD
+cbQ
 kUN
-vWZ
-vWZ
-vWZ
+dIq
+dIq
+dIq
 kUN
-qMr
-nZC
+anK
+bMH
 kUN
-bve
+tus
+bvs
 rqX
 rqX
-rqX
-eMH
+fmW
 kUN
 kUN
 cSY
@@ -77746,29 +78096,29 @@ kUN
 gyB
 gyB
 gyB
-pBk
+dgg
 kUN
-ohx
-uqb
+tMr
+fpD
+flT
+fpD
 emK
-uqb
-emK
-emK
-uqb
-gIt
+flT
+fpD
+uso
 kUN
-eHr
+mOS
+anK
+anK
 qMr
-qMr
-qMr
-qMr
-ylL
+anK
+lQm
 kUN
-dVW
+nsf
 rqX
-dVW
+nsf
 rqX
-rqX
+eTS
 kUN
 kUN
 cSY
@@ -78000,26 +78350,26 @@ wFD
 mjG
 vgV
 kUN
-acI
+bXn
 acI
 uBk
-acI
+bXn
 kUN
 cqu
 cqu
+nbd
 cqu
-cqu
-uqb
+rLJ
 emK
-fqF
-uqb
-xTi
-qMr
-qMr
-qMr
-qMr
-qMr
-qMr
+lwv
+fpD
+xtg
+anK
+anK
+anK
+anK
+anK
+gqj
 kUN
 rqX
 rqX
@@ -78031,7 +78381,7 @@ kUN
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -78257,10 +78607,10 @@ wFD
 mjG
 vgV
 kUN
+gNv
 acI
-acI
-rGe
-acI
+fyC
+crx
 kUN
 kUN
 kUN
@@ -78272,15 +78622,15 @@ kUN
 kUN
 kUN
 eHr
-qMr
-qMr
-qMr
-qMr
-cXP
+anK
+anK
+anK
+anK
+owJ
 kUN
-bHI
+bVO
 rqX
-dVW
+nsf
 rqX
 cLd
 kUN
@@ -78288,7 +78638,7 @@ kUN
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -78514,9 +78864,9 @@ wFD
 mjG
 vgV
 kUN
-acI
-lUs
-ckD
+bXn
+dli
+sfM
 lyd
 kUN
 kUN
@@ -78529,17 +78879,17 @@ kUN
 kUN
 kUN
 wpa
+nHM
 sTs
-sTs
-sTs
-qMr
+vPv
+anK
 qMr
 ltu
 rqX
-rqX
-rAd
-aqW
-nFt
+tsX
+vjM
+jFq
+fnc
 kUN
 kUN
 cSY
@@ -79059,7 +79409,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -79288,10 +79638,10 @@ hQE
 hQE
 aoj
 aoj
-qXj
+caw
 aoj
 aoj
-uLP
+gIt
 vcx
 aoj
 aoj
@@ -79316,7 +79666,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -79546,7 +79896,7 @@ hQE
 aoj
 aoj
 aoj
-npf
+faq
 emV
 aoj
 aoj
@@ -79573,7 +79923,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -80058,10 +80408,10 @@ fQL
 hQE
 hQE
 dXE
-iDd
-qTe
-eLg
-fwZ
+cdh
+kQt
+qGl
+uvj
 dXE
 aoj
 vcx
@@ -80315,7 +80665,7 @@ fQL
 hQE
 hQE
 dXE
-cxY
+ica
 dHw
 dHw
 dHw
@@ -80325,7 +80675,7 @@ aoj
 aoj
 aoj
 aoj
-mYc
+ciU
 hKN
 cPI
 hQE
@@ -80572,7 +80922,7 @@ fQL
 hQE
 hQE
 dXE
-cYs
+dok
 dHw
 dHw
 rSB
@@ -80584,7 +80934,7 @@ aoj
 aoj
 uPr
 cPI
-tXd
+cJI
 hQE
 dXE
 dXE
@@ -80831,7 +81181,7 @@ hQE
 dXE
 dXE
 dXE
-tzz
+jHj
 dXE
 dXE
 hQE
@@ -80849,7 +81199,7 @@ hQE
 hQE
 hQE
 hQE
-qEH
+ckD
 hQE
 hQE
 hQE
@@ -81085,10 +81435,10 @@ mjG
 fQL
 hQE
 hQE
-jHj
-hqt
+uyC
+ffZ
 sVP
-lWO
+bRm
 buN
 aoj
 aoj
@@ -81098,7 +81448,7 @@ aoj
 aoj
 aoj
 buN
-mYc
+ciU
 aoj
 aoj
 aoj
@@ -81113,9 +81463,9 @@ dii
 dii
 dii
 dii
-ndz
+sOm
 dii
-ndz
+sOm
 wFD
 mNE
 wFD
@@ -81342,15 +81692,15 @@ mjG
 fQL
 hQE
 hQE
-jHj
+uyC
 uuq
-lWO
-lWO
+bRm
+bRm
 hQE
 hQE
 hQE
 hQE
-qEH
+ckD
 hQE
 aoj
 dXE
@@ -81370,9 +81720,9 @@ dii
 dii
 dii
 dii
-ndz
+sOm
 dii
-ndz
+sOm
 wFD
 mNE
 wFD
@@ -81599,10 +81949,10 @@ mjG
 fQL
 hQE
 hQE
-lWO
-lWO
-rQv
-lWO
+bRm
+bRm
+vfF
+bRm
 hQE
 hzR
 dHw
@@ -81620,7 +81970,7 @@ hQE
 hQE
 hQE
 hQE
-qEH
+ckD
 hQE
 buN
 hQE
@@ -81856,15 +82206,15 @@ mjG
 fQL
 hQE
 hQE
-lWO
-lWO
-lWO
-lWO
+bRm
+bRm
+bRm
+bRm
 hQE
 dHw
 flj
 dHw
-itn
+dsx
 hQE
 aoj
 dXE
@@ -81878,7 +82228,7 @@ aoj
 aoj
 aoj
 aoj
-qEH
+ckD
 aoj
 hQE
 cSY
@@ -81886,7 +82236,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 dXE
 dXE
@@ -82113,15 +82463,15 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 uCP
-lWO
-lWO
+bRm
+bRm
 hQE
 flj
 dHw
 dHw
-dEl
+kKb
 hQE
 aoj
 dXE
@@ -82143,7 +82493,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 uPr
@@ -82370,10 +82720,10 @@ mjG
 fQL
 hQE
 hQE
-lWO
-lWO
-lWO
-lWO
+bRm
+bRm
+bRm
+bRm
 hQE
 cLS
 dHw
@@ -82385,7 +82735,7 @@ aoj
 aoj
 aoj
 aoj
-qEH
+ckD
 aoj
 dXE
 dXE
@@ -82400,7 +82750,7 @@ cSY
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -82627,15 +82977,15 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 jPC
-jFq
+iPX
 jPC
 hQE
 hQE
 hQE
 hQE
-qEH
+ckD
 hQE
 hQE
 hQE
@@ -82884,10 +83234,10 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 jPC
 jzO
-dFt
+uLP
 hQE
 dXE
 dXE
@@ -83141,7 +83491,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 jPC
 lzb
 uqE
@@ -83398,7 +83748,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 jPC
 wDa
 gSS
@@ -83406,7 +83756,7 @@ hQE
 aoj
 hQE
 hQE
-qEH
+ckD
 hQE
 hQE
 hQE
@@ -83655,7 +84005,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 lQz
 uqE
 ncJ
@@ -83912,7 +84262,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 rCl
 fxD
 gSS
@@ -84169,7 +84519,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 ngX
 dXE
 dXE
@@ -84426,7 +84776,7 @@ mjG
 fQL
 hQE
 hQE
-lWO
+bRm
 lNw
 jPC
 jPC
@@ -84456,7 +84806,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 juh
@@ -84683,10 +85033,10 @@ mjG
 fQL
 hQE
 hQE
-lWO
-fis
-lWO
-tCQ
+bRm
+dFt
+bRm
+fyh
 hQE
 aoj
 hQE
@@ -84713,7 +85063,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 cSY
@@ -84940,9 +85290,9 @@ mjG
 fQL
 hQE
 hQE
-lWO
-lWO
-lWO
+bRm
+bRm
+bRm
 nBV
 hQE
 aoj
@@ -84970,7 +85320,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 pcO
@@ -85194,15 +85544,15 @@ mjG
 wFD
 wFD
 dtk
-vPv
+cMf
 nEz
 uCP
 bSl
-lWO
-lWO
-lWO
-qEH
-mYc
+bRm
+bRm
+bRm
+ckD
+ciU
 hQE
 dXE
 aoj
@@ -85459,7 +85809,7 @@ nEz
 hQE
 hQE
 hQE
-mYc
+ciU
 hQE
 dXE
 aoj
@@ -85711,8 +86061,8 @@ mjG
 fQL
 hQE
 hQE
-lWO
-lWO
+bRm
+bRm
 hQE
 dXE
 dXE
@@ -85969,7 +86319,7 @@ fQL
 hQE
 hQE
 gQR
-lWO
+bRm
 hQE
 dXE
 dXE
@@ -85998,7 +86348,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -86225,8 +86575,8 @@ bbB
 fQL
 hQE
 hQE
-lWO
-lWO
+bRm
+bRm
 hQE
 dXE
 dXE
@@ -86482,8 +86832,8 @@ bbB
 fQL
 hQE
 hQE
-lWO
-lWO
+bRm
+bRm
 hQE
 dXE
 dXE
@@ -86739,8 +87089,8 @@ bbB
 fQL
 hQE
 hQE
-lWO
-lWO
+bRm
+bRm
 hQE
 dXE
 dXE
@@ -86996,7 +87346,7 @@ mjG
 fQL
 hQE
 hQE
-qEH
+ckD
 hQE
 hQE
 dXE
@@ -87026,7 +87376,7 @@ nmy
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 dXE
@@ -87283,7 +87633,7 @@ dXE
 cSY
 cSY
 cSY
-saE
+fdw
 dXE
 uPr
 uPr
@@ -88282,7 +88632,7 @@ fQL
 hQE
 hQE
 hQE
-qEH
+ckD
 hQE
 hQE
 hQE
@@ -88310,8 +88660,8 @@ dXE
 dXE
 dXE
 dXE
-cMf
-tsX
+flP
+cYs
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,8 +302,21 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -330,7 +343,8 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
 /turf/open/water,
 /area/f13/den)
 "alv" = (
@@ -408,8 +422,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "anM" = (
@@ -480,9 +499,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "aqn" = (
 /obj/effect/decal/waste,
@@ -496,23 +524,33 @@
 	},
 /area/f13/brotherhood/rnd)
 "aqQ" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -582,10 +620,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ava" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1149,10 +1189,11 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1218,10 +1259,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1314,9 +1354,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
 /area/f13/den)
 "aPG" = (
 /obj/structure/cable{
@@ -1342,10 +1385,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/mirror{
+	pixel_y = 32
 	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
@@ -1537,9 +1584,9 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/caves)
 "aXi" = (
 /obj/machinery/light/small{
@@ -1796,8 +1843,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1831,10 +1883,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/turf/open/water,
 /area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1965,8 +2019,41 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2096,9 +2183,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "blH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -2292,13 +2381,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
@@ -2468,7 +2560,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/machinery/photocopier,
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "bux" = (
@@ -2492,9 +2587,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2504,11 +2603,17 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/caves)
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -2564,9 +2669,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bwW" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
@@ -2606,13 +2713,12 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2696,11 +2802,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2894,10 +2999,16 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -2969,19 +3080,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "bHI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "bIa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -3098,9 +3205,9 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3166,20 +3273,17 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "bMI" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3209,14 +3313,16 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "bNI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
@@ -3226,15 +3332,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3299,33 +3406,37 @@
 	},
 /area/f13/tunnel)
 "bPA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
-/area/f13/sewer)
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "bPB" = (
 /obj/structure/fence/corner{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
-"bPD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
+"bPD" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "bPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3381,13 +3492,13 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3538,16 +3649,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/dorms)
-"bUD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "bUR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3604,11 +3705,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3735,16 +3836,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "caw" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
@@ -3791,13 +3888,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3815,8 +3909,12 @@
 	},
 /area/f13/tunnel)
 "cbQ" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cbX" = (
 /obj/structure/lattice{
@@ -3911,12 +4009,8 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "cdu" = (
 /obj/structure/cable{
@@ -4083,9 +4177,9 @@
 	},
 /area/f13/bunker)
 "ciU" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -4377,11 +4471,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4487,21 +4578,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4510,6 +4587,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/clinic)
+"cvf" = (
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "cvg" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -4601,10 +4682,12 @@
 	},
 /area/f13/tunnel)
 "cxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/caves)
+/area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4660,12 +4743,15 @@
 	},
 /area/f13/tunnel)
 "czr" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "czF" = (
 /obj/machinery/light,
@@ -4775,14 +4861,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
-	},
-/turf/open/water,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4903,10 +4984,15 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/light/fo13colored/Red,
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cDP" = (
@@ -5084,18 +5170,27 @@
 	},
 /area/f13/brotherhood/armory)
 "cIZ" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
@@ -5202,9 +5297,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "cMJ" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -5255,8 +5352,14 @@
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
 "cQc" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
@@ -5313,6 +5416,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -5574,11 +5681,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5639,18 +5743,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "daL" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5737,9 +5846,13 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "deM" = (
@@ -5765,10 +5878,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "dgx" = (
@@ -5809,13 +5920,12 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "dgO" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
@@ -5844,12 +5954,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6001,9 +6107,10 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6103,10 +6210,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6151,9 +6259,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/table/wood/junk,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -6190,12 +6297,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/handrail/g_central{
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
 	dir = 8;
-	pixel_x = -20
+	pixel_y = -7
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dpu" = (
 /obj/structure/table/wood/settler,
@@ -6222,19 +6331,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dqh" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/wiki/cit/chem_recipies,
@@ -6307,9 +6421,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6532,7 +6648,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6653,10 +6772,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6704,14 +6830,17 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
 	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6725,11 +6854,9 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "dES" = (
@@ -6765,9 +6892,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "dFv" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dGP" = (
 /obj/structure/cable{
@@ -6794,8 +6922,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -6804,10 +6934,11 @@
 	},
 /area/f13/bunker)
 "dHg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "dHh" = (
@@ -6829,17 +6960,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/water,
 /area/f13/den)
 "dIo" = (
 /obj/structure/cable{
@@ -6848,14 +6974,9 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -6965,10 +7086,16 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
+/area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -7007,11 +7134,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7069,17 +7199,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
-	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -7117,8 +7238,8 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7261,16 +7382,15 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
-	dir = 1
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
@@ -7282,7 +7402,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/turf/open/floor/grass,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "dennorthshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
@@ -7305,14 +7436,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7332,10 +7466,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dUO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
@@ -7422,16 +7555,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dWg" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light/floor,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7551,16 +7684,9 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7601,16 +7727,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
 /obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
+/obj/machinery/microwave{
+	pixel_x = -6
+	},
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7830,8 +7957,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "egg" = (
@@ -7861,10 +7991,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
+/turf/open/water,
 /area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -7901,13 +8033,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = "denmedshutters"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
@@ -7918,9 +8051,14 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
@@ -8115,9 +8253,6 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -8187,14 +8322,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8378,10 +8507,15 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "euv" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -8432,11 +8566,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "ewe" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -8456,11 +8587,15 @@
 /turf/open/floor/grass,
 /area/f13/den)
 "exg" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -8554,12 +8689,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8632,10 +8767,8 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -8758,20 +8891,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8820,10 +8941,10 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
@@ -8989,16 +9110,13 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -9014,26 +9132,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/machinery/door/window/brigdoor/eastleft,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "eLq" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/turf/open/water,
+/area/f13/caves)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -9086,9 +9198,12 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9176,11 +9291,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/obj/machinery/light/floor,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "ePe" = (
@@ -9354,17 +9473,12 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
@@ -9416,11 +9530,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eVt" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
@@ -9453,8 +9568,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "eWN" = (
@@ -9557,15 +9673,32 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
 	},
-/turf/closed/wall/r_wall/rust,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "faq" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
+	},
+/turf/open/water,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9625,12 +9758,9 @@
 /turf/open/water,
 /area/f13/sewer)
 "fdw" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
 "fdG" = (
@@ -9692,9 +9822,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
@@ -9755,18 +9888,12 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
@@ -9782,13 +9909,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
@@ -9808,12 +9930,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/pondlily_small,
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9838,7 +9960,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/turf/closed/indestructible/f13/matrix,
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "fjL" = (
 /obj/structure/grille,
@@ -9854,9 +9979,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fka" = (
@@ -9905,19 +10029,14 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/structure/fence{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "flT" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "flW" = (
 /obj/structure/wreck/trash/engine,
 /obj/structure/spider/stickyweb,
@@ -9959,19 +10078,14 @@
 	},
 /area/f13/clinic)
 "fmW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10067,20 +10181,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -10104,16 +10208,11 @@
 	},
 /area/f13/caves)
 "fpT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fpV" = (
@@ -10137,23 +10236,39 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqB" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
+"fqF" = (
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
+	},
+/obj/item/scalpel,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
 	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
 /turf/open/floor/wood/wood_large,
-/area/f13/den)
-"fqF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10341,15 +10456,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
@@ -10369,20 +10478,20 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fxi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -10399,9 +10508,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
@@ -10415,14 +10526,9 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fym" = (
@@ -10455,16 +10561,14 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10493,23 +10597,14 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "fzD" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fzP" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -10526,9 +10621,10 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10809,14 +10905,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10873,13 +10963,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fLK" = (
@@ -10986,9 +11073,13 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/item/clothing/gloves/boxing,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -11024,15 +11115,23 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "fPt" = (
-/obj/item/kirbyplants/random,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fPu" = (
@@ -11070,10 +11169,14 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "fQL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -11085,8 +11188,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/floor,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fRK" = (
@@ -11225,14 +11330,8 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -11270,8 +11369,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -11336,12 +11437,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -11610,13 +11706,14 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "geR" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
@@ -11731,10 +11828,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11761,23 +11863,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
@@ -11874,14 +11966,8 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11928,12 +12014,8 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "gqt" = (
 /obj/structure/rack,
@@ -12104,13 +12186,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -12120,14 +12198,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "gwm" = (
@@ -12166,8 +12239,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/structure/sign/poster/official/build,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
@@ -12213,9 +12290,15 @@
 	},
 /area/f13/bunker)
 "gza" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -12295,14 +12378,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12396,12 +12475,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
@@ -12443,10 +12521,9 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
@@ -12545,13 +12622,10 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -12579,15 +12653,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gIt" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/turf/open/water,
+/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12693,8 +12764,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gMt" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "gMw" = (
 /obj/machinery/light/small{
@@ -12849,13 +12929,14 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gRa" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13024,9 +13105,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13497,12 +13579,10 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "hlO" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
 /area/f13/den)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13633,19 +13713,16 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "hri" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13821,12 +13898,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13959,9 +14037,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -14083,12 +14162,9 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "hJD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -14279,11 +14355,9 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -14741,10 +14815,13 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15205,8 +15282,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "itB" = (
@@ -15377,12 +15456,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
@@ -15526,17 +15603,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "iDh" = (
 /obj/structure/rack,
@@ -15749,12 +15818,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/machinery/light{
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
@@ -15907,11 +15980,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
@@ -16070,15 +16142,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "iUY" = (
@@ -16108,11 +16178,19 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "denmedshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -16299,7 +16377,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16325,8 +16404,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jbM" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jco" = (
 /obj/structure/lattice{
@@ -16619,17 +16699,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"jmR" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/den)
 "jmS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -16941,13 +17010,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jxS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Canteen"
@@ -17060,15 +17126,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "jBt" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
@@ -17131,12 +17195,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17177,11 +17240,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/machinery/light/floor,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
@@ -17258,11 +17319,14 @@
 	},
 /area/f13/building)
 "jIs" = (
-/obj/structure/chair/wood{
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
@@ -17849,10 +17913,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "kbf" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17931,9 +17996,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/machinery/light/floor,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "kcj" = (
@@ -18180,10 +18248,11 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18978,11 +19047,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
-/turf/open/water,
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -19015,21 +19082,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29;
-	id = "dennorthshutters"
-	},
-/obj/machinery/light{
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -19062,13 +19124,15 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
@@ -19197,12 +19261,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/chair/wood{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19217,8 +19280,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kQU" = (
@@ -19294,10 +19361,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19603,18 +19671,9 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "denmedshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
@@ -19903,12 +19962,11 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "liS" = (
@@ -20056,10 +20114,10 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "lmG" = (
 /obj/structure/rack,
@@ -20225,13 +20283,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "lsw" = (
@@ -20361,9 +20421,14 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/structure/simple_door/glass,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "lwU" = (
@@ -20374,11 +20439,10 @@
 	},
 /area/f13/bunker)
 "lxs" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/caves)
+/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20470,6 +20534,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "lAv" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_y = -7
@@ -20661,9 +20728,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/machinery/vending/snack{
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
 	density = 0;
-	pixel_y = -34
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/green,
@@ -21007,11 +21088,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/structure/decoration/vent/rusty,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/sewer)
+/area/f13/caves)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -21112,10 +21195,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -21195,11 +21279,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
@@ -21705,11 +21789,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "mnU" = (
 /obj/structure/cable{
@@ -22052,11 +22136,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mCP" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -22305,8 +22390,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "mNt" = (
 /obj/structure/rack,
@@ -22348,12 +22435,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22476,9 +22565,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
@@ -22640,19 +22729,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mYc" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22698,15 +22777,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
@@ -22894,10 +22968,14 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "nee" = (
 /obj/structure/cable{
@@ -23219,16 +23297,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "npf" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "npi" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -23327,11 +23404,11 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
@@ -23561,16 +23638,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
 /area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
@@ -23589,10 +23664,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23629,11 +23704,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23777,23 +23849,19 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "nEP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "nFc" = (
@@ -23830,12 +23898,18 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23885,9 +23959,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nGN" = (
@@ -23931,16 +24004,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nHM" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23994,16 +24073,11 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24327,9 +24401,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -24590,8 +24671,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24812,8 +24894,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
@@ -25090,10 +25175,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25295,11 +25383,13 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -25444,9 +25534,11 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
@@ -25958,13 +26050,21 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -26366,9 +26466,16 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -26837,18 +26944,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26888,17 +26987,12 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
 /obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -27091,13 +27185,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
@@ -27275,8 +27369,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -27411,15 +27509,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/structure/table{
-	pixel_x = 6
-	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
 /obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -27821,12 +27912,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27927,13 +28019,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -28016,9 +28105,12 @@
 /area/f13/bunker)
 "qjN" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
@@ -28032,12 +28124,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
@@ -28325,12 +28419,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qtf" = (
@@ -28438,11 +28528,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -28627,16 +28716,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28667,13 +28749,15 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -28752,8 +28836,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
@@ -28773,11 +28865,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28817,27 +28909,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -29201,16 +29277,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/closed/indestructible/f13/matrix,
 /area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -29330,15 +29397,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/clothing/gloves/boxing,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29562,10 +29623,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/enclave)
-"rdP" = (
-/obj/machinery/light,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "rdT" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet/black,
@@ -29999,13 +30056,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rsi" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
@@ -30401,11 +30460,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sign/poster/official/build,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30424,12 +30480,16 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30722,11 +30782,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/sewer)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30784,9 +30843,11 @@
 	},
 /area/f13/brotherhood/operations)
 "rIU" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/water,
 /area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30946,9 +31007,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -31121,11 +31184,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "rQO" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -31176,22 +31237,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/chem_master/condimaster{
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
 	density = 0
 	},
-/turf/open/space/basic,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rSU" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31442,10 +31500,14 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "saS" = (
 /obj/item/mine/shrapnel,
 /turf/open/water,
@@ -31573,13 +31635,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "sfM" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32422,9 +32481,11 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -32544,8 +32605,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -32589,24 +32654,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
@@ -33018,8 +33071,10 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
@@ -33033,23 +33088,32 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
 	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "darkdirty"
 	},
-/area/f13/sewer)
+/area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "tdv" = (
@@ -33156,16 +33220,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "thm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33300,15 +33359,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33448,17 +33504,16 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tqC" = (
-/obj/structure/fence/corner{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
@@ -33546,11 +33601,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
@@ -33563,13 +33617,14 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/water,
 /area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
@@ -33597,12 +33652,12 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
@@ -33779,39 +33834,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
@@ -33898,20 +33925,22 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tCQ" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/chem_master/condimaster{
+	density = 0
 	},
+/turf/open/space/basic,
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34056,8 +34085,39 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34293,11 +34353,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "stagestairs2"
 	},
 /area/f13/den)
 "tMD" = (
@@ -34383,6 +34448,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"tPc" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "tPl" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -34573,13 +34643,11 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = "denmedshutters"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "tXh" = (
@@ -34587,41 +34655,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/light,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34773,8 +34808,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "ube" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
@@ -34872,14 +34909,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
+/obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "uhC" = (
@@ -35283,12 +35318,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -35385,8 +35421,10 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
 "uvj" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
@@ -35399,33 +35437,11 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/water,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35465,9 +35481,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "uyC" = (
-/obj/structure/barricade/bars,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35656,10 +35683,6 @@
 	icon_state = "housewood_stage_top_right"
 	},
 /area/f13/brotherhood/archives)
-"uFe" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "uFh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
@@ -35733,18 +35756,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "dennorthshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35823,11 +35839,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -36078,17 +36097,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
-	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -36318,9 +36328,8 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vbU" = (
 /obj/structure/bed,
@@ -36510,13 +36519,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
+/obj/machinery/light/floor,
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -36589,16 +36597,9 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36639,14 +36640,15 @@
 	},
 /area/f13/brotherhood/mining)
 "vkj" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
@@ -36664,16 +36666,8 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
@@ -36681,13 +36675,8 @@
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36769,10 +36758,10 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36844,13 +36833,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "vrx" = (
 /obj/structure/sink{
@@ -36897,16 +36881,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -36962,6 +36939,10 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"vuH" = (
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "vuO" = (
 /obj/structure/table/wood/settler,
 /obj/item/candle,
@@ -37182,11 +37163,15 @@
 	},
 /area/f13/sewer)
 "vBZ" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/structure/table{
+	pixel_x = 6
 	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "vCe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37682,13 +37667,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37715,7 +37697,7 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
+/obj/structure/sign/poster/contraband/power,
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vQs" = (
@@ -37732,10 +37714,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37870,10 +37856,8 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -38018,15 +38002,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38211,17 +38191,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -38243,9 +38217,11 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "wir" = (
@@ -38290,10 +38266,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -38361,13 +38339,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/turf/open/water,
-/area/f13/den)
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -38391,8 +38367,12 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38489,14 +38469,12 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38564,12 +38542,9 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -38577,15 +38552,13 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -38763,12 +38736,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wzt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39175,14 +39144,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
-	},
-/turf/open/water,
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "wMb" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -39292,9 +39255,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -39590,8 +39559,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -39638,8 +39612,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -40273,11 +40252,9 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -40355,8 +40332,17 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40567,12 +40553,12 @@
 	},
 /area/f13/bunker)
 "xzj" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
@@ -41187,8 +41173,10 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41233,11 +41221,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVD" = (
-/obj/machinery/light/small{
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
 	dir = 4;
-	light_color = "red"
+	pixel_y = -16
 	},
-/turf/open/floor/carpet/green,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "xVK" = (
 /obj/structure/cable{
@@ -41445,9 +41441,9 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -41724,14 +41720,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -41760,12 +41753,10 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
 "ylL" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -66883,8 +66874,8 @@ wFD
 wFD
 wFD
 wFD
-wPZ
-iVF
+flT
+qIj
 wFD
 mjG
 dXE
@@ -67131,19 +67122,19 @@ wFD
 lYx
 wFD
 wFD
-wPZ
-bPA
-bPA
-bPA
-bPA
-bPA
-bPA
-bPA
-bPA
-bPA
-iVF
-dLC
-bPA
+flT
+aJI
+aJI
+aJI
+aJI
+aJI
+aJI
+aJI
+aJI
+aJI
+qIj
+rGe
+aJI
 dXE
 dXE
 dXE
@@ -67392,13 +67383,13 @@ kUN
 kUN
 kUN
 kUN
-nEP
+owJ
 dAO
 dAO
 dAO
 dAO
-bPA
-uso
+aJI
+mCP
 wFD
 mjG
 dXE
@@ -67642,20 +67633,20 @@ hQE
 uPr
 hQE
 gMZ
-jIs
-vlM
-jIs
-jIs
+ylp
+pKf
+ylp
+ylp
 auj
 auj
-bEV
-dCp
-dUO
-rLJ
-uUB
+gWk
+ylL
+xTi
+qxm
+dEl
 dAO
 mjG
-iVF
+qIj
 wFD
 mjG
 fQL
@@ -67898,21 +67889,21 @@ hQE
 hQE
 uPr
 kUN
-gkm
-aqh
-sMl
-sMl
-sMl
+gwf
+gvC
+yck
+yck
+yck
 auj
-gkm
-sMl
-dCp
-rSO
-sMl
-eiz
+gwf
+yck
+ylL
+tCQ
+yck
+dgg
 dzP
-bPA
-dLC
+aJI
+rGe
 wFD
 wFD
 wFD
@@ -68155,23 +68146,23 @@ uPr
 uPr
 uPr
 kUN
-cuS
-eTS
-flP
-flP
-flP
-tqC
+oVS
+dCp
+mOS
+mOS
+mOS
+bPB
 auj
 auj
-dNa
-bNI
-sMl
-jBt
+itn
+qjU
+yck
+cJI
 dAO
-bPA
-bPA
-bPA
-bPA
+aJI
+aJI
+aJI
+aJI
 wFD
 wFD
 wFD
@@ -68412,24 +68403,24 @@ hQE
 hQE
 hQE
 kUN
-gow
-eMH
+dNa
+jbM
 bzg
 bzg
-flT
-qEH
+jaG
+wvj
 auj
-sMl
-sMl
-qtc
+yck
+yck
+cIZ
 tac
-gRa
+bdf
 wYo
 wYo
 ddv
 ddv
 mjG
-lQm
+kaQ
 mjG
 mjG
 mjG
@@ -68669,24 +68660,24 @@ hQE
 hQE
 hQE
 kUN
-gow
+dNa
 bzg
 bzg
-bhO
+eFq
 bzg
-fyC
+qFM
 auj
 auj
-opa
-jaG
+sIa
+cuS
 bTE
-jaG
-jaG
-jaG
-jaG
+cuS
+cuS
+cuS
+cuS
 ddv
 ddv
-uLP
+bVO
 ddv
 ddv
 ddv
@@ -68926,21 +68917,21 @@ wCB
 hQE
 hQE
 kUN
-gow
+dNa
 bzg
 bzg
-flT
-bzg
-gWk
-jmR
-sMl
-auj
-dPc
-wvj
-qGl
-ohx
-cTL
 jaG
+bzg
+vjM
+dLC
+yck
+auj
+gow
+gkm
+mnK
+dhF
+cTL
+cuS
 ddv
 ddv
 jqn
@@ -69183,21 +69174,21 @@ hQE
 hQE
 hQE
 kUN
+dNa
+kjh
+bzg
+bzg
+pBk
+qFM
+auj
+auj
+yck
 gow
-eGQ
-bzg
-bzg
-nHM
-fyC
-auj
-auj
-sMl
-dPc
-dTr
-bKb
-ohx
+iLY
+cAU
+dhF
 cTL
-jaG
+cuS
 ddv
 ddv
 jqn
@@ -69440,21 +69431,21 @@ hQE
 hQE
 hQE
 kUN
-gow
-flT
-bzg
-bzg
-fOr
-qEH
-auj
-sMl
-sMl
-ica
-wvj
-ohx
-aJI
-rSU
+dNa
 jaG
+bzg
+bzg
+qXj
+wvj
+auj
+yck
+yck
+sfM
+gkm
+dhF
+nGD
+fUu
+cuS
 ddv
 ddv
 jqn
@@ -69694,24 +69685,24 @@ afb
 hQE
 hQE
 hQE
-fjJ
-fjJ
+qTe
+qTe
 kUN
-bPB
-fJp
-fJp
-fJp
-fJp
-pCO
-auj
 aqh
-sMl
-dPc
-eKX
-bKb
-aJI
+geR
+geR
+geR
+geR
+dUk
+auj
+gvC
+yck
+gow
+cCO
+cAU
 nGD
-jaG
+lmD
+cuS
 ddv
 ddv
 jqn
@@ -69953,7 +69944,7 @@ hOB
 eBU
 tiS
 auj
-ciU
+uII
 auj
 auj
 auj
@@ -69961,14 +69952,14 @@ auj
 auj
 auj
 tac
-sMl
-rQv
-dPc
-wvj
-lWO
-aJI
-gza
-jaG
+yck
+ixi
+gow
+gkm
+jEr
+nGD
+nzO
+cuS
 ddv
 ddv
 jqn
@@ -70200,7 +70191,7 @@ fIf
 bQP
 fIf
 lBm
-mnK
+oBq
 fIf
 fIf
 fIf
@@ -70208,31 +70199,31 @@ fIf
 wRa
 auj
 auj
-sMl
-sMl
+yck
+yck
 auj
 uOX
 uOX
 uOX
 uOX
-dgg
-sMl
-oBq
+kQt
+yck
+fjU
 wYo
 wYo
 wYo
-jaG
-jaG
-jaG
+cuS
+cuS
+cuS
 yiv
-jaG
+cuS
 ddv
 ddv
 jqn
 jqn
 jqn
 jqn
-uLP
+bVO
 mjG
 wFD
 wFD
@@ -70464,25 +70455,25 @@ eFv
 eFv
 ekK
 tac
-sMl
-sMl
+yck
+yck
 auj
-aqh
-sMl
-auj
-auj
-sMl
+gvC
+yck
 auj
 auj
-aqh
+yck
+auj
+auj
+gvC
 wYo
 dpu
-vsF
-jaG
-caw
-cdh
-daL
-jaG
+tqC
+cuS
+bvs
+cbQ
+pSU
+cuS
 ddv
 ddv
 jqn
@@ -70685,61 +70676,61 @@ wFD
 wFD
 mjG
 abB
-gDU
-rsi
-gDU
-gDU
-bPD
-fzj
+bxH
+hxB
+bxH
+bxH
+fhe
+caw
 fEj
-fju
-ylL
+pCO
+woj
 fEj
-bPD
+fhe
 fEj
-bPD
-vfF
-geR
-gvC
-gDU
-bPD
-gDU
-fzj
+fhe
+eKX
+vQw
+ica
+bxH
+fhe
+bxH
+caw
 fEj
-ylL
-gDU
-gqj
+woj
+bxH
+ava
 fEj
-ehL
+gkY
 fEj
-gDU
-gqj
-hlO
-dEL
+bxH
+ava
+gxS
+wrg
 fEj
 fEj
-dpl
+eMH
 fEj
 mZU
 gMZ
 auj
 auj
-rLJ
-sMl
-sMl
+qxm
+yck
+yck
 auj
 auj
 auj
-aqh
-bHA
+gvC
+dGU
 wYo
-nJC
-bNV
-jaG
-nJC
-wrg
-cCO
-jaG
+rAd
+pjR
+cuS
+rAd
+aQw
+dnc
+cuS
 ddv
 ddv
 jqn
@@ -70942,40 +70933,40 @@ wFD
 wWB
 mjG
 abB
-akT
-voL
-fzY
-akT
+fis
+bKb
+fzj
+fis
 hRI
-blG
-akT
+fPo
+fis
 hRI
-akT
-ndz
-cbQ
-hRI
-hRI
-akT
+fis
+dEL
+vlM
 hRI
 hRI
-dli
-cbQ
-akT
-cJI
-akT
-cJI
-dsx
+fis
 hRI
+hRI
+tPc
+vlM
+fis
+eCs
+fis
+eCs
+dUO
+hRI
+fis
 akT
-bwW
-cJI
+eCs
 uVE
-cbQ
-cJI
-cJI
-eup
+vlM
+eCs
+eCs
+xsf
 hRI
-npc
+iDd
 hRI
 vWZ
 fEW
@@ -70984,19 +70975,19 @@ auj
 auj
 auj
 auj
-sMl
+yck
 auj
-sMl
-sMl
-saE
+yck
+yck
+qtc
 wYo
-wjM
+fVm
 cTL
-xtg
-gza
-nGD
-nGD
-jaG
+vkI
+nzO
+lmD
+lmD
+cuS
 ddv
 ddv
 jqn
@@ -71229,31 +71220,31 @@ kUN
 kUN
 hRI
 esc
-cJI
-wLY
+eCs
+faq
 uVE
 gZB
 hRI
-xzj
+vfF
 uOX
 auj
 auj
 iDK
-ewe
-hJy
-ewe
-hJy
-auj
-sMl
-aqh
-kQO
 wam
-fxi
+tzz
+wam
+tzz
+auj
+yck
+gvC
+hFt
+liN
+dZO
 yiv
 cTL
-dpW
-qfj
-jaG
+kQO
+ffZ
+cuS
 ddv
 ddv
 ddv
@@ -71272,7 +71263,7 @@ mjG
 mjG
 mjG
 mjG
-tco
+fQB
 xse
 mjG
 mjG
@@ -71457,41 +71448,41 @@ wFD
 mjG
 aou
 kUN
-qia
-lAv
+fpT
 cRY
-lsh
+aqQ
+fyC
+aqQ
 cRY
-lAv
-cRY
+aqQ
 kUN
-tMr
-epg
-cRY
-nHE
-fxi
-cRY
-nHE
-cRY
-epg
-tMr
+eVt
+dpl
+aqQ
+fqB
+dZO
+aqQ
+fqB
+aqQ
+dpl
+eVt
 kUN
-lAv
 cRY
-lsh
-cRY
-cRY
-jEr
-qia
+aqQ
+fyC
+aqQ
+aqQ
+wif
+fpT
 kUN
 hRI
-kIf
+rIU
 hRI
-kaQ
-cJI
+gFp
+eCs
 xwm
 hRI
-aqW
+fju
 gMZ
 iDK
 auj
@@ -71499,18 +71490,18 @@ auj
 blx
 diR
 diR
-fmW
-fmW
-eCs
-eCs
+nHE
+nHE
+mZs
+mZs
 kUN
-jaG
+cuS
 bTE
-jaG
+cuS
 yiv
-jaG
-cQc
-cQc
+cuS
+wLY
+wLY
 ddv
 ddv
 ddv
@@ -71714,37 +71705,37 @@ wFD
 mjG
 bzl
 kUN
-qia
-cRY
-cRY
+fpT
+aqQ
+aqQ
 kUN
-cRY
-fPo
-cRY
+aqQ
+nyG
+aqQ
 kUN
-mCP
-cRY
-cRY
+ube
+aqQ
+aqQ
 kUN
-fXU
+dWg
 bIT
 kUN
-cRY
-cRY
-mCP
+aqQ
+aqQ
+ube
 kUN
-cRY
-cRY
-bdf
+aqQ
+aqQ
+dPc
 wYo
-cRY
-fPo
-qia
+aqQ
+nyG
+fpT
 kUN
-cJI
+eCs
 hRI
-cJI
-tst
+eCs
+qGl
 rjD
 esc
 hRI
@@ -71756,8 +71747,8 @@ iDK
 blx
 gKU
 aVZ
-dyB
-dyB
+fmW
+fmW
 gCa
 fjS
 wYo
@@ -71766,7 +71757,7 @@ ekQ
 dLn
 efa
 bFe
-cQc
+wLY
 eLE
 eLE
 eLE
@@ -71971,38 +71962,38 @@ wFD
 mjG
 bzl
 kUN
-kJu
+ajO
 nCx
 cTL
 kUN
-cRY
-cRY
-cRY
+aqQ
+aqQ
+aqQ
 kUN
-cRY
-fPo
-cRY
+aqQ
+nyG
+aqQ
 kUN
-cRY
-fxi
-dGU
-cRY
-fPo
-cRY
+aqQ
+dZO
+cYs
+aqQ
+nyG
+aqQ
 kUN
-cRY
-cRY
+aqQ
+aqQ
 kUN
 wYo
-cRY
-cRY
-qia
+aqQ
+aqQ
+fpT
 kUN
 hRI
-cJI
-cJI
-cIZ
-nzO
+eCs
+eCs
+uvI
+gIt
 rjD
 hRI
 mZU
@@ -72023,7 +72014,7 @@ tBY
 xbj
 efa
 efa
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -72228,49 +72219,49 @@ wWB
 mjG
 agK
 kUN
+bPA
+cTL
+cTL
+kUN
+dWg
+aqQ
+tst
+hOx
+fPt
+fPt
+fPt
+vQn
 dZO
-cTL
-cTL
-kUN
-fXU
-cRY
-gFp
-gMt
-fpD
-fpD
-fpD
-cMf
-fxi
-fxi
+dZO
 cKb
-fpD
-fpD
-fpD
+fPt
+fPt
+fPt
 kUN
-cRY
-cRY
-jbM
+aqQ
+aqQ
+fJp
 wYo
-cRY
-cRY
-cRY
+aqQ
+aqQ
+aqQ
 kUN
 rjD
 uVE
 hRI
-cJI
-wms
-eup
+eCs
+ehc
+xsf
 hRI
-czr
+bRm
 iDK
 auj
 iDK
 auj
 kDG
-tlZ
+czr
 okb
-bAz
+dyB
 gCa
 gCa
 gCa
@@ -72280,7 +72271,7 @@ jyQ
 flC
 efa
 aLf
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -72484,39 +72475,39 @@ bbB
 bbB
 mjG
 aEg
-vQn
-uII
-uII
-uII
+cvf
+dTG
+dTG
+dTG
 dtr
-fxi
-fxi
+dZO
+dZO
 wpc
-iUU
-cRY
-cRY
-cRY
 lAv
-fxi
+aqQ
+aqQ
+aqQ
 cRY
-lAv
+dZO
+aqQ
 cRY
+aqQ
+aqQ
+aqQ
 cRY
-cRY
-lAv
-cRY
-cRY
+aqQ
+aqQ
 kUN
 wYo
-fXU
-fPo
-gFp
+dWg
+nyG
+tst
 kUN
 hRI
 esc
-cJI
-cJI
-cJI
+eCs
+eCs
+eCs
 oYU
 hRI
 qFJ
@@ -72524,7 +72515,7 @@ fUQ
 iDK
 uDa
 iDK
-bHI
+fwZ
 cjg
 auj
 hOB
@@ -72537,7 +72528,7 @@ hlg
 bTE
 efa
 efa
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -72741,39 +72732,39 @@ bbB
 bbB
 mjG
 mjG
-tsX
+fOr
+aqQ
+aqQ
+aqQ
 cRY
-cRY
-cRY
-lAv
-fxi
-cRY
-cRY
-fxi
-cRY
-cRY
-cRY
-cRY
-ehc
+dZO
+aqQ
+aqQ
+dZO
+aqQ
+aqQ
+aqQ
+aqQ
+hlO
 gyu
 gyu
 gyu
-ehc
+hlO
 gyu
 gyu
-ehc
-cRY
+hlO
+aqQ
 kUN
 wYo
 nCx
-nFt
+fxi
 ooI
 kUN
 esc
 rjD
 hRI
 uVE
-cJI
+eCs
 uVE
 hRI
 bLc
@@ -72781,20 +72772,20 @@ iDK
 uDa
 tUT
 gmI
-rzy
+rSU
 wIN
 dTK
 bMt
 pxK
 gCa
-wYl
+vVu
 wYo
 wLR
 kLD
 txw
 efa
-faq
-cQc
+gqj
+wLY
 eLE
 yhT
 yhT
@@ -73002,27 +72993,27 @@ gyu
 gyu
 gyu
 gyu
-fyh
+dTr
 gyu
-ehc
+hlO
 gyu
-wzt
-wzt
-wzt
+dHg
+dHg
+dHg
 gyu
 gyu
 gyu
-dTG
+fXU
 exf
 eiS
-dTG
+fXU
 exf
-dTG
+fXU
 gyu
-cRY
-gxS
-wYo
 aqQ
+rzy
+wYo
+gDU
 cTL
 lVK
 kUN
@@ -73036,10 +73027,10 @@ hRI
 mZU
 auj
 gJA
-fjU
+uvj
 fjA
-rzy
-fhe
+rSU
+nFt
 dyu
 bMt
 bIC
@@ -73051,7 +73042,7 @@ ekQ
 dke
 efa
 efa
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -73255,39 +73246,39 @@ wFD
 wWB
 mjG
 bzl
-cRY
-dok
-cRY
-cRY
-cRY
-cRY
-cRY
-dok
-cRY
-cRY
-cRY
-dok
-cRY
-wzt
-dTG
+aqQ
+egc
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
+egc
+aqQ
+aqQ
+aqQ
+egc
+aqQ
+dHg
+fXU
 iFg
 okH
 maO
 rvK
-dTG
+fXU
 gyu
-cRY
-cRY
+aqQ
+aqQ
 kUN
 vct
 vct
 vct
 kUN
-qjU
-qjU
-qjU
-qjU
-qjU
+dIm
+dIm
+dIm
+dIm
+dIm
 fsN
 gNZ
 auj
@@ -73295,20 +73286,20 @@ fUQ
 lCp
 tUT
 iDK
-rzy
+rSU
 cjg
-gkY
+eZw
 dxH
 bIC
 gCa
-wYl
+vVu
 wYo
 xXZ
 wQp
 xbj
 efa
 efa
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -73517,29 +73508,29 @@ kUN
 kUN
 kUN
 kUN
-cMf
+vQn
 kUN
 kUN
 kUN
 kUN
 kUN
 pJN
-cRY
+aqQ
 gyu
-aPF
+bHA
 kbT
 uVE
 eyK
 ghs
-tGq
+bMI
 gyu
 gyu
 gyu
-fwZ
-cRY
-cRY
-cRY
-dgO
+aPF
+aqQ
+aqQ
+aqQ
+kcf
 xdj
 xdj
 xdj
@@ -73552,7 +73543,7 @@ jLx
 cAC
 gVL
 tKj
-rzy
+rSU
 wIN
 iDK
 hOB
@@ -73565,7 +73556,7 @@ bIh
 pHQ
 efa
 crb
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -73781,22 +73772,22 @@ kUN
 kUN
 kUN
 kUN
-cRY
-nEK
-dTG
+aqQ
+bNI
+fXU
 bUh
-cAU
-fQB
+tsX
+jFq
 bhu
-dTG
-ehc
+fXU
+hlO
 gyu
 gyu
 fUv
-cRY
-cRY
-cRY
-fPo
+aqQ
+aqQ
+aqQ
+nyG
 xdj
 xdj
 xdj
@@ -73817,12 +73808,12 @@ bmJ
 gCa
 gCa
 dAO
-jaG
-jaG
-jaG
+cuS
+cuS
+cuS
 efa
 efa
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -74028,32 +74019,32 @@ mjG
 vgV
 kUN
 kUN
-qIj
+lFt
 nbd
 gCa
 fjS
 kUN
 gCa
-jFq
+fRv
 gCa
 gCa
-lsh
-cRY
-wzt
-dTG
-kKb
+fyC
+aqQ
+dHg
+fXU
+uLP
 uVE
 eyK
-mOS
-dTG
+ezs
+fXU
 gyu
 gyu
 gyu
 fUv
-cRY
-ddI
-cRY
-cRY
+aqQ
+dFv
+aqQ
+aqQ
 xdj
 xdj
 xdj
@@ -74062,11 +74053,11 @@ flG
 fuL
 eiA
 iDK
-gHU
+dgO
 iDK
 auj
-rzy
-wgS
+rSU
+kJu
 aVZ
 gCa
 gCa
@@ -74077,9 +74068,9 @@ wYo
 ibY
 gVp
 fVQ
-jaG
+cuS
 cbu
-cQc
+wLY
 eLE
 yhT
 yhT
@@ -74285,27 +74276,27 @@ mjG
 vgV
 kUN
 kUN
-ffZ
+mYc
 cUt
 dyH
 dLs
 kUN
 eJq
-fRv
-rIU
+vsF
+dIq
 gCa
-uFe
-cRY
+cdh
+aqQ
+dHg
 wzt
-pPI
-mYc
-tus
-dUk
-nye
-dTG
+uyC
+bdL
+jIs
+bqI
+fXU
 gyu
-cRY
-cRY
+aqQ
+aqQ
 kUN
 kUN
 kUN
@@ -74322,12 +74313,12 @@ iDK
 iDK
 iDK
 auj
-rzy
-wgS
+rSU
+kJu
 aVZ
 gCa
 nZC
-npf
+hri
 xpf
 gCa
 bmJ
@@ -74335,7 +74326,7 @@ exn
 bFe
 uuD
 efa
-hri
+rSO
 hQE
 eLE
 yhT
@@ -74542,33 +74533,33 @@ aLB
 vgV
 kUN
 kUN
-eVt
+bup
 cWc
 dyH
 fjS
 kUN
-eWL
-fRv
-rIU
-mNi
+kZh
+vsF
+dIq
+uUB
 kUN
-fXU
+dWg
 cBZ
-dTG
+fXU
 exf
-pPI
-dTG
+wzt
+fXU
 exf
-aPF
+bHA
 gyu
-cRY
+aqQ
 pJN
 kUN
 kUN
 kUN
 kUN
 kUN
-eZw
+fxX
 fEj
 fEj
 fEj
@@ -74579,7 +74570,7 @@ fjh
 gmI
 iDK
 auj
-rzy
+rSU
 gBD
 aVZ
 gCa
@@ -74592,7 +74583,7 @@ gAy
 efa
 efa
 efa
-dOg
+eay
 hQE
 eLE
 yhT
@@ -74800,25 +74791,25 @@ vgV
 kUN
 kUN
 fjS
-xVD
+dsx
 gCa
-bup
+vuH
 kUN
-uvj
-hxB
-woj
+epg
+wjM
+aLA
 gCa
 kUN
-cRY
+aqQ
 bwq
-wzt
+dHg
 gyu
 gyu
-ehc
+hlO
 gyu
 gyu
-ehc
-cRY
+hlO
+aqQ
 kUN
 kUN
 kUN
@@ -74836,8 +74827,8 @@ fjh
 hOB
 iDK
 auj
-rzy
-wgS
+rSU
+kJu
 gQW
 gCa
 fjS
@@ -74845,11 +74836,11 @@ gCa
 exN
 gCa
 wKN
-thm
+vkj
 efa
 ucR
 efa
-pSU
+vBZ
 hQE
 eLE
 yhT
@@ -75062,33 +75053,33 @@ ohV
 kUN
 kUN
 eJq
-fRv
-rIU
+vsF
+dIq
 gCa
 kUN
-cRY
-cRY
-cRY
-fxi
+aqQ
+aqQ
+aqQ
+dZO
 wpc
-cRY
-cRY
-cRY
-cRY
-cRY
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
 kUN
 kUN
 ddx
-fzD
-vkI
+anK
+bEV
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-gwf
-hqt
+dpW
+ciU
 fjh
 iDK
 tZP
@@ -75317,27 +75308,27 @@ gCa
 gCa
 gCa
 eiA
-bVO
 eWL
+kZh
 cXP
-rIU
-mNi
+dIq
+uUB
 cKb
-fXU
-cRY
 dWg
-cRY
-cRY
-cRY
-dEl
-cRY
-cRY
-eOP
-dGU
+aqQ
+dok
+aqQ
+aqQ
+aqQ
+eiz
+aqQ
+aqQ
+pPI
+cYs
 kUN
-crx
-cbG
-fxX
+bwW
+sOm
+flP
 kUN
 kUN
 hRI
@@ -75355,13 +75346,13 @@ eiA
 gCa
 gCa
 nZC
-npf
+hri
 xpf
 gCa
 ibo
-vra
+opa
 xac
-tCl
+dVW
 efa
 fKK
 hQE
@@ -75580,28 +75571,28 @@ gCa
 gCa
 gCa
 kUN
-cRY
-cRY
-cRY
-cRY
-fPo
-cRY
-cRY
-cRY
-fxi
-cRY
+aqQ
+aqQ
+aqQ
+aqQ
+nyG
+aqQ
+aqQ
+aqQ
+dZO
+aqQ
 kUN
 kUN
-pBk
-ixi
-jxS
+tco
+tXd
+tus
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-tbE
+tCl
 iDK
 iDK
 iDK
@@ -75610,7 +75601,7 @@ auj
 gmI
 eiA
 fjS
-dyB
+fmW
 gCa
 fGK
 gCa
@@ -75827,7 +75818,7 @@ aLB
 vgV
 kUN
 kUN
-nyG
+fpD
 fjS
 gCa
 eiA
@@ -75835,21 +75826,21 @@ gCa
 gCa
 fjS
 gCa
-dVW
+bMH
 kUN
-cRY
-cRY
-cRY
-cRY
-cRY
-cRY
-cRY
-cRY
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
+aqQ
 wpc
-cRY
+aqQ
 kUN
 kUN
-eFq
+nUx
 gJz
 gJz
 kUN
@@ -76094,28 +76085,28 @@ gCa
 gCa
 fOg
 kUN
-fXU
-cRY
 dWg
-cRY
-cRY
-cRY
-dWg
-cRY
-fxi
-eOP
+aqQ
+dok
+aqQ
+aqQ
+aqQ
+dok
+aqQ
+dZO
+pPI
 kUN
 kUN
-qXj
-eLg
-lUs
+qEH
+bAz
+cQc
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-itn
+fws
 gmI
 pVU
 tac
@@ -76346,26 +76337,26 @@ gCa
 gCa
 eiA
 gCa
-qjN
+dli
 gCa
 gCa
-lFt
+sMl
 kUN
-cRY
-cRY
-uhB
-cRY
-fPo
-cRY
-cRY
-cRY
-cRY
+aqQ
+aqQ
+daL
+aqQ
+nyG
+aqQ
+aqQ
+aqQ
+aqQ
 kUN
 kUN
 kUN
-iLY
-fxX
-ava
+tlZ
+flP
+kTJ
 kUN
 kUN
 hRI
@@ -76598,31 +76589,31 @@ mjG
 vgV
 kUN
 kUN
-ajO
-ajO
-ajO
+vbx
+vbx
+vbx
 kUN
 kUN
 kUN
-lsh
+fyC
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-lwv
+fjJ
 nfB
 nfB
 kUN
 kUN
 kUN
 kUN
-nUx
-ezs
-fxX
-fxX
-vPv
+wYl
+dqh
+flP
+flP
+jBt
 kUN
 kUN
 hRI
@@ -76855,31 +76846,31 @@ mjG
 vgV
 kUN
 kUN
-fjJ
-fjJ
-fjJ
+qTe
+qTe
+qTe
 kUN
 dcd
+xzj
 emK
-egc
-egc
-aQw
-oVS
+emK
+gBM
+nEK
 uqb
-cYs
+nEP
 kUN
-vbx
-anK
+kIf
+lxs
 qMr
-kZh
+iVF
 qMr
-tda
+nJC
 kUN
-ylp
-fxX
-iPX
-fxX
-dhF
+iUU
+flP
+fzY
+flP
+uso
 kUN
 kUN
 hRI
@@ -77116,27 +77107,27 @@ kUN
 kUN
 kUN
 kUN
-lmD
-egc
-vjM
-egc
+tbE
+emK
+lsh
+emK
 uqb
 aEe
 uqb
-qTe
+wZU
 kUN
-tCQ
-anK
-anK
-kZh
-anK
-rAd
+uhB
+lxs
+lxs
+iVF
+lxs
+bve
 kUN
-sfM
-fxX
-fxX
-fxX
-fLy
+eLg
+flP
+flP
+flP
+lUs
 kUN
 kUN
 hRI
@@ -77373,27 +77364,27 @@ dDz
 ccg
 sVT
 kUN
-fis
-egc
-egc
-dIq
-wZU
+qjN
+emK
+emK
+ddI
+rLJ
 uqb
 uqb
-eay
+eOP
 kUN
-vVu
-anK
-anK
-kZh
-anK
-anK
-daE
-fxX
-bxH
-fxX
-fxX
-tXl
+npc
+lxs
+lxs
+iVF
+lxs
+lxs
+nye
+flP
+flP
+flP
+flP
+bhO
 kUN
 kUN
 hRI
@@ -77627,35 +77618,35 @@ vgV
 kUN
 cQp
 acI
-fqB
+eTS
 acI
 kUN
-bdL
-egc
-egc
-dIq
-fws
-fqF
+hqt
+emK
+emK
+ddI
+rsi
+lwv
 uqb
-bqI
+qfj
 kUN
-fPt
-anK
-anK
-fUu
-anK
-anK
-kUN
-kUN
+mNi
+lxs
+lxs
+gRa
+lxs
+lxs
 kUN
 kUN
-lsh
+kUN
+kUN
+fyC
 kUN
 kUN
 kUN
 cSY
-vQw
-aXd
+iPX
+bHI
 xdj
 dXE
 dXE
@@ -77887,27 +77878,27 @@ lLo
 fQz
 cSN
 ltu
-kcf
+eGQ
 dQG
-fqF
-qDc
+lwv
+tda
 cqu
-egc
+emK
 uqb
-dHg
+cxY
 kUN
-kZh
-kZh
-kZh
+iVF
+iVF
+iVF
 kUN
-anK
-tXd
+lxs
+ehL
 kUN
-fVm
-dnc
+dOg
+vPv
 rqX
 rqX
-qFM
+ewe
 kUN
 kUN
 cSY
@@ -78142,29 +78133,29 @@ kUN
 gyB
 gyB
 gyB
-mZs
+kKb
 kUN
-iDd
+gMt
 uqb
-kcf
+eGQ
 uqb
-egc
-kcf
+emK
+eGQ
 uqb
-bUD
+exg
 kUN
-pKf
-anK
-anK
+nHM
+lxs
+lxs
 qMr
-anK
-kQt
+lxs
+daE
 kUN
-wuU
+nsf
 rqX
-wuU
+nsf
 rqX
-xTi
+crx
 kUN
 kUN
 cSY
@@ -78403,19 +78394,19 @@ bXn
 kUN
 cqu
 cqu
-vkj
+wPZ
 cqu
-liN
-egc
-fqF
+bNV
+emK
+lwv
 uqb
-fpT
-anK
-anK
-anK
-anK
-anK
-nsf
+tMr
+lxs
+lxs
+lxs
+lxs
+lxs
+fLy
 kUN
 rqX
 rqX
@@ -78427,7 +78418,7 @@ kUN
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -78655,8 +78646,8 @@ vgV
 kUN
 gNv
 acI
-vBZ
-rdP
+ohx
+tXl
 kUN
 kUN
 kUN
@@ -78668,15 +78659,15 @@ kUN
 kUN
 kUN
 eHr
-anK
-anK
-anK
-anK
-wif
+lxs
+lxs
+lxs
+lxs
+fyh
 kUN
-gBM
+ndz
 rqX
-wuU
+nsf
 rqX
 cLd
 kUN
@@ -78684,7 +78675,7 @@ kUN
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -78911,8 +78902,8 @@ mjG
 vgV
 kUN
 bXn
-uvI
-dFv
+fqF
+fnc
 lyd
 kUN
 kUN
@@ -78925,17 +78916,17 @@ kUN
 kUN
 kUN
 wpa
-eLq
+xVD
 sTs
-dIm
-anK
+xtg
+lxs
 qMr
 ltu
 rqX
-xsf
-sOm
-tzz
-ube
+lWO
+aqW
+tGq
+vra
 kUN
 kUN
 cSY
@@ -79455,7 +79446,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -79684,10 +79675,10 @@ hQE
 hQE
 aoj
 aoj
-kjh
+ocq
 aoj
 aoj
-owJ
+thm
 vcx
 aoj
 aoj
@@ -79712,7 +79703,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -79942,7 +79933,7 @@ hQE
 aoj
 aoj
 aoj
-yck
+bPD
 emV
 aoj
 aoj
@@ -79969,7 +79960,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -80454,10 +80445,10 @@ fQL
 hQE
 hQE
 dXE
-mSP
-sIa
-fnc
-pjR
+voL
+qDc
+jxS
+hJy
 dXE
 aoj
 vcx
@@ -80711,7 +80702,7 @@ fQL
 hQE
 hQE
 dXE
-qxm
+wgS
 dHw
 dHw
 dHw
@@ -80968,7 +80959,7 @@ fQL
 hQE
 hQE
 dXE
-ocq
+fzD
 dHw
 dHw
 rSB
@@ -80980,7 +80971,7 @@ aoj
 aoj
 uPr
 cPI
-kTJ
+qia
 hQE
 dXE
 dXE
@@ -81227,7 +81218,7 @@ hQE
 dXE
 dXE
 dXE
-hFt
+wuU
 dXE
 dXE
 hQE
@@ -81245,7 +81236,7 @@ hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -81482,9 +81473,9 @@ fQL
 hQE
 hQE
 jHj
-bMH
+gza
 sVP
-cxY
+aXd
 buN
 aoj
 aoj
@@ -81498,9 +81489,9 @@ ckD
 aoj
 aoj
 aoj
-dqh
-dqh
-dqh
+mSP
+mSP
+mSP
 aoj
 aoj
 aoj
@@ -81509,9 +81500,9 @@ dii
 dii
 dii
 dii
-aLA
+gHU
 dii
-aLA
+gHU
 wFD
 mNE
 wFD
@@ -81740,13 +81731,13 @@ hQE
 hQE
 jHj
 uuq
-cxY
-cxY
+aXd
+aXd
 hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 aoj
 dXE
@@ -81755,9 +81746,9 @@ aoj
 aoj
 aoj
 aoj
-dqh
+mSP
 wpF
-dqh
+mSP
 aoj
 aoj
 aoj
@@ -81766,9 +81757,9 @@ dii
 dii
 dii
 dii
-aLA
+gHU
 dii
-aLA
+gHU
 wFD
 mNE
 wFD
@@ -81995,10 +81986,10 @@ mjG
 fQL
 hQE
 hQE
-cxY
-cxY
-exg
-cxY
+aXd
+aXd
+cMf
+aXd
 hQE
 hzR
 dHw
@@ -82016,7 +82007,7 @@ hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 buN
 hQE
@@ -82252,15 +82243,15 @@ mjG
 fQL
 hQE
 hQE
-cxY
-cxY
-cxY
-cxY
+aXd
+aXd
+aXd
+aXd
 hQE
 dHw
 flj
 dHw
-bMI
+cbG
 hQE
 aoj
 dXE
@@ -82274,7 +82265,7 @@ aoj
 aoj
 aoj
 aoj
-rGe
+eLq
 aoj
 hQE
 cSY
@@ -82282,7 +82273,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -82509,15 +82500,15 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 uCP
-cxY
-cxY
+aXd
+aXd
 hQE
 flj
 dHw
 dHw
-bve
+npf
 hQE
 aoj
 dXE
@@ -82539,7 +82530,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 uPr
@@ -82766,10 +82757,10 @@ mjG
 fQL
 hQE
 hQE
-cxY
-cxY
-cxY
-cxY
+aXd
+aXd
+aXd
+aXd
 hQE
 cLS
 dHw
@@ -82781,7 +82772,7 @@ aoj
 aoj
 aoj
 aoj
-rGe
+eLq
 aoj
 dXE
 dXE
@@ -82796,7 +82787,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -83023,15 +83014,15 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 jPC
-hOx
+wms
 jPC
 hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -83280,7 +83271,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 jPC
 jzO
 dFt
@@ -83537,7 +83528,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 jPC
 lzb
 uqE
@@ -83794,7 +83785,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 jPC
 wDa
 gSS
@@ -83802,7 +83793,7 @@ hQE
 aoj
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -84051,7 +84042,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 lQz
 uqE
 ncJ
@@ -84308,7 +84299,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 rCl
 fxD
 gSS
@@ -84565,7 +84556,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 ngX
 dXE
 dXE
@@ -84822,7 +84813,7 @@ mjG
 fQL
 hQE
 hQE
-cxY
+aXd
 lNw
 jPC
 jPC
@@ -84852,7 +84843,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 juh
@@ -85079,10 +85070,10 @@ mjG
 fQL
 hQE
 hQE
-cxY
-lxs
-cxY
-gIt
+aXd
+fdw
+aXd
+eup
 hQE
 aoj
 hQE
@@ -85109,7 +85100,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 cSY
@@ -85336,9 +85327,9 @@ mjG
 fQL
 hQE
 hQE
-cxY
-cxY
-cxY
+aXd
+aXd
+aXd
 nBV
 hQE
 aoj
@@ -85366,7 +85357,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 pcO
@@ -85590,14 +85581,14 @@ mjG
 wFD
 wFD
 dtk
-bRm
+lQm
 nEz
 uCP
 bSl
-cxY
-cxY
-cxY
-rGe
+aXd
+aXd
+aXd
+eLq
 ckD
 hQE
 dXE
@@ -86107,8 +86098,8 @@ mjG
 fQL
 hQE
 hQE
-cxY
-cxY
+aXd
+aXd
 hQE
 dXE
 dXE
@@ -86365,7 +86356,7 @@ fQL
 hQE
 hQE
 gQR
-cxY
+aXd
 hQE
 dXE
 dXE
@@ -86394,7 +86385,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -86621,8 +86612,8 @@ bbB
 fQL
 hQE
 hQE
-cxY
-cxY
+aXd
+aXd
 hQE
 dXE
 dXE
@@ -86878,8 +86869,8 @@ bbB
 fQL
 hQE
 hQE
-cxY
-cxY
+aXd
+aXd
 hQE
 dXE
 dXE
@@ -87135,8 +87126,8 @@ bbB
 fQL
 hQE
 hQE
-cxY
-cxY
+aXd
+aXd
 hQE
 dXE
 dXE
@@ -87392,7 +87383,7 @@ mjG
 fQL
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 dXE
@@ -87422,7 +87413,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -87679,7 +87670,7 @@ dXE
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 uPr
@@ -88678,7 +88669,7 @@ fQL
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -88706,8 +88697,8 @@ dXE
 dXE
 dXE
 dXE
-uyC
-bvs
+rQv
+blG
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,9 +302,13 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/f13_blue,
@@ -329,12 +333,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
-"akT" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -410,6 +408,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
+/obj/structure/simple_door/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -482,8 +481,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -510,15 +513,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"aqW" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice/d20,
@@ -587,13 +581,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ava" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
-	},
-/turf/open/water,
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -969,11 +959,10 @@
 	},
 /area/f13/tunnel)
 "aEe" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "aEg" = (
@@ -1156,14 +1145,13 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "aKc" = (
 /obj/structure/cable{
@@ -1230,9 +1218,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
@@ -1326,9 +1314,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "aPG" = (
 /obj/structure/cable{
@@ -1354,8 +1342,20 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
@@ -1546,6 +1546,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/brotherhood/archives)
+"aXd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1801,13 +1810,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1841,11 +1847,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
 /turf/open/water,
 /area/f13/den)
 "bdY" = (
@@ -1977,9 +1982,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2107,6 +2111,12 @@
 /area/f13/enclave)
 "blx" = (
 /turf/closed/indestructible/f13vaultrusted,
+/area/f13/den)
+"blG" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2301,13 +2311,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
@@ -2476,14 +2489,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bup" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2505,16 +2510,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bvm" = (
@@ -2526,10 +2522,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
@@ -2585,6 +2579,15 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"bwW" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/barber{
@@ -2623,8 +2626,17 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2708,15 +2720,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2910,11 +2915,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -2984,22 +2990,14 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"bHA" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bHI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
@@ -3052,9 +3050,15 @@
 	},
 /area/f13/brotherhood/operating)
 "bIT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
@@ -3112,12 +3116,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bKb" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -3181,21 +3179,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"bMH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bMI" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/water,
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
@@ -3225,6 +3216,13 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
+"bNI" = (
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
+	},
+/turf/open/water,
+/area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -3233,8 +3231,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3299,27 +3304,35 @@
 	},
 /area/f13/tunnel)
 "bPA" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bPB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "bPD" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "bPG" = (
@@ -3377,40 +3390,11 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3616,6 +3600,12 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
+"bVO" = (
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3643,9 +3633,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "bXn" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3742,6 +3737,13 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"caw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3786,11 +3788,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"cbG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3842,8 +3839,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -3905,10 +3905,17 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cdu" = (
 /obj/structure/cable{
@@ -4145,12 +4152,11 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "ckH" = (
@@ -4336,9 +4342,14 @@
 	},
 /area/f13/caves)
 "cqu" = (
-/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "cqC" = (
@@ -4371,8 +4382,15 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4577,18 +4595,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"cxY" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4644,12 +4650,12 @@
 	},
 /area/f13/tunnel)
 "czr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "czF" = (
 /obj/machinery/light,
@@ -4759,12 +4765,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4885,8 +4888,13 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/structure/falsewall/rust,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
@@ -5063,22 +5071,19 @@
 	},
 /area/f13/brotherhood/armory)
 "cIZ" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
@@ -5184,10 +5189,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
-"cMf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -5237,15 +5238,23 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
+"cQc" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -5290,14 +5299,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5522,9 +5530,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5554,13 +5561,24 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5621,13 +5639,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
 /turf/open/water,
-/area/f13/sewer)
+/area/f13/den)
 "daL" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/plating/dirt,
@@ -5713,8 +5741,9 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5739,9 +5768,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5780,11 +5809,9 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "dgO" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dgR" = (
@@ -5814,11 +5841,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5970,12 +5996,9 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -6074,10 +6097,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/sewer)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6122,9 +6148,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6156,15 +6192,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"dpl" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dpu" = (
 /obj/structure/table/wood/settler,
 /obj/structure/mirror{
@@ -6189,13 +6216,21 @@
 /obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dqh" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+"dpW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
+"dqh" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
@@ -6269,9 +6304,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6493,7 +6527,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6614,9 +6651,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6664,11 +6711,12 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6682,17 +6730,13 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/fence{
-	dir = 1
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/fence{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
@@ -6726,14 +6770,6 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"dFv" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6759,11 +6795,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
@@ -6783,16 +6822,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "dHw" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6804,6 +6835,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
+"dIm" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6811,9 +6846,15 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -6923,13 +6964,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6968,15 +7005,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7034,12 +7065,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -7077,18 +7115,13 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7231,10 +7264,12 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/area/f13/caves)
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7244,6 +7279,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"dTG" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "dennorthshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -7265,24 +7314,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dUn" = (
@@ -7302,6 +7335,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"dUO" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -7387,10 +7430,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dWg" = (
 /obj/structure/table/wood/junk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -7512,16 +7555,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7562,12 +7600,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "eaB" = (
@@ -7788,11 +7824,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "egg" = (
@@ -7821,11 +7854,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"ehc" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7861,9 +7889,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7873,8 +7904,11 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "eiA" = (
@@ -7998,9 +8032,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "ekQ" = (
@@ -8065,18 +8099,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
-/obj/structure/fence/corner{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "emN" = (
 /turf/open/floor/wood/f13/oakbroken,
@@ -8143,9 +8168,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8232,12 +8257,8 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/chair/wood,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "esg" = (
 /obj/item/flag/bos,
@@ -8333,21 +8354,9 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8398,16 +8407,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"ewe" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -8424,12 +8423,6 @@
 "exf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/grass,
-/area/f13/den)
-"exg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8479,6 +8472,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
+"exN" = (
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8518,8 +8518,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8568,9 +8575,12 @@
 	},
 /area/f13/building)
 "eBU" = (
-/obj/structure/chair/f13foldupchair,
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "eBZ" = (
@@ -8591,14 +8601,10 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot_white,
@@ -8720,12 +8726,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8774,8 +8778,8 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "eGX" = (
@@ -8791,9 +8795,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "eHr" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -8897,10 +8898,8 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
@@ -8941,14 +8940,8 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -8964,10 +8957,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "eLq" = (
 /obj/structure/simple_door/metal/ventilation{
@@ -9027,9 +9021,13 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
+	},
+/turf/open/water,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9116,6 +9114,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"eOP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9286,10 +9288,6 @@
 	dir = 5
 	},
 /area/f13/brotherhood/mining)
-"eTS" = (
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9340,13 +9338,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eVt" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
@@ -9379,8 +9376,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -9482,15 +9482,13 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/structure/table{
-	pixel_x = 6
-	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
+"faq" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9617,11 +9615,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/f13/sewer)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9681,8 +9681,13 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
@@ -9698,7 +9703,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "fiI" = (
@@ -9717,6 +9722,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/carpet/red,
+/area/f13/den)
+"fju" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9741,12 +9754,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9809,9 +9821,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/den)
+"flP" = (
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "flT" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/closed/wall/f13/wood,
 /area/f13/caves)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9853,11 +9871,34 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"fmW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "fnc" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
 	},
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -9954,8 +9995,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -9978,6 +10021,17 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"fpT" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
+/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -9999,15 +10053,52 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqB" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fqF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10195,10 +10286,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
@@ -10218,25 +10312,22 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
+/obj/structure/fence{
 	dir = 1
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fxi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -10252,14 +10343,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"fxX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/remains/human,
@@ -10272,10 +10355,8 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
@@ -10306,15 +10387,6 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"fyC" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
-/area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
 /turf/open/floor/carpet/vault,
@@ -10342,15 +10414,23 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "fzD" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10368,8 +10448,15 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10548,7 +10635,7 @@
 /area/f13/tunnel)
 "fGK" = (
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -10653,14 +10740,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/structure/fence{
-	dir = 1
-	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10716,13 +10801,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"fLy" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "fLK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -10827,16 +10905,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fOy" = (
@@ -10873,10 +10946,9 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fPt" = (
 /obj/structure/barricade/bars{
@@ -10929,11 +11001,11 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/wood{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -10946,8 +11018,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -11085,10 +11161,10 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "fUv" = (
@@ -11127,10 +11203,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -11464,13 +11542,8 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "geR" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
 /area/f13/den)
 "gfu" = (
@@ -11586,8 +11659,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11614,14 +11694,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
@@ -11718,8 +11792,9 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11766,11 +11841,12 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
 	},
-/area/f13/caves)
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "gqt" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -11940,11 +12016,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -11954,15 +12027,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/turf/open/water,
+/area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -11998,6 +12068,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"gxS" = (
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
+	},
+/turf/open/water,
+/area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/enclave)
@@ -12015,6 +12093,14 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
+"gyu" = (
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_large,
@@ -12036,6 +12122,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"gza" = (
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -12110,6 +12200,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/green,
+/area/f13/den)
+"gBM" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12246,18 +12347,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"gFp" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -12355,38 +12444,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -12417,15 +12480,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"gIt" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12563,13 +12617,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
@@ -12675,22 +12726,14 @@
 	},
 /area/f13/caves)
 "gQW" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "gRa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
-	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12859,10 +12902,8 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13466,14 +13507,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"hqt" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "hrM" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -13648,12 +13681,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13786,9 +13815,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13911,19 +13939,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -14115,13 +14132,14 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14580,12 +14598,13 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15046,10 +15065,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -15218,15 +15237,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
 	dir = 1;
-	pixel_x = 7
+	pixel_y = 23
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
@@ -15370,11 +15395,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "iDh" = (
 /obj/structure/rack,
@@ -15587,11 +15610,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15743,18 +15765,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -15914,10 +15930,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/stage_t,
@@ -15945,11 +15962,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -16136,9 +16152,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16164,15 +16179,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jbM" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "jco" = (
 /obj/structure/lattice{
@@ -16684,10 +16696,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "juA" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
@@ -16775,14 +16787,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jxS" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/pondlily_small,
-/turf/open/water,
-/area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Canteen"
@@ -16895,13 +16899,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "jBt" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "jBu" = (
@@ -16965,17 +16969,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/area/f13/den)
+/area/f13/sewer)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17015,12 +17013,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "jFC" = (
@@ -17070,11 +17068,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
@@ -17097,6 +17093,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jIs" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17682,8 +17684,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
@@ -17762,6 +17768,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"kcf" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -18006,9 +18016,11 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18833,9 +18845,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "kJB" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -18867,15 +18884,8 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
@@ -19004,16 +19014,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
-	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "kQy" = (
@@ -19029,13 +19037,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kQU" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -19110,10 +19118,14 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/fence{
+	dir = 8
 	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
@@ -19419,6 +19431,20 @@
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
+"kZh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
+/area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -19703,9 +19729,15 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
@@ -19852,21 +19884,11 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "lmG" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -20031,14 +20053,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20167,14 +20187,13 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "lwU" = (
@@ -20184,6 +20203,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"lxs" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20468,8 +20496,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20810,9 +20841,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -20913,11 +20946,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20994,11 +21024,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
 "lWW" = (
@@ -21505,9 +21532,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "mnU" = (
 /obj/structure/cable{
@@ -21849,6 +21890,17 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"mCP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -22097,13 +22149,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/junglebush,
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
 	dir = 4
 	},
-/obj/effect/light_emitter,
 /turf/open/water,
 /area/f13/den)
 "mNt" = (
@@ -22146,9 +22196,39 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22482,10 +22562,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
@@ -22568,6 +22649,7 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -22668,17 +22750,6 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"ndz" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/den)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22999,15 +23070,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = denmedshutters
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "npf" = (
 /obj/structure/table/booth,
@@ -23112,12 +23180,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"nsf" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -23373,10 +23435,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
@@ -23414,13 +23476,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"nzO" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23563,17 +23618,16 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "nEP" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
@@ -23609,13 +23663,13 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23710,19 +23764,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "nHM" = (
-/obj/structure/chair/f13chair2{
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23776,15 +23833,17 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24108,14 +24167,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nUA" = (
@@ -24299,8 +24352,10 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "nZW" = (
@@ -24373,11 +24428,16 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24598,10 +24658,6 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -24881,10 +24937,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25086,11 +25141,8 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
@@ -25236,14 +25288,10 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -25754,12 +25802,17 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/obj/machinery/microwave{
+	pixel_x = -6
+	},
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -26161,12 +26214,10 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/turf/open/water,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -26636,8 +26687,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26677,9 +26733,12 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt{
@@ -26854,9 +26913,8 @@
 /turf/closed/wall/rust,
 /area/f13/building)
 "pJN" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
@@ -26872,10 +26930,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -27053,13 +27110,13 @@
 /area/f13/brotherhood/operations)
 "pPI" = (
 /obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
+/obj/structure/railing{
 	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
@@ -27196,8 +27253,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -27599,12 +27664,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27705,16 +27768,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -27796,15 +27853,13 @@
 	},
 /area/f13/bunker)
 "qjN" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
@@ -27818,13 +27873,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -28111,9 +28164,15 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "qtf" = (
@@ -28221,16 +28280,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
 /area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
@@ -28416,11 +28472,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/area/f13/caves)
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28451,13 +28511,12 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/water,
 /area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -28536,11 +28595,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -28559,13 +28617,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28605,8 +28662,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/water,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -28744,14 +28804,13 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/caves)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -29094,8 +29153,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29751,6 +29810,10 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rsi" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30145,8 +30208,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30165,8 +30233,16 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30459,8 +30535,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30519,16 +30597,10 @@
 /area/f13/brotherhood/operations)
 "rIU" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30688,9 +30760,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -30863,13 +30938,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
@@ -30921,10 +30995,31 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
+"rSU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31175,10 +31270,10 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "saS" = (
 /obj/item/mine/shrapnel,
@@ -31306,6 +31401,16 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"sfM" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
+/area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -32147,11 +32252,9 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sign/poster/contraband/power,
+/obj/structure/simple_door/wood,
+/turf/open/space/basic,
 /area/f13/den)
 "sIA" = (
 /obj/structure/rack,
@@ -32272,9 +32375,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -32317,10 +32420,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32493,10 +32595,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sTs" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "sTW" = (
 /obj/structure/simple_door/metal/barred,
@@ -32728,10 +32830,15 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -32744,10 +32851,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/den)
 "tcL" = (
@@ -32755,12 +32863,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -32865,14 +32978,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"thm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33007,11 +33112,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "tmc" = (
@@ -33236,6 +33350,17 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"tst" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -33246,6 +33371,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"tsX" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -33271,6 +33406,14 @@
 "tur" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
+"tus" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -33446,12 +33589,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -33540,14 +33678,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"tCQ" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
+"tCl" = (
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
+"tCQ" = (
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = denmedshutters
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "tCZ" = (
@@ -33692,12 +33837,6 @@
 	name = "vault floor"
 	},
 /area/f13/enclave)
-"tGq" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33932,29 +34071,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34229,35 +34350,17 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34408,13 +34511,6 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
-"ube" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -34511,12 +34607,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -34796,18 +34893,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
-"uqb" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -34923,12 +35008,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "usp" = (
@@ -35023,25 +35112,6 @@
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
-"uvj" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -35053,17 +35123,12 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35370,17 +35435,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/waste{
@@ -35457,6 +35514,15 @@
 "uLI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"uLP" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -35707,7 +35773,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "uUH" = (
@@ -35938,16 +36004,11 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "vbU" = (
@@ -36138,11 +36199,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "vfU" = (
@@ -36216,10 +36275,12 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "vjQ" = (
@@ -36229,12 +36290,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"vjW" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -36255,13 +36310,6 @@
 	dir = 1
 	},
 /area/f13/brotherhood/mining)
-"vkj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -36278,20 +36326,27 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/caves)
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36371,11 +36426,6 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"voL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36447,12 +36497,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36498,9 +36546,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/structure/sign/poster/contraband/power,
-/obj/structure/simple_door/wood,
-/turf/open/space/basic,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -37274,10 +37323,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37304,12 +37353,12 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37324,14 +37373,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37467,7 +37518,9 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/item/kirbyplants/random,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
@@ -37524,18 +37577,12 @@
 /turf/open/floor/plasteel,
 /area/f13/bunker)
 "vWZ" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "denmedshutters
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "vXF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -37619,16 +37666,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -37812,18 +37855,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"wgS" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -37845,9 +37876,10 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/machinery/light/floor,
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -37890,6 +37922,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wjM" = (
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
 	desc = "Some sort of pod. Seems this one's maintanance panel is open, someone was working on this.";
@@ -37956,12 +38000,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
@@ -37986,10 +38028,11 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
 	},
-/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -38009,18 +38052,15 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
-	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wpc" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38082,14 +38122,10 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/large,
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
 /turf/open/water,
-/area/f13/den)
+/area/f13/caves)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -38156,15 +38192,9 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -38173,11 +38203,13 @@
 /area/f13/clinic)
 "wvj" = (
 /obj/structure/fence{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
 /obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+	pixel_y = -16
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -38356,6 +38388,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"wzt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -38586,12 +38626,8 @@
 	},
 /area/f13/den)
 "wGF" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
+/obj/structure/falsewall/rust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wGG" = (
 /obj/structure/wreck/trash/engine{
@@ -38711,8 +38747,8 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -38764,9 +38800,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "wMb" = (
 /obj/structure/rack,
@@ -38877,11 +38920,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wQb" = (
 /obj/structure/rack,
@@ -38939,8 +38979,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wRa" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
@@ -39176,12 +39219,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -39228,14 +39267,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "xac" = (
@@ -39794,12 +39832,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"xpf" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/glass,
@@ -39867,13 +39899,10 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -39951,8 +39980,9 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40162,18 +40192,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"xzj" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40786,22 +40804,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"xTi" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -40843,16 +40845,6 @@
 /area/f13/tunnel)
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"xVD" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/caves)
 "xVK" = (
 /obj/structure/cable{
@@ -41060,13 +41052,15 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/machinery/light{
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -41342,6 +41336,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ylp" = (
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -66484,8 +66484,8 @@ wFD
 wFD
 wFD
 wFD
-pCO
-dnc
+eOP
+fjJ
 wFD
 mjG
 dXE
@@ -66732,19 +66732,19 @@ wFD
 lYx
 wFD
 wFD
-pCO
-ffZ
-ffZ
-ffZ
-ffZ
-ffZ
-ffZ
-ffZ
-ffZ
-ffZ
-dnc
-daE
-ffZ
+eOP
+jEr
+jEr
+jEr
+jEr
+jEr
+jEr
+jEr
+jEr
+jEr
+fjJ
+cQp
+jEr
 dXE
 dXE
 dXE
@@ -66993,13 +66993,13 @@ kUN
 kUN
 kUN
 kUN
-czr
+rLJ
 dAO
 dAO
 dAO
 dAO
-ffZ
-vQn
+jEr
+ehL
 wFD
 mjG
 dXE
@@ -67243,20 +67243,20 @@ hQE
 uPr
 hQE
 gMZ
-tXl
-eVt
-tXl
-tXl
+dqh
+fws
+dqh
+dqh
 auj
 auj
 auj
-fqF
-exg
-gkm
-gRa
-vjM
+rSU
+dhF
+sMl
+tda
+eLg
 mjG
-dnc
+fjJ
 wFD
 mjG
 fQL
@@ -67499,21 +67499,21 @@ hQE
 hQE
 uPr
 kUN
-fVm
-jaG
-gkm
-gkm
-gkm
+sTs
+fPo
+sMl
+sMl
+sMl
 auj
-fVm
-gkm
-fqF
+sTs
+sMl
+rSU
 gAy
-gkm
-aLA
+sMl
+jHj
 dzP
-ffZ
-daE
+jEr
+cQp
 wFD
 wFD
 wFD
@@ -67756,23 +67756,23 @@ uPr
 uPr
 uPr
 kUN
-eup
-dEL
-fJp
-fJp
-fJp
-uvI
+ixi
+bPA
+fwZ
+fwZ
+fwZ
+bxH
 auj
 auj
-fzj
+caw
+cdh
+sMl
 kQt
-gkm
-eZw
 dAO
-ffZ
-ffZ
-ffZ
-ffZ
+jEr
+jEr
+jEr
+jEr
 wFD
 wFD
 wFD
@@ -68013,24 +68013,24 @@ hQE
 hQE
 hQE
 kUN
-aqh
-ezs
+kTJ
+jaG
 bzg
 bzg
 bzg
-cYs
+bHI
 auj
-gkm
-gkm
-rQv
+sMl
+sMl
+rzy
 auj
-dpl
+nFt
 wYo
 wYo
 ddv
 ddv
 mjG
-dGU
+ylp
 mjG
 mjG
 mjG
@@ -68270,15 +68270,15 @@ hQE
 hQE
 hQE
 kUN
-aqh
+kTJ
 bzg
 bzg
-fzY
+cJI
 bzg
-xzj
+wvj
 auj
 auj
-dVW
+epg
 cuS
 bTE
 cuS
@@ -68287,7 +68287,7 @@ cuS
 cuS
 ddv
 ddv
-tGq
+lQm
 ddv
 ddv
 ddv
@@ -68527,20 +68527,20 @@ wCB
 hQE
 hQE
 kUN
-aqh
+kTJ
 bzg
 bzg
-pBk
+bve
 bzg
-mOS
-ndz
-gkm
+gow
+fpT
+sMl
 auj
-dsx
-nUx
-bxH
-bxH
-pSU
+wPZ
+gkm
+fyh
+fyh
+bvs
 cuS
 ddv
 ddv
@@ -68784,19 +68784,19 @@ hQE
 hQE
 hQE
 kUN
-aqh
-opa
+kTJ
+gQW
 bzg
 bzg
-fws
-xzj
+pjR
+wvj
 auj
 auj
-gkm
-dsx
-fwZ
-wpc
-bxH
+sMl
+wPZ
+rAd
+dNa
+fyh
 cTL
 cuS
 ddv
@@ -69041,18 +69041,18 @@ hQE
 hQE
 hQE
 kUN
-aqh
+kTJ
 bzg
 bzg
 bzg
-eTS
-cYs
+vkI
+bHI
 auj
+sMl
+sMl
+jIs
 gkm
-gkm
-nsf
-nUx
-bxH
+fyh
 nGD
 cTL
 cuS
@@ -69298,20 +69298,20 @@ hQE
 qTe
 qTe
 kUN
-emK
-wvj
-wvj
-wvj
-wvj
-bve
+aqh
+dUO
+dUO
+dUO
+dUO
+nJC
 auj
-jaG
-gkm
-dsx
-uqb
-wpc
+fPo
+sMl
+wPZ
+pPI
+dNa
 nGD
-iLY
+wms
 cuS
 ddv
 ddv
@@ -69551,7 +69551,7 @@ eah
 eah
 eah
 hOB
-gkm
+sMl
 tiS
 auj
 tac
@@ -69562,13 +69562,13 @@ auj
 auj
 auj
 tac
-gkm
+sMl
 auj
-dsx
-nUx
-bxH
+wPZ
+gkm
+fyh
 nGD
-eMH
+nUx
 cuS
 ddv
 ddv
@@ -69801,7 +69801,7 @@ fIf
 bQP
 fIf
 lBm
-vkj
+eay
 fIf
 fIf
 fIf
@@ -69809,16 +69809,16 @@ fIf
 fIf
 auj
 auj
-gkm
-gkm
+sMl
+sMl
 auj
 uOX
 uOX
 uOX
 uOX
-fjJ
-gkm
-gkm
+fQB
+sMl
+sMl
 wYo
 wYo
 wYo
@@ -69833,7 +69833,7 @@ jqn
 jqn
 jqn
 jqn
-tGq
+lQm
 mjG
 wFD
 wFD
@@ -70065,23 +70065,23 @@ eFv
 eFv
 eFv
 tac
-gkm
-gkm
+sMl
+sMl
 auj
-jaG
-gkm
-auj
-auj
-gkm
+fPo
+sMl
 auj
 auj
-jaG
+sMl
+auj
+auj
+fPo
 wYo
 dpu
-wam
+ocq
 cuS
-xsf
-nJC
+bMI
+mCP
 cTL
 cuS
 ddv
@@ -70286,60 +70286,60 @@ wFD
 wFD
 mjG
 abB
-bPA
-nFt
-bPA
-bPA
-uhB
-ica
+fju
+qjN
+fju
+fju
+wam
+daE
 fEj
-jxS
-tda
+jbM
+uvI
 fEj
-uhB
+wam
 fEj
-uhB
-bdf
-bqI
-nEP
-bPA
-uhB
-bPA
-ica
+wam
+lxs
+fhe
+aJI
+fju
+wam
+fju
+daE
 fEj
-tda
-bPA
-wKN
+uvI
+fju
+fJp
 fEj
-fyC
+dPc
 fEj
-bPA
-wKN
-cJI
-oVS
+fju
+fJp
+tus
+dEl
 fEj
 fEj
-dqh
+tco
 fEj
 mZU
 gMZ
 auj
 auj
-gkm
-gkm
-gkm
+sMl
+sMl
+sMl
 tac
 auj
 auj
-jaG
-jaG
+fPo
+fPo
 wYo
-pPI
-cRY
+wjM
+bXn
 cuS
-gNv
-cRY
-gvC
+fzD
+bXn
+mZs
 cuS
 ddv
 ddv
@@ -70543,60 +70543,60 @@ wFD
 wWB
 mjG
 abB
-fis
-eGQ
-rLJ
-fis
+kcf
+eup
+tXl
+kcf
 hRI
-gow
-fis
+eKX
+kcf
 hRI
-fis
-gWk
-crx
-hRI
-hRI
-fis
+kcf
+gNv
+gRa
 hRI
 hRI
-mnK
-crx
-fis
-wRa
-fis
-wRa
-liN
+kcf
 hRI
+hRI
+iDd
+gRa
+kcf
 fis
-dIq
-wRa
+kcf
+fis
+eZw
+hRI
+kcf
+xtg
+fis
 uVE
-crx
-wRa
-wRa
-epg
+gRa
+fis
+fis
+wpc
 hRI
-fqB
+oBq
 hRI
-esc
+vWZ
 fjU
 bMt
 auj
 auj
 auj
 auj
-gkm
+sMl
 auj
-gkm
-gkm
-dVW
+sMl
+sMl
+epg
 wYo
-saE
+bVO
 cTL
-cQp
-cMf
-iLY
-iLY
+cXP
+pKf
+wms
+wms
 cuS
 ddv
 ddv
@@ -70829,32 +70829,32 @@ kUN
 kUN
 kUN
 hRI
-eWL
-wRa
-ava
+esc
+fis
+eMH
 uVE
 gZB
 hRI
-nHE
+npc
 uOX
 auj
 auj
 iDK
-qXj
-ube
-qXj
-ube
+gWk
+gqj
+gWk
+gqj
 auj
-gkm
-jaG
-fxi
-tzz
-cAU
-vsF
-cTL
+sMl
+fPo
 kQO
-dFv
-bvs
+cqu
+fxi
+sIa
+cTL
+dGU
+kaQ
+bdf
 ddv
 ddv
 ddv
@@ -70873,7 +70873,7 @@ mjG
 mjG
 mjG
 mjG
-oBq
+dnc
 xse
 mjG
 mjG
@@ -71058,38 +71058,38 @@ wFD
 mjG
 aou
 kUN
-hqt
-bIT
-bIT
-jBt
-bIT
-bIT
-bIT
+nEK
+aPF
+aPF
+dZO
+aPF
+aPF
+aPF
 kUN
-qjU
-bIT
-bIT
-fPo
-cAU
-bIT
-fPo
-bIT
-bIT
-qjU
+fOr
+aPF
+aPF
+tzz
+fxi
+aPF
+tzz
+aPF
+aPF
+fOr
 kUN
-bIT
-bIT
-jBt
-bIT
-bIT
-yck
-hqt
+aPF
+aPF
+dZO
+aPF
+aPF
+cIZ
+nEK
 kUN
 hRI
-bMI
+qIj
 hRI
-pJN
-wRa
+ddI
+fis
 xwm
 hRI
 fEW
@@ -71100,18 +71100,18 @@ auj
 blx
 diR
 diR
-bMH
-bMH
-eLg
-eLg
+kJu
+kJu
+vPv
+vPv
 kUN
 cuS
 bTE
 cuS
 yiv
 cuS
-daL
-daL
+dsx
+dsx
 ddv
 ddv
 ddv
@@ -71315,41 +71315,41 @@ wFD
 mjG
 bzl
 kUN
-hqt
-bIT
-bIT
+nEK
+aPF
+aPF
 kUN
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
 kUN
-akT
-bIT
-bIT
+vsF
+aPF
+aPF
 kUN
-bIT
-cAU
+aPF
+fxi
 kUN
-bIT
-bIT
-akT
+aPF
+aPF
+vsF
 kUN
-bIT
-bIT
-kjh
+aPF
+aPF
+uUB
 wYo
-bIT
-bIT
-hqt
+aPF
+aPF
+nEK
 kUN
-wRa
+fis
 hRI
-wRa
-lUs
+fis
+bdL
 rjD
-eWL
-hRI
 esc
+hRI
+vWZ
 fjU
 bMt
 auj
@@ -71357,8 +71357,8 @@ iDK
 blx
 gKU
 aVZ
-dyB
-dyB
+fmW
+fmW
 gCa
 fjS
 wYo
@@ -71367,7 +71367,7 @@ ekQ
 dLn
 efa
 bFe
-daL
+dsx
 eLE
 eLE
 eLE
@@ -71572,38 +71572,38 @@ wFD
 mjG
 bzl
 kUN
-xTi
+tlZ
 nCx
 cTL
 kUN
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
 kUN
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
 kUN
-bIT
-cAU
-lFt
-bIT
-bIT
-bIT
+aPF
+fxi
+flP
+aPF
+aPF
+aPF
 kUN
-bIT
-bIT
+aPF
+aPF
 kUN
 wYo
-bIT
-bIT
-hqt
+aPF
+aPF
+nEK
 kUN
 hRI
-wRa
-wRa
-dli
-tco
+fis
+fis
+bNI
+gwf
 rjD
 hRI
 mZU
@@ -71618,13 +71618,13 @@ gCa
 bmJ
 gCa
 gCa
-cCO
+wGF
 xXZ
 tBY
 xbj
 gJz
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -71829,49 +71829,49 @@ wWB
 mjG
 agK
 kUN
-dZO
+dOg
 cTL
 cTL
 kUN
-bIT
-bIT
-bIT
-uUB
+aPF
+aPF
+aPF
+hFt
 fPt
 fPt
 fPt
-ccg
-cAU
-cAU
+gvC
+fxi
+fxi
 cKb
 fPt
 fPt
 fPt
 kUN
-bIT
-bIT
-fRv
+aPF
+aPF
+faq
 wYo
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
 kUN
 rjD
 uVE
 hRI
-wRa
-dLC
-epg
+fis
+gxS
+wpc
 hRI
-bup
+iPX
 iDK
 auj
 iDK
 auj
 kDG
-kKb
+bPD
 okb
-cIZ
+dyB
 gCa
 gCa
 gCa
@@ -71881,7 +71881,7 @@ jyQ
 flC
 efa
 aLf
-flT
+wuU
 eLE
 yhT
 yhT
@@ -72085,39 +72085,39 @@ bbB
 bbB
 mjG
 aEg
-dgg
-uII
-uII
-uII
+kKb
+dTG
+dTG
+dTG
 dtr
-cAU
-cAU
+fxi
+fxi
 nye
 lAv
-bIT
-bIT
-bIT
-aqW
-cAU
-bIT
-aqW
-bIT
-bIT
-bIT
-aqW
-bIT
-bIT
+aPF
+aPF
+aPF
+cRY
+fxi
+aPF
+cRY
+aPF
+aPF
+aPF
+cRY
+aPF
+aPF
 kUN
 wYo
-fxX
-vPv
-bKb
+ffZ
+vfF
+juA
 kUN
 hRI
-eWL
-wRa
-wRa
-wRa
+esc
+fis
+fis
+fis
 oYU
 hRI
 qFJ
@@ -72125,7 +72125,7 @@ gmI
 iDK
 uDa
 iDK
-nyG
+wzt
 cjg
 auj
 cbQ
@@ -72138,7 +72138,7 @@ hlg
 bTE
 efa
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -72342,39 +72342,39 @@ bbB
 bbB
 mjG
 mjG
-uso
-bIT
-bIT
-bIT
-aqW
-cAU
-bIT
-bIT
-cAU
-bIT
-bIT
-bIT
-bIT
+uLP
+aPF
+aPF
+aPF
+cRY
+fxi
+aPF
+aPF
+fxi
+aPF
+aPF
+aPF
+aPF
 hlO
-bhO
-bhO
-bhO
-bhO
-bhO
-bhO
+egc
+egc
+egc
+egc
+egc
+egc
 hlO
-bIT
+aPF
 kUN
 wYo
 nCx
-eFq
+czr
 ooI
 kUN
-eWL
+esc
 rjD
 hRI
 uVE
-wRa
+fis
 uVE
 hRI
 bLc
@@ -72382,20 +72382,20 @@ iDK
 uDa
 tUT
 gmI
-sIa
+pCO
 wIN
 dTK
 bMt
 pxK
 gCa
-vVu
+wYl
 wYo
 wLR
 kLD
 txw
 efa
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -72599,31 +72599,31 @@ wFD
 wWB
 mjG
 bzl
-bhO
-bhO
-bhO
-bhO
-jbM
-bhO
-bhO
-bhO
+egc
+egc
+egc
+egc
+liN
+egc
+egc
+egc
 dHg
 dHg
 dHg
-bhO
-bhO
-bhO
+egc
+egc
+egc
 fXU
 exf
 eiS
 fXU
 exf
 fXU
-bhO
-bIT
+egc
+aPF
 aqQ
 wYo
-nHM
+eWL
 cTL
 lVK
 kUN
@@ -72639,8 +72639,8 @@ auj
 gJA
 vBZ
 fjA
-sIa
-dPc
+pCO
+dok
 dyu
 bMt
 bIC
@@ -72652,7 +72652,7 @@ ekQ
 dke
 efa
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -72856,19 +72856,19 @@ wFD
 wWB
 mjG
 bzl
-bIT
-egc
-bIT
-bIT
-bIT
-bIT
-bIT
-egc
-bIT
-bIT
-bIT
-egc
-bIT
+aPF
+bPB
+aPF
+aPF
+aPF
+aPF
+aPF
+bPB
+aPF
+aPF
+aPF
+bPB
+aPF
 dHg
 fXU
 iFg
@@ -72876,19 +72876,19 @@ okH
 maO
 rvK
 fXU
-bhO
-bIT
-bIT
+egc
+aPF
+aPF
 kUN
 vct
 vct
 vct
 kUN
-bdL
-bdL
-bdL
-bdL
-bdL
+qGl
+qGl
+qGl
+qGl
+qGl
 fsN
 gNZ
 auj
@@ -72896,20 +72896,20 @@ fUQ
 lCp
 tUT
 iDK
-sIa
+pCO
 cjg
-uvj
+mnK
 dxH
 bIC
 gCa
-vVu
+wYl
 wYo
 xXZ
 wQp
 xbj
 efa
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -73118,29 +73118,29 @@ kUN
 kUN
 kUN
 kUN
-ccg
+gvC
 kUN
 kUN
 kUN
 kUN
 kUN
-fpD
-bIT
-bhO
+pJN
 aPF
+egc
+aLA
 kbT
 uVE
 eyK
 ghs
-fhe
-bhO
-bhO
-bhO
+hJy
+egc
+egc
+egc
 fUv
-bIT
-bIT
-bIT
-qEH
+aPF
+aPF
+aPF
+jFq
 xdj
 xdj
 xdj
@@ -73153,7 +73153,7 @@ jLx
 cAC
 gVL
 tKj
-sIa
+pCO
 wIN
 iDK
 hOB
@@ -73166,7 +73166,7 @@ bIh
 pHQ
 efa
 crb
-daL
+dsx
 eLE
 yhT
 yhT
@@ -73382,22 +73382,22 @@ kUN
 kUN
 kUN
 kUN
-bIT
+aPF
 cBZ
 fXU
 bUh
-wuU
-bXn
+sfM
+eGQ
 bhu
 fXU
-bhO
-bhO
-bhO
+egc
+egc
+egc
 fUv
-bIT
-bIT
-bIT
-vPv
+aPF
+aPF
+aPF
+vfF
 xdj
 xdj
 xdj
@@ -73411,7 +73411,7 @@ auj
 auj
 blx
 qQR
-wGF
+wKN
 fjH
 fjH
 bmJ
@@ -73423,7 +73423,7 @@ cuS
 cuS
 efa
 efa
-daL
+dsx
 eLE
 yhT
 yhT
@@ -73629,8 +73629,8 @@ mjG
 vgV
 kUN
 kUN
-dUk
-sOm
+rSO
+cAU
 gCa
 gCa
 kUN
@@ -73638,23 +73638,23 @@ gCa
 gCa
 gCa
 gCa
-jBt
-bIT
+dZO
+aPF
 dHg
 fXU
-wrg
+bwW
 uVE
 eyK
-pjR
+qEH
 fXU
-bhO
-bhO
-bhO
+egc
+egc
+egc
 fUv
-bIT
-qtc
-bIT
-bIT
+aPF
+ekK
+aPF
+aPF
 xdj
 xdj
 xdj
@@ -73666,12 +73666,12 @@ iDK
 fjh
 iDK
 auj
-sIa
-wgS
+pCO
+vQw
 aVZ
 gCa
 gCa
-juA
+fGK
 gCa
 gCa
 wYo
@@ -73680,7 +73680,7 @@ gVp
 fVQ
 cuS
 cbu
-daL
+dsx
 eLE
 yhT
 yhT
@@ -73886,27 +73886,27 @@ mjG
 vgV
 kUN
 kUN
-hFt
+rGe
 cUt
 dyH
 dLs
 kUN
-wLY
-cXP
-bPD
+itn
+eJq
+dUk
 gCa
-rAd
-bIT
+qXj
+aPF
 dHg
-rzy
-hJy
-wYl
+lUs
+dCp
 mNi
-qxm
+qDc
+wLY
 fXU
-bhO
-bIT
-bIT
+egc
+aPF
+aPF
 kUN
 kUN
 kUN
@@ -73923,20 +73923,20 @@ iDK
 iDK
 iDK
 auj
-sIa
-wgS
+pCO
+vQw
 aVZ
 gCa
-nZC
+ava
 npf
-xpf
+vVu
 gCa
 bmJ
 exn
 bFe
 uuD
 efa
-qfj
+nyG
 hQE
 eLE
 yhT
@@ -74143,33 +74143,33 @@ aLB
 vgV
 kUN
 kUN
-bHA
+lsh
 cWc
 dyH
 gCa
 kUN
-wLY
-cXP
-bPD
+itn
+eJq
+dUk
 gCa
 kUN
-bIT
+aPF
 cBZ
 fXU
 exf
-rzy
+lUs
 fXU
 exf
+aLA
+egc
 aPF
-bhO
-bIT
-fpD
+pJN
 kUN
 kUN
 kUN
 kUN
 kUN
-owJ
+bEV
 fEj
 fEj
 fEj
@@ -74180,12 +74180,12 @@ fjh
 gmI
 iDK
 auj
-sIa
+pCO
 gBD
 aVZ
 gCa
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -74193,7 +74193,7 @@ gAy
 efa
 efa
 efa
-rIU
+oVS
 hQE
 eLE
 yhT
@@ -74400,26 +74400,26 @@ mjG
 vgV
 kUN
 kUN
-dOg
+gyu
 gCa
 gCa
-ddI
+gkY
 kUN
-qIj
-nzO
-kaQ
+nEP
+exN
+owJ
 gCa
 kUN
-bIT
+aPF
 bwq
 dHg
-bhO
-bhO
-bhO
-bhO
-bhO
+egc
+egc
+egc
+egc
+egc
 hlO
-bIT
+aPF
 kUN
 kUN
 kUN
@@ -74437,8 +74437,8 @@ fjh
 hOB
 iDK
 auj
-sIa
-wgS
+pCO
+vQw
 aVZ
 gCa
 gCa
@@ -74446,11 +74446,11 @@ gCa
 gMt
 gCa
 bmJ
-dNa
+tst
 efa
 ucR
 efa
-ixi
+crx
 hQE
 eLE
 yhT
@@ -74662,34 +74662,34 @@ kUN
 ohV
 kUN
 kUN
-wLY
-cXP
-bPD
+itn
+eJq
+dUk
 gCa
 kUN
-bIT
-bIT
-bIT
-cAU
+aPF
+aPF
+aPF
+fxi
 nye
-bIT
-bIT
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
+aPF
+aPF
 kUN
 kUN
 ddx
-aJI
-cxY
+daL
+bqI
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-bAz
-wPZ
+bIT
+ccg
 fjh
 iDK
 tZP
@@ -74699,7 +74699,7 @@ kUN
 gCa
 gCa
 gCa
-juA
+fGK
 gCa
 gCa
 gCa
@@ -74919,26 +74919,26 @@ gCa
 gCa
 eiA
 gCa
-wLY
-cXP
-bPD
+itn
+eJq
+dUk
 gCa
 cKb
-fxX
-bIT
+ffZ
+aPF
 dWg
-bIT
-bIT
-bIT
-eay
-bIT
-bIT
-vra
-lFt
+aPF
+aPF
+aPF
+eBU
+aPF
+aPF
+wRa
+flP
 kUN
-fQB
-hxB
-dCp
+rIU
+eVt
+ohx
 kUN
 kUN
 hRI
@@ -74955,12 +74955,12 @@ iDK
 eiA
 gCa
 gCa
-nZC
+ava
 npf
-xpf
+vVu
 gCa
 ibo
-hOx
+pBk
 xac
 psU
 efa
@@ -75181,28 +75181,28 @@ gCa
 gCa
 gCa
 kUN
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
-cAU
-bIT
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
+fxi
+aPF
 kUN
 kUN
-iPX
-tlZ
-vfF
+kZh
+ajO
+fVm
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-fzD
+rsi
 iDK
 iDK
 iDK
@@ -75211,9 +75211,9 @@ auj
 gmI
 eiA
 fjS
-dyB
+fmW
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -75436,23 +75436,23 @@ gCa
 gCa
 gCa
 gCa
-fLy
+nZC
 kUN
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
 nye
-bIT
+aPF
 kUN
 kUN
-lmD
-qia
-qia
+aQw
+bNV
+bNV
 kUN
 kUN
 hRI
@@ -75695,28 +75695,28 @@ gCa
 gCa
 fOg
 kUN
-fxX
-bIT
+ffZ
+aPF
 dWg
-bIT
-bIT
-bIT
+aPF
+aPF
+aPF
 dWg
-bIT
-cAU
-vra
+aPF
+fxi
+wRa
 kUN
 kUN
-bPB
-mZs
-gIt
+gHU
+xsf
+dEL
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-wif
+qFM
 gmI
 pVU
 tac
@@ -75950,23 +75950,23 @@ gCa
 gCa
 gCa
 gCa
-eJq
+tMr
 kUN
-bIT
-bIT
-wZU
-bIT
-bIT
-bIT
-bIT
-bIT
-bIT
+aPF
+aPF
+dIq
+aPF
+aPF
+aPF
+aPF
+aPF
+aPF
 kUN
 kUN
 kUN
-thm
-dCp
-fyh
+eiz
+ohx
+iUU
 kUN
 kUN
 hRI
@@ -76199,31 +76199,31 @@ mjG
 vgV
 kUN
 kUN
-aQw
-aQw
-aQw
+bAz
+bAz
+bAz
 kUN
 kUN
 kUN
-jBt
+dZO
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-cdh
-cdh
+anK
+anK
 nfB
 kUN
 kUN
 kUN
 kUN
-qGl
-dCp
-dCp
-dCp
+nHE
 ohx
+ohx
+ohx
+qxm
 kUN
 kUN
 hRI
@@ -76461,26 +76461,26 @@ qTe
 qTe
 kUN
 dcd
-nbd
-nbd
-nbd
-iVF
-eCs
-aEe
-ocq
+emK
+emK
+emK
+qfj
+nHM
+fRv
+lFt
 kUN
-eiz
-anK
-anK
-vWZ
-anK
-sTs
+geR
+eHr
+eHr
+gBM
+eHr
+wpa
 kUN
-ewe
-dCp
-dCp
-dCp
-dgO
+lwv
+ohx
+ohx
+ohx
+vbx
 kUN
 kUN
 hRI
@@ -76717,27 +76717,27 @@ kUN
 kUN
 kUN
 kUN
-fnc
-nbd
-lwv
-nbd
-aEe
-aEe
-aEe
-gFp
+eFq
+emK
+fqF
+emK
+fRv
+fRv
+fRv
+pSU
 kUN
-bHI
-anK
-anK
-vWZ
-anK
-fUu
+aXd
+eHr
+eHr
+gBM
+eHr
+aEe
 kUN
-jFq
-dCp
-dCp
-dCp
-tCQ
+vjM
+ohx
+ohx
+ohx
+wZU
 kUN
 kUN
 hRI
@@ -76974,27 +76974,27 @@ dDz
 gyB
 sVT
 kUN
-woj
-nbd
-nbd
-eKX
-iDd
-aEe
-aEe
-jEr
+uhB
+emK
+emK
+jBt
+cQc
+fRv
+fRv
+qtc
 kUN
-eBU
-anK
-anK
-vWZ
-anK
-anK
-geR
-dCp
-dCp
-dCp
-dCp
-gHU
+fpD
+eHr
+eHr
+gBM
+eHr
+eHr
+tsX
+ohx
+ohx
+ohx
+ohx
+fqB
 kUN
 kUN
 hRI
@@ -77228,35 +77228,35 @@ vgV
 kUN
 ciU
 acI
-wms
+rQv
 acI
 kUN
-ekK
-nbd
-nbd
-eKX
-ckD
-lwv
-aEe
-qMr
-kUN
-kTJ
-anK
-anK
-vQw
-anK
-sTs
-kUN
-kUN
-kUN
-kUN
+dgO
+emK
+emK
 jBt
+dpW
+fqF
+fRv
+ica
+kUN
+wif
+eHr
+eHr
+hOx
+eHr
+wpa
+kUN
+kUN
+kUN
+kUN
+dZO
 kUN
 kUN
 kUN
 cSY
-pKf
-ehc
+wrg
+qia
 xdj
 dXE
 dXE
@@ -77488,27 +77488,27 @@ lLo
 fQz
 cSN
 ltu
-nbd
+emK
 dQG
-lwv
-qjN
-cqu
+fqF
+ezs
 nbd
-aEe
-jHj
+emK
+fRv
+fUu
 kUN
-vWZ
-vWZ
-vWZ
+gBM
+gBM
+gBM
 kUN
-anK
-npc
+eHr
+tCQ
 kUN
-xtg
+hxB
 rqX
 rqX
 rqX
-nEK
+dIm
 kUN
 kUN
 cSY
@@ -77743,27 +77743,27 @@ kUN
 gyB
 gyB
 gyB
-dHw
+fzY
 kUN
-vbx
-aEe
-nbd
-aEe
-nbd
-nbd
-aEe
-gkY
+uso
+fRv
+emK
+fRv
+emK
+emK
+fRv
+woj
 kUN
+ckD
 eHr
-anK
-anK
-anK
-anK
-fUu
+eHr
+eHr
+eHr
+aEe
 kUN
-dhF
+vQn
 rqX
-dhF
+vQn
 rqX
 rqX
 kUN
@@ -78002,21 +78002,21 @@ acI
 uBk
 acI
 kUN
-cqu
-cqu
-cqu
-cqu
-aEe
 nbd
-lwv
-aEe
-fOr
-anK
-anK
-anK
-anK
-anK
-anK
+nbd
+nbd
+nbd
+fRv
+emK
+fqF
+fRv
+vlM
+eHr
+eHr
+eHr
+eHr
+eHr
+eHr
 kUN
 rqX
 rqX
@@ -78256,7 +78256,7 @@ vgV
 kUN
 acI
 acI
-dEl
+dTr
 acI
 kUN
 kUN
@@ -78268,16 +78268,16 @@ kUN
 kUN
 kUN
 kUN
+ckD
 eHr
-anK
-anK
-anK
-anK
-rSO
+eHr
+eHr
+eHr
+saE
 kUN
-lsh
+tbE
 rqX
-dhF
+vQn
 rqX
 cLd
 kUN
@@ -78512,8 +78512,8 @@ mjG
 vgV
 kUN
 acI
-tMr
-gQW
+fnc
+opa
 lyd
 kUN
 kUN
@@ -78525,18 +78525,18 @@ kUN
 kUN
 kUN
 kUN
+cCO
 wpa
-sTs
-sTs
-sTs
-anK
-anK
+wpa
+wpa
+eHr
+eHr
 ltu
 rqX
 rqX
-tXd
-bRm
-bNV
+cYs
+mOS
+bhO
 kUN
 kUN
 cSY
@@ -79285,10 +79285,10 @@ hQE
 hQE
 aoj
 aoj
-itn
+dVW
 aoj
 aoj
-bEV
+qjU
 vcx
 aoj
 aoj
@@ -79543,7 +79543,7 @@ hQE
 aoj
 aoj
 aoj
-ajO
+dgg
 emV
 aoj
 aoj
@@ -80055,10 +80055,10 @@ fQL
 hQE
 hQE
 dXE
-cbG
-dok
-iUU
-ehL
+iLY
+tXd
+eCs
+dLC
 dXE
 aoj
 vcx
@@ -80312,10 +80312,10 @@ fQL
 hQE
 hQE
 dXE
-qFM
-rGe
-rGe
-rGe
+lmD
+dHw
+dHw
+dHw
 dXE
 aoj
 aoj
@@ -80569,9 +80569,9 @@ fQL
 hQE
 hQE
 dXE
-sMl
-rGe
-rGe
+gza
+dHw
+dHw
 rSB
 dXE
 aoj
@@ -80828,7 +80828,7 @@ hQE
 dXE
 dXE
 dXE
-vkI
+sOm
 dXE
 dXE
 hQE
@@ -81083,9 +81083,9 @@ fQL
 hQE
 hQE
 uyC
-xVD
+fzj
 sVP
-dTr
+lWO
 buN
 aoj
 aoj
@@ -81110,9 +81110,9 @@ dii
 dii
 dii
 dii
-voL
+vra
 dii
-voL
+vra
 wFD
 mNE
 wFD
@@ -81341,8 +81341,8 @@ hQE
 hQE
 uyC
 uuq
-dTr
-dTr
+lWO
+lWO
 hQE
 hQE
 hQE
@@ -81367,9 +81367,9 @@ dii
 dii
 dii
 dii
-voL
+vra
 dii
-voL
+vra
 wFD
 mNE
 wFD
@@ -81596,15 +81596,15 @@ mjG
 fQL
 hQE
 hQE
-dTr
-dTr
-qDc
-dTr
+lWO
+lWO
+bRm
+lWO
 hQE
 hzR
-rGe
+dHw
 flj
-rGe
+dHw
 hQE
 aoj
 dXE
@@ -81853,15 +81853,15 @@ mjG
 fQL
 hQE
 hQE
-dTr
-dTr
-dTr
-dTr
+lWO
+lWO
+lWO
+lWO
 hQE
-rGe
+dHw
 flj
-rGe
-tbE
+dHw
+iVF
 hQE
 aoj
 dXE
@@ -82110,15 +82110,15 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 uCP
-dTr
-dTr
+lWO
+lWO
 hQE
 flj
-rGe
-rGe
-kJu
+dHw
+dHw
+dli
 hQE
 aoj
 dXE
@@ -82367,15 +82367,15 @@ mjG
 fQL
 hQE
 hQE
-dTr
-dTr
-dTr
-dTr
+lWO
+lWO
+lWO
+lWO
 hQE
 cLS
-rGe
-rGe
-rGe
+dHw
+dHw
+dHw
 hQE
 aoj
 aoj
@@ -82624,9 +82624,9 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 jPC
-vjW
+flT
 jPC
 hQE
 hQE
@@ -82881,7 +82881,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 jPC
 jzO
 dFt
@@ -83138,7 +83138,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 jPC
 lzb
 uqE
@@ -83395,7 +83395,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 jPC
 wDa
 gSS
@@ -83652,7 +83652,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 lQz
 uqE
 ncJ
@@ -83909,7 +83909,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 rCl
 fxD
 gSS
@@ -84166,7 +84166,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 ngX
 dXE
 dXE
@@ -84423,7 +84423,7 @@ mjG
 fQL
 hQE
 hQE
-dTr
+lWO
 lNw
 jPC
 jPC
@@ -84680,10 +84680,10 @@ mjG
 fQL
 hQE
 hQE
-dTr
-vlM
-dTr
-gwf
+lWO
+kjh
+lWO
+yck
 hQE
 aoj
 hQE
@@ -84937,9 +84937,9 @@ mjG
 fQL
 hQE
 hQE
-dTr
-dTr
-dTr
+lWO
+lWO
+lWO
 nBV
 hQE
 aoj
@@ -85191,13 +85191,13 @@ mjG
 wFD
 wFD
 dtk
-lWO
+qMr
 nEz
 uCP
 bSl
-dTr
-dTr
-dTr
+lWO
+lWO
+lWO
 eLq
 mYc
 hQE
@@ -85708,8 +85708,8 @@ mjG
 fQL
 hQE
 hQE
-dTr
-dTr
+lWO
+lWO
 hQE
 dXE
 dXE
@@ -85966,7 +85966,7 @@ fQL
 hQE
 hQE
 gQR
-dTr
+lWO
 hQE
 dXE
 dXE
@@ -86222,8 +86222,8 @@ bbB
 fQL
 hQE
 hQE
-dTr
-dTr
+lWO
+lWO
 hQE
 dXE
 dXE
@@ -86479,8 +86479,8 @@ bbB
 fQL
 hQE
 hQE
-dTr
-dTr
+lWO
+lWO
 hQE
 dXE
 dXE
@@ -86736,8 +86736,8 @@ bbB
 fQL
 hQE
 hQE
-dTr
-dTr
+lWO
+lWO
 hQE
 dXE
 dXE
@@ -88307,8 +88307,8 @@ dXE
 dXE
 dXE
 dXE
-lQm
-gqj
+uII
+tCl
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -60,6 +60,9 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"acI" = (
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "acL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -299,11 +302,13 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -330,9 +335,13 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
@@ -409,6 +418,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
+/obj/structure/simple_door/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -481,15 +491,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/machinery/button/door{
-	id = "densouthgate";
-	name = "South Den Gate";
-	pixel_x = 6;
-	pixel_y = 25
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "aqn" = (
 /obj/effect/decal/waste,
@@ -502,13 +511,22 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"aqQ" = (
+/obj/structure/sign/poster/official/build,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -950,14 +968,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"aEe" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1201,19 +1211,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"aLA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1339,10 +1336,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
@@ -1534,17 +1532,10 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1800,11 +1791,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "bdp" = (
@@ -1838,6 +1827,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bdL" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -1967,13 +1969,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2103,17 +2101,10 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2308,8 +2299,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2478,11 +2470,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -2504,26 +2493,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"bve" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2553,6 +2522,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
+"bwq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "bwt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/left,
@@ -2579,10 +2557,10 @@
 /area/f13/tunnel)
 "bwW" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
@@ -2622,15 +2600,15 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/fence{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/turf/open/floor/plasteel/stairs,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2713,6 +2691,9 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
+"bAz" = (
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "bAC" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/r_wall/rust,
@@ -2905,10 +2886,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -2979,8 +2961,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHI" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
@@ -3033,13 +3017,10 @@
 	},
 /area/f13/brotherhood/operating)
 "bIT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3097,12 +3078,8 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/water,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3168,19 +3145,28 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Auxillary Storage";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "bMI" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3279,13 +3265,8 @@
 	},
 /area/f13/tunnel)
 "bPB" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
@@ -3378,6 +3359,15 @@
 "bRV" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
+"bSl" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -3570,6 +3560,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"bXn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3665,6 +3662,12 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"caw" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3702,13 +3705,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "cbu" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -3760,6 +3762,16 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"ccg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3819,12 +3831,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"cdh" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3989,6 +3995,10 @@
 	dir = 10
 	},
 /area/f13/bunker)
+"ciU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "cjc" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/stripes/white/line,
@@ -4057,17 +4067,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
-"ckD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4251,12 +4250,9 @@
 	},
 /area/f13/caves)
 "cqu" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "cqC" = (
@@ -4287,6 +4283,15 @@
 "crb" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"crx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4546,8 +4551,12 @@
 	},
 /area/f13/tunnel)
 "czr" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "czF" = (
 /obj/machinery/light,
@@ -4657,9 +4666,21 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4778,12 +4799,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"cCO" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -4959,25 +4974,22 @@
 	},
 /area/f13/brotherhood/armory)
 "cIZ" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_y = 29;
-	pixel_x = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
 /area/f13/den)
 "cJJ" = (
@@ -4985,14 +4997,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "cKb" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d00,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "cKA" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -5052,6 +5058,7 @@
 	name = "riverbed soil";
 	yieldmod = 1.3
 	},
+/obj/machinery/light,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "cLe" = (
@@ -5090,13 +5097,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -5151,8 +5155,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
@@ -5199,12 +5206,7 @@
 /area/f13/enclave)
 "cRY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5224,6 +5226,14 @@
 "cSG" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"cSN" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "cSV" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -5254,6 +5264,19 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"cTL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -5383,6 +5406,11 @@
 /obj/machinery/cell_charger{
 	pixel_y = 1
 	},
+/obj/item/card/id/denid,
+/obj/item/card/id/denid,
+/obj/item/card/id/denid,
+/obj/item/card/id/denid,
+/obj/item/card/id/denid,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "cWe" = (
@@ -5413,8 +5441,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5444,17 +5475,19 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
 	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "darkdirty"
 	},
-/area/f13/sewer)
+/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5513,6 +5546,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
+"daE" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/floor/plating/dirt,
@@ -5598,10 +5636,22 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp,
@@ -5624,10 +5674,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dgg" = (
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5665,6 +5711,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"dgO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5692,8 +5745,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5843,6 +5898,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"dli" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -5940,18 +5999,37 @@
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
+"dnc" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "dnP" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 27
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dnQ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -5983,6 +6061,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dok" = (
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6014,13 +6097,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dpl" = (
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dpu" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dpD" = (
 /obj/effect/mob_spawn/human/corpse/vault,
@@ -6031,14 +6114,29 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/item/clothing/gloves/boxing,
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "dqh" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
@@ -6111,6 +6209,10 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"dsx" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6143,6 +6245,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"dtr" = (
+/obj/structure/sign/poster/contraband/scum,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "dty" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6339,6 +6445,12 @@
 /obj/structure/decoration/vent/rusty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"dyH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dyQ" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6388,15 +6500,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "dzP" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dAp" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"dAO" = (
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "dBj" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -6442,6 +6563,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"dCp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
@@ -6461,12 +6590,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "dDz" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dDC" = (
 /obj/structure/chair/stool/bar,
@@ -6490,6 +6616,15 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"dEl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6501,6 +6636,17 @@
 	icon_state = "greenrustycorner"
 	},
 /area/f13/sewer)
+"dEL" = (
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
@@ -6530,17 +6676,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
+"dFv" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dGP" = (
 /obj/structure/cable{
@@ -6566,16 +6715,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"dGU" = (
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
 /area/f13/bunker)
+"dHg" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"dHw" = (
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6587,12 +6751,32 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
+"dIm" = (
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
+"dIq" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -6700,6 +6884,13 @@
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"dLC" = (
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6738,13 +6929,10 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "dNb" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -6800,10 +6988,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"dOg" = (
-/obj/item/reagent_containers/pill/patch/turbo,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -6839,6 +7023,16 @@
 /obj/effect/decal/remains/human,
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
+"dPc" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
+/area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -6898,6 +7092,7 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "dQG" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -6978,6 +7173,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/bunker)
+"dTr" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -6987,18 +7187,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"dTG" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -7019,6 +7207,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"dUk" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7036,6 +7230,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"dUO" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -7121,13 +7322,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dWg" = (
-/obj/structure/table/wood/junk,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7247,10 +7449,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -7292,8 +7492,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7512,6 +7716,14 @@
 /obj/effect/light_emitter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"egc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -7538,15 +7750,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"ehc" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7581,6 +7784,27 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
+"ehL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7589,15 +7813,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"eiz" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -7719,12 +7934,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "ekQ" = (
 /obj/structure/chair/sofa/right{
@@ -7787,6 +8002,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"emK" = (
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "emN" = (
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/den)
@@ -7936,12 +8159,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/water,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "esg" = (
 /obj/item/flag/bos,
 /obj/structure/fence/handrail_end/non_dense{
@@ -8035,12 +8255,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
-"eup" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -8091,10 +8305,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "ewe" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -8109,9 +8321,6 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"exf" = (
-/turf/open/floor/grass,
-/area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -8199,14 +8408,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8254,17 +8459,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"eBU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "eBZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -8283,10 +8477,11 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -8408,6 +8603,11 @@
 /obj/item/key,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"eFq" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8467,10 +8667,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "eHr" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "eHs" = (
@@ -8572,20 +8773,19 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
-/obj/structure/fence{
-	dir = 8
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It smells awful.";
+	name = "waste bucket"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "eJX" = (
 /obj/structure/bed/mattress{
@@ -8616,12 +8816,6 @@
 	light_range = 4
 	},
 /area/f13/brotherhood/archives)
-"eKX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8636,9 +8830,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
+"eLq" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/water,
 /area/f13/caves)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -8691,6 +8891,15 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
+"eMH" = (
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -8946,6 +9155,11 @@
 	dir = 5
 	},
 /area/f13/brotherhood/mining)
+"eTS" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9025,6 +9239,15 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"eWL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -9125,15 +9348,13 @@
 	},
 /area/f13/bunker)
 "faq" = (
-/obj/machinery/chem_master/advanced,
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9251,11 +9472,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/fence{
-	dir = 1
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "fgo" = (
@@ -9316,6 +9537,12 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
+"fhe" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9329,6 +9556,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"fis" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9347,12 +9578,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9376,15 +9603,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
-"fjJ" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9399,15 +9617,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjU" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/structure/table/booth,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
@@ -9454,10 +9665,21 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/den)
+"flP" = (
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "flT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "flW" = (
@@ -9505,12 +9727,15 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Auxillary Storage";
-	req_access_txt = "87"
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/space/basic,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -9607,12 +9832,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -9656,9 +9885,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqF" = (
-/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fqK" = (
@@ -9846,16 +10078,6 @@
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
-"fws" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -9874,17 +10096,38 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
+	},
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fxi" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -9901,13 +10144,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fyd" = (
@@ -9950,6 +10189,12 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"fyC" = (
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
 /turf/open/floor/carpet/vault,
@@ -9977,27 +10222,10 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/turf/closed/indestructible/f13/matrix,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fzD" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
+/obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fzP" = (
@@ -10163,9 +10391,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/operations)
 "fEW" = (
-/obj/structure/table/booth,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fFv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10188,10 +10421,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fGK" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/wood{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
@@ -10294,10 +10528,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10352,6 +10586,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"fLy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "fLK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -10455,6 +10700,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"fOr" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/wood/f13/oak,
@@ -10489,26 +10744,27 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
-"fPt" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
+/obj/structure/table{
 	pixel_x = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"fPt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fPu" = (
 /obj/structure/closet,
@@ -10540,17 +10796,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "fQz" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
-"fQB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -10563,10 +10811,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -10704,8 +10951,14 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/carpet/green,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -10742,6 +10995,12 @@
 "fVi" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
+"fVm" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 4;
@@ -10804,6 +11063,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"fXU" = (
+/turf/open/floor/grass,
+/area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -11070,6 +11332,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
+"geR" = (
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11183,10 +11452,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/sewer)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11305,6 +11572,15 @@
 	name = "plating"
 	},
 /area/f13/bunker)
+"gow" = (
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -11375,14 +11651,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "grm" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/handrail/g_central{
 	dir = 1;
 	pixel_y = 23
 	},
+/obj/structure/table/booth,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "grx" = (
@@ -11532,6 +11806,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"gwf" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -11567,6 +11850,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"gxS" = (
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/enclave)
@@ -11585,13 +11876,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "gyB" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -11609,13 +11911,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"gza" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -11682,11 +11977,19 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"gBD" = (
+/obj/machinery/computer/slot_machine,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "gBM" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/item/kirbyplants/random,
+/turf/open/floor/grass,
+/area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -11779,9 +12082,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
@@ -11918,6 +12228,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
+"gHU" = (
+/obj/structure/table/wood/poker,
+/obj/item/dice/d00,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -12350,11 +12670,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/carpet/green,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -12497,15 +12817,6 @@
 	dir = 8
 	},
 /area/f13/bunker)
-"gZB" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "gZF" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
@@ -12829,6 +13140,7 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "hlO" = (
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
 	},
@@ -12962,23 +13274,14 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "hri" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13154,15 +13457,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/vest/old,
-/obj/item/clothing/suit/armor/vest/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13295,9 +13591,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
+/obj/structure/falsewall/rust,
 /obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/caves)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -13418,16 +13717,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
-"hJy" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -13473,13 +13762,12 @@
 	},
 /area/f13/bunker)
 "hKN" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "hKS" = (
@@ -13622,16 +13910,10 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/sewer)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14088,13 +14370,6 @@
 "ibY" = (
 /obj/structure/sign/poster/contraband/bountyhunters,
 /turf/closed/wall/f13/wood/interior,
-/area/f13/den)
-"ica" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14555,11 +14830,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "greencorner"
-	},
+/turf/open/floor/plating/tunnel,
 /area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
@@ -14729,20 +15000,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
@@ -14885,6 +15148,41 @@
 "iCA" = (
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
+"iDd" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15095,17 +15393,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
-"iLY" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15257,9 +15544,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/item/clothing/gloves/boxing/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "iQf" = (
@@ -15420,11 +15712,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/machinery/processor{
-	density = 0;
-	pixel_x = 30
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
@@ -15453,14 +15751,12 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
@@ -15648,10 +15944,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -15676,13 +15971,6 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jbM" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -16095,8 +16383,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "jqn" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "jqE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16285,13 +16575,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jxS" = (
-/obj/structure/bed/mattress/pregame,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Canteen"
@@ -16403,6 +16686,15 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"jBt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16464,16 +16756,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16560,10 +16850,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
@@ -17170,16 +17458,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"kaQ" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17258,10 +17536,15 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17505,6 +17788,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"kjh" = (
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18298,6 +18585,11 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"kIf" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18329,15 +18621,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -18370,9 +18663,10 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -18500,14 +18794,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18522,12 +18811,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kQU" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -18601,10 +18892,6 @@
 /obj/structure/debris/v4,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"kTJ" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -18910,11 +19197,10 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/table/wood/junk,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
@@ -19199,17 +19485,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"liN" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19355,12 +19630,12 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "lmG" = (
 /obj/structure/rack,
@@ -19557,6 +19832,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"ltu" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "ltN" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/structure/lattice/catwalk,
@@ -19659,10 +19944,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"lxs" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -19681,9 +19962,9 @@
 	},
 /area/f13/brotherhood/operations)
 "lyd" = (
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19753,11 +20034,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "lAv" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "lAw" = (
@@ -19943,10 +20228,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20079,6 +20362,12 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
+"lLo" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "lLs" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -20281,14 +20570,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "lQs" = (
 /obj/structure/fans/tiny{
@@ -20368,6 +20657,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"lTs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "lTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20384,14 +20678,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"lUs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -20970,8 +21256,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "mnU" = (
 /obj/structure/cable{
@@ -21560,15 +21846,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mNi" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "mNt" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -21729,11 +22006,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/area/f13/den)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -21936,17 +22212,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mZs" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -22028,9 +22293,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22128,6 +22393,11 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"ndz" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22169,14 +22439,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"nfB" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "nfW" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -22447,10 +22709,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npf" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -22549,6 +22812,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"nsf" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -22776,17 +23047,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
-"nye" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt{
@@ -22804,15 +23064,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/structure/fence{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -22848,10 +23104,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
-"nzO" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22926,17 +23178,13 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"nBV" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/den)
 "nCl" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
+"nCx" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "nCF" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
@@ -22982,6 +23230,31 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"nEz" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
+"nEK" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
+"nEP" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/fulltile/store,
@@ -23015,11 +23288,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"nFt" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23068,9 +23336,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "nGN" = (
 /obj/machinery/light/small{
@@ -23112,13 +23379,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
-"nHM" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
+"nHE" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "darkrusty"
 	},
+/area/f13/den)
+"nHM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23171,6 +23453,14 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/operating)
+"nJC" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -23492,6 +23782,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"nUx" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -24217,11 +24517,16 @@
 	},
 /area/f13/brotherhood/operations)
 "ooI" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/machinery/button/door{
+	id = "denshutterssouth";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = -25
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "ooJ" = (
 /obj/machinery/light/fo13colored/Pink{
 	dir = 4;
@@ -24432,9 +24737,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"owJ" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -24578,6 +24880,11 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"oBq" = (
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -25087,6 +25394,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"oVS" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -25145,15 +25463,6 @@
 "oYG" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"oYU" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "oZx" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt{
@@ -25488,9 +25797,8 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -25959,6 +26267,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"pBk" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -25996,6 +26312,13 @@
 	name = "cave"
 	},
 /area/f13/tunnel)
+"pCO" = (
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt{
@@ -26169,6 +26492,10 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
 /area/f13/building)
+"pJN" = (
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -26182,6 +26509,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"pKf" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -26358,12 +26689,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -26497,6 +26824,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"pSU" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable{
@@ -26994,15 +27326,6 @@
 /obj/item/stack/sheet/prewar,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"qia" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -27083,16 +27406,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"qjN" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -27390,13 +27703,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/structure/fence{
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -27685,12 +27996,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qDc" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -27797,14 +28102,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -27823,9 +28123,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/barricade/wooden/strong,
@@ -27863,6 +28167,15 @@
 /obj/structure/chair/office,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qIj" = (
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -27999,13 +28312,14 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
@@ -28229,13 +28543,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/closed/indestructible/f13/matrix,
 /area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -28355,9 +28663,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -28723,15 +29032,6 @@
 "rjz" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"rjD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "rjM" = (
 /obj/structure/lattice{
 	layer = 3
@@ -28984,14 +29284,7 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "rqX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/floor/carpet/green,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "rrh" = (
 /obj/effect/decal/cleanable/ash/large,
@@ -29024,13 +29317,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rsi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29425,10 +29711,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/falsewall/rust,
+/obj/structure/decoration/vent/rusty,
+/turf/open/water,
+/area/f13/caves)
 "rzA" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29736,11 +30022,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -29797,6 +30083,43 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"rIU" = (
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -29954,6 +30277,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
+"rLJ" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
@@ -30125,14 +30453,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
+/obj/structure/fence/pole_t,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
@@ -30180,8 +30506,29 @@
 	},
 /area/f13/brotherhood/operating)
 "rSB" = (
+/obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
+"rSO" = (
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
+"rSU" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
 	desc = "Rumor has it that, as long as this tree stands firm, so too will the town of Oasis.";
@@ -31405,6 +31752,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"sIa" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -31524,10 +31877,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/f13{
-	dir = 8;
-	icon_state = "greenrusty"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "sMO" = (
@@ -31572,10 +31924,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/den)
+/area/f13/caves)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31749,9 +32102,6 @@
 /area/f13/tunnel)
 "sTs" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -31814,6 +32164,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sVT" = (
+/obj/structure/table/wood,
+/obj/item/restraints/handcuffs/cable/random,
+/obj/item/restraints/handcuffs/cable/random,
+/obj/item/restraints/legcuffs,
+/obj/item/restraints/legcuffs,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "sWe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -31969,9 +32329,10 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -31984,16 +32345,25 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"tda" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -32150,15 +32520,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"tiS" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greencorner"
-	},
-/area/f13/den)
 "tjf" = (
 /obj/structure/decoration/vent/rusty{
 	pixel_x = -8;
@@ -32234,6 +32595,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tlZ" = (
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -32372,13 +32738,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tqC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/structure/chair/f13foldupchair{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/turf/open/water,
 /area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
@@ -32465,6 +32830,19 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"tst" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -32475,6 +32853,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"tsX" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -32500,6 +32884,14 @@
 "tur" = (
 /turf/closed/wall/rust,
 /area/f13/tunnel)
+"tus" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/water,
+/area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -32758,15 +33150,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"tCl" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32910,11 +33293,11 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33053,11 +33436,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"tKj" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "tKk" = (
 /obj/structure/curtain,
 /obj/structure/lattice/catwalk,
@@ -33419,28 +33797,13 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"tXl" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
-/area/f13/den)
 "tXr" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -33590,11 +33953,6 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
-"ube" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -33968,6 +34326,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"uqb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -34082,6 +34448,11 @@
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
+"uso" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -34136,6 +34507,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"uuq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "uur" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -34179,10 +34554,11 @@
 	},
 /area/f13/building)
 "uvI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/area/f13/caves)
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -34220,11 +34596,6 @@
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
-"uyC" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -34264,19 +34635,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "uBk" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "uBp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34494,6 +34856,18 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"uII" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/waste{
@@ -34571,11 +34945,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
+/obj/structure/table,
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "uLR" = (
@@ -34827,16 +35203,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"uUB" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -35064,13 +35430,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"vbx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "vbU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
@@ -35118,47 +35477,16 @@
 	dir = 4;
 	pixel_x = 6
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = "denshutterssouth"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
 /area/f13/den)
 "vcx" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vcC" = (
 /obj/structure/chair/f13chair1,
@@ -35288,12 +35616,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -35373,14 +35698,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vjW" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/cig_packs,
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "greenrusty"
-	},
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -35402,16 +35725,6 @@
 	dir = 1
 	},
 /area/f13/brotherhood/mining)
-"vkj" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/water,
-/area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -35427,6 +35740,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"vkI" = (
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
@@ -35581,6 +35901,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"vra" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -35626,11 +35954,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
 /area/f13/den)
 "vsI" = (
@@ -36404,6 +36730,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vPv" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36428,6 +36764,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"vQn" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36442,8 +36784,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/green,
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -36579,10 +36924,15 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -36725,14 +37075,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wam" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -36916,10 +37258,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
@@ -36942,15 +37287,16 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
 /area/f13/den)
 "wir" = (
@@ -36995,8 +37341,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/grass,
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -37063,6 +37413,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"wms" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37085,10 +37440,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
-"woj" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
 "wom" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -37104,16 +37455,23 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/item/clothing/mask/cigarette/rollie,
-/obj/item/clothing/mask/cigarette/rollie,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
+"wpc" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "wpj" = (
@@ -37137,6 +37495,19 @@
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
+/area/f13/den)
+"wpF" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
+	},
+/obj/machinery/microwave{
+	pixel_x = -6
+	},
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wqt" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -37172,9 +37543,14 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -37240,6 +37616,18 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"wuU" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
+/area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -37247,10 +37635,8 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -37428,12 +37814,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wzt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37664,6 +38046,10 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/den)
+"wGF" = (
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "wGG" = (
 /obj/structure/wreck/trash/engine{
 	pixel_x = 9
@@ -37777,17 +38163,6 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"wKN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -37949,6 +38324,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
+"wPZ" = (
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
+	},
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -38005,13 +38395,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wRa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
@@ -38247,9 +38635,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28
+	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wYo" = (
@@ -38297,9 +38689,11 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/item/reagent_containers/pill/patch/turbo,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -38856,6 +39250,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"xpf" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/glass,
@@ -38922,6 +39322,17 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"xsf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6;
@@ -38998,10 +39409,8 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -39144,11 +39553,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "xwm" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "xwr" = (
@@ -39826,6 +40234,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"xTi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39868,6 +40283,18 @@
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xVD" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "xVK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40074,10 +40501,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -40353,10 +40781,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ylp" = (
-/obj/structure/bed/mattress,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -40383,6 +40807,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
+"ylL" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -64982,11 +65415,11 @@ sKt
 dXE
 dXE
 dXE
-uPr
+buN
 dXE
-vPg
-vPg
-vPg
+dXE
+dXE
+dXE
 vPg
 vPg
 vPg
@@ -65234,15 +65667,15 @@ dXE
 wFD
 wFD
 dXE
-mjG
-mjG
-dXE
-dXE
-dXE
-bqI
-dXE
-dXE
-dXE
+vlu
+vlu
+hFt
+clb
+clb
+dTr
+rzy
+clb
+clb
 dXE
 dXE
 dXE
@@ -65491,26 +65924,26 @@ wFD
 wFD
 wFD
 wFD
-mjG
-mjG
-mSP
-bqI
-bqI
-bqI
-ddv
-ddv
-wFD
-wFD
-wFD
-wFD
+vlu
+vlu
+qGX
+dTr
+dTr
+dTr
+qGX
+pSU
+vsF
+dpu
+wzt
+geR
 dXE
-aoj
-aoj
-aoj
-aoj
-vPg
-vPg
-vPg
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
 vPg
 vPg
 vPg
@@ -65754,20 +66187,20 @@ snI
 snI
 snI
 snI
-ddv
-ddv
-wFD
-wFD
-wFD
-wFD
+snI
+wYo
+dpu
+dpu
+jaG
+dpu
 dXE
-aoj
-aoj
-aoj
-aoj
-vPg
-vPg
-vPg
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
 vPg
 vPg
 vPg
@@ -66013,18 +66446,18 @@ kUN
 kUN
 wYo
 wYo
-wFD
-wFD
-wFD
-wFD
+dpu
+jaG
+wzt
+geR
 dXE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
 aoj
 vPg
 vPg
@@ -66257,32 +66690,32 @@ dXE
 hQE
 uPr
 hQE
-wYo
-wYo
-wYo
-wYo
-wYo
-kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-cAe
-cYs
-wFD
-wFD
+gMZ
+dUO
+bSl
+dUO
+dUO
+auj
+auj
+auj
+jaG
+dpu
+auj
+auj
+auj
+auj
+dpu
+auj
+dpu
 dXE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-aoj
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
+fQL
 vPg
 vPg
 vPg
@@ -66512,34 +66945,34 @@ dXE
 hQE
 hQE
 kUN
-dhF
+itn
 kUN
-sOm
-sOm
-sOm
-sOm
-sOm
-bMH
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-mjG
-abB
-wFD
-wFD
-dXE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+jaG
+jaG
+dpu
+dpu
+dpu
+auj
+jaG
+dpu
+jaG
+auj
+dpu
+dpu
+dpu
+dpu
+dpu
+auj
+auj
+rzy
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+fQL
 vPg
 mNY
 mNY
@@ -66764,39 +67197,39 @@ dXE
 wFD
 wFD
 bbB
-mSP
+fVm
 uPr
 uPr
 uPr
-dhF
-dhF
+itn
+itn
 kUN
-sOm
-sOm
-sOm
-cCO
-wYo
-kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-mjG
-abB
-wFD
-wFD
-dXE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-mNY
+ddI
+bdL
+jEr
+jEr
+jEr
+iUU
+auj
+dpu
+dgO
+auj
+dpu
+auj
+auj
+auj
+auj
+dpu
+auj
+rzy
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+cSY
+fQL
 mNY
 mNY
 vPg
@@ -67028,32 +67461,32 @@ hQE
 kUN
 kUN
 kUN
-sOm
-sOm
-sOm
-cCO
-wYo
-kUN
-gZB
-gZB
-aXd
-gZB
-gZB
-eFv
-vgV
-mjG
-abB
-wFD
-wFD
+aqh
+hqt
+bzg
+bzg
+bzg
+gwf
+auj
+dpu
+dpu
+auj
+auj
+dpu
+auj
+wzt
+geR
+wzt
+geR
 dXE
-vPg
-aoj
-aoj
-aoj
-lnr
-vPg
-mNY
-mNY
+fQL
+fQL
+fQL
+fQL
+miI
+cSY
+cSY
+fQL
 mNY
 vPg
 vPg
@@ -67285,32 +67718,32 @@ hQE
 kUN
 kUN
 kUN
-sOm
-sOm
-sOm
-sOm
+aqh
+bzg
+bzg
+wvj
+bzg
+xVD
+auj
+auj
+dpu
+dpu
+dpu
+auj
 wYo
-kUN
-mZs
-bxH
-ffZ
-ffZ
-ffZ
-nHM
-nGD
-mjG
-abB
-wFD
-wFD
+wYo
+wYo
+wYo
+wYo
 dXE
-vPg
-vPg
-vPg
-qGl
-lnr
-lnr
-wZU
-mNY
+dXE
+dXE
+dXE
+tur
+miI
+dDp
+dDp
+fQL
 aoj
 aoj
 vPg
@@ -67542,32 +67975,32 @@ wCB
 kUN
 kUN
 kUN
-sOm
-sOm
-sOm
-sOm
-wYo
-kUN
-eJW
-iPX
-gkm
-gkm
-gkm
-eJW
+aqh
+bzg
+bzg
+bzg
+bzg
+tlZ
+bxH
+auj
+auj
+auj
+dpu
+auj
 nGD
-mjG
-abB
-wFD
-wFD
+wRa
+pKf
+pKf
+fzj
+bAz
 dXE
-vPg
-vPg
-vPg
-kKb
-lnr
-lnr
-piQ
-vPg
+dXE
+dXE
+tur
+miI
+dDp
+dDp
+fQL
 vPg
 aoj
 vPg
@@ -67799,32 +68232,32 @@ hQE
 kUN
 kUN
 kUN
-fnc
-wYo
-wYo
-wYo
-wYo
-kUN
-eJW
-gkm
-gkm
+aqh
+ezs
+bzg
+bzg
+uvI
+xVD
+auj
+auj
+dpu
 jaG
-gkm
-nyG
+auj
+dpu
 nGD
-mjG
-abB
-wFD
-wFD
+qGl
+oBq
+pKf
+fzj
+bAz
 dXE
-vPg
-vPg
-vPg
-vPg
-gpM
-gpM
-vPg
-vPg
+dXE
+dXE
+dXE
+miI
+dDp
+cSY
+fQL
 aoj
 vPg
 vPg
@@ -68038,7 +68471,7 @@ hQE
 hQE
 hQE
 hQE
-hQE
+uPr
 hQE
 hQE
 hQE
@@ -68056,32 +68489,32 @@ kUN
 kUN
 kUN
 kUN
-sOm
-sOm
-sOm
-cCO
-wYo
-kUN
-eJW
-gkm
-gkm
-gkm
-gkm
-bup
-nGD
-mjG
-abB
-wFD
-wFD
+aqh
+bzg
+bzg
+bzg
+jHj
+gwf
+auj
+auj
+dgO
+jaG
+dpu
+dpu
+dUk
+wRa
+pKf
+kIf
+fzj
+bAz
 dXE
-vPg
 dXE
 dXE
 tur
-tur
-gpM
-tur
-vPg
+miI
+dDp
+dDp
+fQL
 aoj
 vPg
 vPg
@@ -68295,7 +68728,7 @@ dXE
 dXE
 dXE
 dXE
-dXE
+buN
 dXE
 dXE
 dXE
@@ -68313,32 +68746,32 @@ kUN
 kUN
 kUN
 kUN
-aqh
-sOm
-sOm
-cCO
-wYo
-kUN
-eJW
-vfF
-gkm
-gkm
-lAv
-nyG
+bMI
+fOr
+fOr
+fOr
+fOr
+tst
+auj
+dpu
+jaG
+dpu
+jaG
+dpu
 nGD
-mjG
-abB
-wFD
-wFD
+rQv
+oBq
+kIf
+wZU
+bAz
 dXE
-vPg
 dXE
-eLg
-lfk
-ube
-qXj
+dXE
 tur
-vPg
+miI
+dDp
+dDp
+fQL
 aoj
 aoj
 vPg
@@ -68559,43 +68992,43 @@ eah
 eah
 eah
 eah
-eah
-jxS
-kaQ
-fju
-mNi
-vjW
-rQv
-eBU
-tiS
-nGD
-kUN
-aqh
-sOm
-sOm
-cCO
 wYo
-kUN
-eJW
-gkm
-gkm
-gkm
-dpW
-eJW
+wYo
+hOB
+gMZ
+iDK
+auj
+hOB
+gMZ
+iDK
+auj
+auj
+auj
+auj
+auj
+auj
+auj
+auj
+auj
+dpu
+auj
+dpu
+dpu
+auj
 nGD
-mjG
-abB
-wFD
-wFD
+wRa
+pKf
+kIf
+uso
+bAz
 dXE
-vPg
 dXE
-tGq
-dxj
-dxj
-dxj
+dXE
 tur
-vPg
+miI
+dDp
+dDp
+fQL
 vPg
 aoj
 vPg
@@ -68816,43 +69249,43 @@ fIf
 bQP
 fIf
 lBm
-fIf
-vgV
-ewe
-fIf
-vgV
-wRa
-wvj
-vgV
-dmS
-lFt
-wKN
-sOm
-sOm
-sOm
-sOm
+ddg
 wYo
-kUN
-bPB
+ewe
+fjU
+bMt
+auj
+ewe
+fjU
+bMt
+iDK
+auj
+uOX
+uOX
+uOX
+uOX
+nyG
+dpu
+dpu
+dpu
 qtc
-qtc
-qtc
-qtc
-cIZ
-vgV
-mjG
-abB
-wFD
-wFD
-hQE
-hQE
+geR
+wYo
+wYo
+wYo
+cuS
+cuS
+cuS
+yiv
+bAz
 dXE
-jqn
-dxj
-dxj
-bnj
+dXE
+dXE
 tur
-vPg
+miI
+dDp
+dDp
+fQL
 vPg
 vPg
 vPg
@@ -69073,42 +69506,42 @@ eFv
 eFv
 eFv
 eFv
-eFv
-eFv
-ajO
-eFv
-lQm
-ekK
-ajO
-sMl
-itn
-lFt
-kUN
-dTG
-dTG
-dTG
-dTG
-hFt
-kUN
-vgV
+wYo
+wYo
+auj
+uOX
+auj
+auj
+auj
+uOX
+auj
+auj
+jaG
 dpu
+auj
+auj
 dpu
+auj
+auj
+jaG
+auj
 dpu
-dpu
-vgV
-vgV
-mjG
-abB
-wFD
-wFD
-hQE
-hQE
+auj
+wYo
+akT
+dZO
+cuS
+faq
+fLy
+fzj
+bAz
 dXE
 dXE
+dXE
 tur
-vtz
-tur
-tur
+miI
+dDp
+dDp
 dXE
 dXE
 dXE
@@ -69330,40 +69763,40 @@ fEj
 fEj
 fEj
 fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-vkj
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-cqu
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+hRI
+hRI
+mZU
+gMZ
+auj
+auj
+iDK
+gMZ
+iDK
+auj
+auj
+gMZ
+xTi
+xTi
+fGK
+fGK
+jaG
+jaG
+auj
+qtc
+geR
+wYo
+faq
+fLy
+cuS
+gow
+kQO
+wZU
+gkm
+ddv
+ddv
+ddv
+ddv
 mjG
-abB
-wFD
-wFD
-wFD
-wFD
-wFD
-wFD
-wFD
-ryY
 wFD
 wFD
 wFD
@@ -69589,38 +70022,38 @@ hRI
 hRI
 hRI
 hRI
-hRI
-esc
-esc
-esc
-esc
-kQt
-vgV
-wvj
-vgV
-vgV
-wvj
-vgV
-vgV
-wvj
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+lmD
+fjU
+bMt
+auj
+ewe
+fjU
+bMt
+auj
+auj
+fjU
+fjU
+fjU
+wms
+fjU
+auj
+auj
+auj
+jaG
+auj
+wYo
+gow
+kQO
+yiv
+cRY
+wZU
+wZU
+gkm
+ddv
+ddv
+ddv
+ddv
 mjG
-abB
-wFD
-wFD
-wFD
-wFD
-wFD
-wFD
-wFD
-ryY
 wFD
 wFD
 wFD
@@ -69846,37 +70279,37 @@ kUN
 hRI
 hRI
 hRI
-esc
-xwm
-gMZ
+gxS
+uOX
+auj
+auj
+tac
+uOX
 iDK
+iDK
+iDK
+uOX
+uOX
+uOX
+uOX
+uOX
 auj
 auj
-vbx
-fIf
-fIf
-vgV
-vgV
-fIf
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-kQO
-mjG
-mjG
-mjG
-mjG
+dpu
+dpu
+auj
+wgS
+vVu
+dZO
+fju
+fxi
+dFv
+cRY
 hOx
-mjG
-mjG
-mjG
-mjG
+ddv
+ddv
+ddv
+ddv
 xse
 mjG
 mjG
@@ -69888,7 +70321,7 @@ mjG
 mjG
 mjG
 mjG
-mjG
+ylL
 xse
 mjG
 mjG
@@ -70073,63 +70506,63 @@ wFD
 mjG
 aou
 kUN
-cCO
-sOm
-sOm
+nsf
+eTS
+eTS
+nUx
+eTS
+eTS
+eTS
+kUN
+nJC
+eTS
+eTS
+tsX
 dZO
-sOm
-sOm
-sOm
+eTS
+tsX
+eTS
+eTS
+nJC
 kUN
-vsF
-sOm
-sOm
-eCs
-bIT
-sOm
-eCs
-sOm
-sOm
-vsF
-kUN
-sOm
-sOm
-dZO
-sOm
-sOm
-sOm
-cCO
+eTS
+eTS
+nUx
+eTS
+eTS
+iVF
+nsf
 kUN
 hRI
 hRI
 hRI
-xwm
-pjR
-fEW
+dCp
+gMZ
 iDK
 auj
-auj
 iDK
-uDa
-uDa
+gMZ
+iDK
+iDK
+auj
 blx
 diR
 diR
-diR
-diR
+dEl
+dEl
+fyC
+fyC
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-hQE
-hQE
-hQE
-hQE
-hQE
+kQt
+bAz
+bAz
+bAz
+bAz
+bAz
 dXE
 dXE
 dXE
@@ -70330,58 +70763,58 @@ wFD
 mjG
 bzl
 kUN
-cCO
-sOm
-sOm
+nsf
+eTS
+eTS
 kUN
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
 kUN
-cCO
-sOm
-sOm
+vQn
+eTS
+eTS
 kUN
-sOm
-bIT
+eTS
+dZO
 kUN
-sOm
-sOm
-cCO
+eTS
+eTS
+vQn
 kUN
-sOm
-sOm
-kUN
+eTS
+eTS
+vcx
 wYo
-sOm
-sOm
-cCO
+eTS
+eTS
+nsf
 kUN
 hRI
 hRI
 hRI
-qFJ
-iDK
-vWZ
-iDK
-iDK
+lmD
+fjU
+bMt
 auj
-gJA
-vBZ
-bVO
+ewe
+fjU
+bMt
+iDK
+iDK
 blx
 gKU
 aVZ
 fmW
 fmW
 gCa
-gCa
+fjS
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
+dPt
+ekQ
+dLn
+efa
+bFe
 hQE
 eLE
 eLE
@@ -70587,45 +71020,45 @@ wFD
 mjG
 bzl
 kUN
-hJy
-sOm
-sOm
+dIm
+nCx
+fzj
 kUN
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
 kUN
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
 kUN
-sOm
-bIT
+eTS
+dZO
+pPI
+eTS
+eTS
+eTS
 kUN
-sOm
-sOm
-sOm
-kUN
-sOm
-sOm
+eTS
+eTS
 kUN
 wYo
-sOm
-sOm
-cCO
+eTS
+eTS
+nsf
 kUN
 hRI
 hRI
 hRI
-bLc
-iDK
-gDU
-gmI
-iDK
+mZU
+uOX
 auj
-lCp
-gvC
-fjA
+auj
+iDK
+uOX
+auj
+iDK
+iDK
 blx
 gKU
 aVZ
@@ -70634,9 +71067,9 @@ bmJ
 gCa
 gCa
 blx
-dPt
-ekQ
-dLn
+xXZ
+tBY
+xbj
 gJz
 efa
 hQE
@@ -70844,59 +71277,59 @@ wWB
 mjG
 agK
 kUN
-cJI
-sOm
-sOm
+wPZ
+fzj
+fzj
 kUN
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
+pjR
+cAU
+cAU
+cAU
+dAO
+dZO
+dZO
+cKb
+cAU
+cAU
+cAU
 kUN
-fPt
-fPt
-fPt
-kUN
-bIT
-bIT
-kUN
-fPt
-fPt
-fPt
-kUN
-sOm
-sOm
-kUN
+eTS
+eTS
+lFt
 wYo
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
 kUN
 hRI
 hRI
 hRI
 mZU
-gMZ
+auj
 auj
 iDK
-iDK
 auj
-lCp
-tUT
-vBZ
+auj
+auj
+auj
+auj
 kDG
-iLY
+oVS
 okb
 dyB
 gCa
 gCa
 gCa
 blx
-xXZ
-tBY
-xbj
+mbT
+jyQ
+flC
 efa
 aLf
-cAU
+mnK
 eLE
 yhT
 yhT
@@ -71100,57 +71533,57 @@ bbB
 bbB
 mjG
 aEg
-kUN
-dTG
-dTG
-dTG
-kUN
-bIT
-bIT
-nye
-bIT
-sOm
-sOm
-sOm
-sOm
-bIT
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
+bqI
+uII
+uII
+uII
+dtr
+dZO
+dZO
+wpc
+lAv
+eTS
+eTS
+eTS
+aqW
+dZO
+eTS
+aqW
+eTS
+eTS
+eTS
+aqW
+eTS
+eTS
 kUN
 wYo
-sOm
-sOm
-sOm
+dWg
+sMl
+caw
 kUN
 hRI
 hRI
 hRI
-oYU
-qDc
-bMt
+qFJ
+auj
+auj
 iDK
 iDK
 auj
-cAC
-gVL
-gVL
-qFM
-qMr
+auj
+uDa
+uDa
+ekK
+jBt
 gMZ
 cbQ
 bIC
 gCa
 gCa
 blx
-mbT
-jyQ
-flC
+cij
+hlg
+bTE
 efa
 efa
 hQE
@@ -71357,57 +71790,57 @@ bbB
 bbB
 mjG
 mjG
-eiz
-sOm
-sOm
-sOm
-sOm
-bIT
-sOm
-sOm
-bIT
-sOm
-sOm
-sOm
-sOm
+tda
+eTS
+eTS
+eTS
+aqW
+dZO
+eTS
+eTS
+dZO
+eTS
+eTS
+eTS
+eTS
 hlO
+bhO
+bhO
+bhO
+bhO
+bhO
+bhO
 hlO
-hlO
-hlO
-hlO
-hlO
-hlO
-hlO
-sOm
+eTS
 kUN
 wYo
-sOm
-sOm
-lVK
+nCx
+pBk
+ooI
 kUN
 hRI
 hRI
 hRI
-mZU
+bLc
 auj
 auj
 auj
 iDK
 auj
-auj
-auj
-auj
-fpD
-cKb
+gJA
+vBZ
+bVO
+pCO
+gHU
 dTK
 bMt
 pxK
 gCa
 gCa
 blx
-cij
-hlg
-bTE
+wLR
+kLD
+txw
 efa
 efa
 hQE
@@ -71614,57 +72047,57 @@ wFD
 wWB
 mjG
 bzl
-hlO
-hlO
-hlO
-hlO
-fjU
-hlO
-hlO
-hlO
-wzt
-wzt
-wzt
-hlO
-hlO
-hlO
-exf
-exf
+bhO
+bhO
+bhO
+bhO
+nEK
+bhO
+bhO
+bhO
+dHg
+dHg
+dHg
+bhO
+bhO
+bhO
+fXU
+fXU
 eiS
-wjM
-dgg
-exf
-hlO
-sOm
-kUN
+gBM
+dGU
+fXU
+bhO
+eTS
+aqQ
 wYo
-sOm
-sOm
+aQw
+fzj
 lVK
 kUN
 hRI
 hRI
 hRI
 mZU
-uOX
+auj
 auj
 iDK
 auj
 iDK
-auj
-iDK
-iDK
-fpD
-blG
+lCp
+gvC
+fjA
+pCO
+fPt
 dyu
 bMt
 bIC
 gCa
 kNM
 blx
-wLR
-kLD
-txw
+kOS
+ekQ
+dke
 efa
 efa
 hQE
@@ -71871,47 +72304,47 @@ wFD
 wWB
 mjG
 bzl
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-wzt
-exf
+eTS
+egc
+eTS
+eTS
+eTS
+eTS
+eTS
+egc
+eTS
+eTS
+eTS
+egc
+eTS
+dHg
+fXU
 iFg
 okH
 maO
 rvK
-exf
-hlO
-sOm
-sOm
+fXU
+bhO
+eTS
+eTS
 kUN
 vct
 vct
 vct
 kUN
-bKb
-bKb
-bKb
-bKb
-bKb
+tus
+tus
+tus
+tus
+tus
 fsN
 gNZ
 auj
 fUQ
-auj
-auj
-auj
-fpD
+lCp
+tUT
+vBZ
+pCO
 cjg
 dyu
 dxH
@@ -71919,9 +72352,9 @@ bIC
 gCa
 gCa
 blx
-kOS
-ekQ
-dke
+xXZ
+wQp
+xbj
 efa
 efa
 hQE
@@ -72128,34 +72561,34 @@ wFD
 wFD
 mjG
 mjG
+dtr
+kUN
+kUN
+kUN
+kUN
+dAO
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-sOm
-hlO
-nFt
+pJN
+eTS
+bhO
+ndz
 kbT
 uVE
 eyK
 ghs
-nzO
-hlO
-hlO
-hlO
+bKb
+bhO
+bhO
+bhO
 fUv
-sOm
-sOm
-sOm
-tCl
+eTS
+eTS
+eTS
+dqh
 xdj
 xdj
 xdj
@@ -72165,10 +72598,10 @@ ftm
 rzR
 iDK
 jLx
-auj
-auj
-auj
-fpD
+cAC
+gVL
+gVL
+pCO
 wIN
 vWZ
 hOB
@@ -72176,9 +72609,9 @@ bIC
 gCa
 gCa
 blx
-xXZ
-wQp
-xbj
+mbT
+bIh
+pHQ
 efa
 crb
 hQE
@@ -72397,22 +72830,22 @@ kUN
 kUN
 kUN
 kUN
-sOm
+eTS
 cBZ
-exf
+fXU
 bUh
-iVF
-fJp
+dPc
+vfF
 bhu
-exf
-hlO
-hlO
-hlO
+fXU
+bhO
+bhO
+bhO
 fUv
-sOm
-sOm
-sOm
-jHj
+eTS
+eTS
+eTS
+sMl
 xdj
 xdj
 xdj
@@ -72433,9 +72866,9 @@ bmJ
 gCa
 gCa
 qQR
-mbT
-bIh
-pHQ
+cuS
+cuS
+cuS
 efa
 efa
 hQE
@@ -72644,32 +73077,32 @@ mjG
 vgV
 kUN
 kUN
-dzP
-nbd
-dLs
+ehL
+dok
+gCa
+gCa
 kUN
 gCa
 gCa
 gCa
 gCa
-gCa
-dZO
-sOm
-wzt
-exf
-cbu
+nUx
+eTS
+dHg
+fXU
+ajO
 uVE
 eyK
-lmD
-exf
-hlO
-hlO
-hlO
+tqC
+fXU
+bhO
+bhO
+bhO
 fUv
-sOm
-flT
-sOm
-sOm
+eTS
+bHI
+eTS
+eTS
 xdj
 xdj
 xdj
@@ -72681,8 +73114,8 @@ iDK
 fjh
 iDK
 auj
-rzy
-gKU
+pCO
+kJu
 aVZ
 gCa
 gCa
@@ -72694,7 +73127,7 @@ ibY
 gVp
 fVQ
 cuS
-aqW
+cbu
 hQE
 eLE
 yhT
@@ -72901,27 +73334,27 @@ mjG
 vgV
 kUN
 kUN
-fUu
+qXj
 cUt
-tqC
+dyH
+dLs
 kUN
-vQw
-tKj
-cXP
+dFt
+fRv
+kKb
 gCa
-gCa
-kUN
-sOm
-wzt
-tbE
-uBk
-nBV
-ezs
-tXl
-exf
-hlO
-sOm
-sOm
+hxB
+eTS
+dHg
+dli
+gyu
+ixi
+qMr
+wuU
+fXU
+bhO
+eTS
+eTS
 kUN
 kUN
 kUN
@@ -72938,20 +73371,20 @@ iDK
 iDK
 iDK
 auj
-rzy
-gKU
+pCO
+kJu
 aVZ
 gCa
 nZC
-npf
-vVu
+hri
+xpf
 gCa
 bmJ
 exn
 bFe
 uuD
 efa
-efa
+emK
 hQE
 eLE
 yhT
@@ -73158,33 +73591,33 @@ aLB
 vgV
 kUN
 kUN
-gCa
+vjW
 cWc
-dzP
-kUN
-vQw
-tKj
-cXP
-gCa
+dyH
 gCa
 kUN
-sOm
+dFt
+fRv
+kKb
+gCa
+kUN
+eTS
 cBZ
-exf
-exf
-tbE
-wjM
-exf
-nFt
-hlO
-sOm
+fXU
+fXU
+dli
+gBM
+fXU
+ndz
+bhO
+eTS
+pJN
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-tco
+gWk
 fEj
 fEj
 fEj
@@ -73195,12 +73628,12 @@ fjh
 gmI
 iDK
 auj
-rzy
-lxs
+pCO
+gBD
 aVZ
 gCa
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -73208,7 +73641,7 @@ gAy
 efa
 efa
 efa
-akT
+wpF
 hQE
 eLE
 yhT
@@ -73415,31 +73848,31 @@ mjG
 vgV
 kUN
 kUN
+wjM
 gCa
 gCa
+xtg
+kUN
+dpl
+eCs
+dIq
 gCa
 kUN
-cQp
-ica
-cXP
-gCa
-gCa
-kUN
-sOm
-wzt
-wzt
+eTS
+bwq
+dHg
+bhO
+bhO
+bhO
+bhO
+bhO
 hlO
-hlO
-hlO
-hlO
-hlO
-hlO
-sOm
+eTS
 kUN
 kUN
-ddx
-faq
-wif
+kUN
+kUN
+kUN
 kUN
 kUN
 hRI
@@ -73447,13 +73880,13 @@ hRI
 hRI
 hRI
 grm
-gza
+lTs
 fjh
 hOB
 iDK
 auj
-rzy
-gKU
+pCO
+kJu
 aVZ
 gCa
 gCa
@@ -73461,11 +73894,11 @@ gCa
 gMt
 gCa
 bmJ
-rqX
+nHM
 efa
 ucR
 efa
-bwW
+fPo
 hQE
 eLE
 yhT
@@ -73676,35 +74109,35 @@ kUN
 kUN
 ohV
 kUN
-vQw
-tKj
-cXP
+kUN
+dFt
+fRv
+kKb
 gCa
-gCa
 kUN
-sOm
-sOm
-sOm
-bIT
-nye
-sOm
-sOm
-sOm
-sOm
-sOm
+eTS
+eTS
+eTS
+dZO
+wpc
+eTS
+eTS
+eTS
+eTS
+eTS
 kUN
 kUN
-jbM
-pPI
-uyC
+ddx
+uLP
+nHE
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-ntg
-iDK
+dEL
+xwm
 fjh
 iDK
 tZP
@@ -73933,34 +74366,34 @@ gCa
 gCa
 gCa
 eiA
-vQw
-tKj
-cXP
 gCa
+dFt
+fRv
+kKb
 gCa
-kUN
-sOm
-sOm
+cKb
 dWg
-sOm
-sOm
-sOm
-fjJ
-sOm
-sOm
-dWg
+eTS
+kZh
+eTS
+eTS
+eTS
+wrg
+eTS
+eTS
+dLC
+pPI
 kUN
-kUN
-ckD
-bdf
-lUs
+bwW
+czr
+eFq
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-fwZ
+ntg
 iDK
 iDK
 iDK
@@ -73971,14 +74404,14 @@ eiA
 gCa
 gCa
 nZC
-npf
-vVu
+hri
+xpf
 gCa
 ibo
-bhO
+eMH
 xac
 psU
-iUU
+efa
 fKK
 hQE
 eLE
@@ -74196,28 +74629,28 @@ gCa
 gCa
 gCa
 kUN
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-bIT
-sOm
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+dZO
+eTS
 kUN
 kUN
-ixi
-liN
-liN
+cYs
+flT
+cJI
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-fyB
+fis
 iDK
 iDK
 iDK
@@ -74228,7 +74661,7 @@ eiA
 fjS
 fmW
 gCa
-fGK
+blG
 gCa
 gCa
 gCa
@@ -74451,30 +74884,30 @@ gCa
 gCa
 gCa
 gCa
-gWk
+vkI
 kUN
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-nye
-sOm
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
+wpc
+eTS
 kUN
 kUN
-uyC
-uyC
-uyC
+dpW
+xsf
+xsf
 kUN
 kUN
 hRI
 hRI
 bVp
 kUN
-tac
+fyB
 auj
 iDK
 iDK
@@ -74710,28 +75143,28 @@ gCa
 gCa
 fOg
 kUN
-sOm
-sOm
 dWg
-sOm
-sOm
-sOm
-dWg
-sOm
-bIT
-dWg
+eTS
+kZh
+eTS
+eTS
+eTS
+kZh
+eTS
+dZO
+dLC
 kUN
 kUN
-dnP
-uyC
-uyC
+iPX
+yck
+flP
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-iDK
+tac
 gmI
 pVU
 tac
@@ -74965,23 +75398,23 @@ gCa
 gCa
 gCa
 gCa
-kZh
+eJq
 kUN
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-sOm
-xtg
+eTS
+eTS
+dzP
+eTS
+eTS
+eTS
+eTS
+eTS
+eTS
 kUN
 kUN
 kUN
-uLP
-uyC
-uyC
+vra
+eFq
+nEP
 kUN
 kUN
 hRI
@@ -75214,31 +75647,31 @@ mjG
 vgV
 kUN
 kUN
-gCa
-gCa
-gCa
+bPB
+bPB
+bPB
 kUN
 kUN
 kUN
-dZO
+nUx
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-fpD
-fpD
-nfB
-nfB
-fpD
-fpD
+anK
+anK
 kUN
-fQz
-uyC
-uyC
-uyC
-qjN
+kUN
+kUN
+kUN
+kUN
+rSO
+eFq
+eFq
+eFq
+hKN
 kUN
 kUN
 hRI
@@ -75471,31 +75904,31 @@ mjG
 vgV
 kUN
 kUN
-gCa
-gCa
-gCa
+qTe
+qTe
+qTe
 kUN
 dcd
-dQG
-dQG
-dQG
-cdh
-qTe
-aEe
-eHr
+nbd
+nbd
+nbd
+rGe
+qIj
+uqb
+tco
 kUN
-fRv
-anK
-anK
-anK
-anK
-dNa
+mSP
+eLg
+eLg
+uII
+eLg
+sTs
 kUN
-ehc
-uyC
-uyC
-uyC
-qia
+fEW
+eFq
+eFq
+eFq
+ffZ
 kUN
 kUN
 hRI
@@ -75728,31 +76161,31 @@ mjG
 vgV
 kUN
 kUN
-gCa
-gCa
-gCa
 kUN
-wgS
-dQG
+kUN
+kUN
+kUN
+bdf
+nbd
 lwv
-dQG
-aEe
-aEe
-aEe
-jEr
+nbd
+uqb
+uqb
+uqb
+fpD
 kUN
-fRv
-anK
-anK
-anK
-anK
-dNa
+fqF
+eLg
+eLg
+uII
+eLg
+vQw
 kUN
-uUB
-eup
-uyC
-eup
-dDz
+bMH
+eFq
+eFq
+eFq
+kcf
 kUN
 kUN
 hRI
@@ -75984,32 +76417,32 @@ wFD
 mjG
 vgV
 kUN
+dnP
+dDz
+gyB
+sVT
 kUN
-gCa
-gCa
-gCa
-kUN
-rjD
-dQG
-dQG
-aPF
-tXd
-aEe
-aEe
 cMf
+nbd
+nbd
+aPF
+cXP
+uqb
+uqb
+gDU
 kUN
-anK
-anK
-anK
-anK
-anK
-anK
-kUN
-vcx
-uyC
-uyC
-uyC
-vcx
+bEV
+eLg
+eLg
+uII
+eLg
+eLg
+fUu
+eFq
+eFq
+eFq
+eFq
+rIU
 kUN
 kUN
 hRI
@@ -76241,37 +76674,37 @@ wFD
 mjG
 vgV
 kUN
+ciU
+acI
+eay
+acI
 kUN
-gCa
-gCa
-gCa
-kUN
-aQw
-dQG
-dQG
+sIa
+nbd
+nbd
 aPF
-hxB
+eWL
 lwv
-aEe
-cRY
+uqb
+crx
 kUN
-hKN
-dFt
-dFt
-dFt
-dFt
-dFt
-kUN
-kUN
+tGq
+eLg
+eLg
+vPv
+eLg
+sTs
 kUN
 kUN
-dZO
+kUN
+kUN
+nUx
 kUN
 kUN
 kUN
 cSY
-yck
-bEV
+rLJ
+aXd
 xdj
 dXE
 dXE
@@ -76498,32 +76931,32 @@ wFD
 mjG
 vgV
 kUN
-kUN
-eay
-eay
-eay
-kUN
+eJW
+lLo
+fQz
+cSN
+ltu
+nbd
 dQG
-wYl
 lwv
-kJu
-eJq
-dQG
-aEe
-rsi
-dVW
-anK
-anK
-anK
-anK
-anK
-anK
+fnc
+cqu
+nbd
+uqb
+bXn
 kUN
-dqh
-owJ
-owJ
-owJ
-czr
+uII
+uII
+uII
+kUN
+eLg
+wYl
+kUN
+bup
+rqX
+rqX
+rqX
+dsx
 kUN
 kUN
 cSY
@@ -76755,32 +77188,32 @@ wFD
 mjG
 vgV
 kUN
+gyB
+gyB
+gyB
+rSU
 kUN
-fzj
-fzj
-fzj
+cTL
+uqb
+nbd
+uqb
+nbd
+nbd
+uqb
+ccg
 kUN
-aLA
-aEe
-dQG
-aEe
-dQG
-dQG
-aEe
-fxX
+eHr
+eLg
+eLg
+eLg
+eLg
+vQw
 kUN
-anK
-anK
-anK
-anK
-anK
-hqt
-kUN
-cLd
-owJ
-cLd
-owJ
-owJ
+npf
+rqX
+npf
+rqX
+rqX
 kUN
 kUN
 cSY
@@ -77012,32 +77445,32 @@ wFD
 mjG
 vgV
 kUN
+acI
+acI
+uBk
+acI
 kUN
-kUN
-kUN
-kUN
-kUN
-fqF
-fqF
-fqF
-fqF
-aEe
-dQG
+cqu
+cqu
+cqu
+cqu
+uqb
+nbd
 lwv
-aEe
-hri
-anK
-anK
-anK
-anK
-anK
-eKX
+uqb
+wif
+eLg
+eLg
+eLg
+eLg
+eLg
+eLg
 kUN
-fQB
-owJ
-owJ
-owJ
-bHI
+rqX
+rqX
+rqX
+rqX
+rqX
 kUN
 kUN
 cSY
@@ -77269,6 +77702,10 @@ wFD
 mjG
 vgV
 kUN
+acI
+acI
+cQp
+acI
 kUN
 kUN
 kUN
@@ -77279,21 +77716,17 @@ kUN
 kUN
 kUN
 kUN
+eHr
+eLg
+eLg
+eLg
+eLg
+fxX
 kUN
-kUN
-kUN
-kUN
-anK
-anK
-anK
-anK
-anK
-anK
-kUN
-cLd
-owJ
-cLd
-owJ
+lQm
+rqX
+npf
+rqX
 cLd
 kUN
 kUN
@@ -77526,6 +77959,10 @@ wFD
 mjG
 vgV
 kUN
+acI
+fwZ
+daE
+lyd
 kUN
 kUN
 kUN
@@ -77536,22 +77973,18 @@ kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-kUN
-fxi
 wpa
 sTs
-eKX
-anK
-anK
-fws
-owJ
-owJ
-bve
+sTs
+sTs
+eLg
+eLg
+ltu
+rqX
+rqX
+dnc
+iDd
 fzD
-kTJ
 kUN
 kUN
 cSY
@@ -77784,12 +78217,12 @@ mjG
 mjG
 hQE
 hQE
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
 aoj
 aoj
 aoj
@@ -78041,12 +78474,12 @@ mjG
 fQL
 hQE
 hQE
-aoj
-aoj
-lyd
-aoj
-aoj
-dOg
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
 aoj
 aoj
 aoj
@@ -78300,10 +78733,10 @@ hQE
 hQE
 aoj
 aoj
-gyB
+bIT
 aoj
 aoj
-fPo
+jqn
 aoj
 aoj
 aoj
@@ -78816,7 +79249,7 @@ dXE
 dXE
 dXE
 dXE
-emV
+dXE
 dXE
 aoj
 aoj
@@ -79070,10 +79503,10 @@ fQL
 hQE
 hQE
 dXE
-eLg
-bMI
-ddI
-gyu
+dVW
+kjh
+fJp
+uuq
 dXE
 aoj
 aoj
@@ -79327,10 +79760,10 @@ fQL
 hQE
 hQE
 dXE
-tGq
-rSB
-rSB
-rSB
+fhe
+dHw
+dHw
+dHw
 dXE
 aoj
 aoj
@@ -79584,10 +80017,10 @@ fQL
 hQE
 hQE
 dXE
-jqn
+tXd
+dHw
+dHw
 rSB
-rSB
-ylp
 dXE
 aoj
 aoj
@@ -79843,7 +80276,7 @@ hQE
 dXE
 dXE
 dXE
-wrg
+esc
 dXE
 dXE
 hQE
@@ -79861,7 +80294,7 @@ hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -80097,10 +80530,10 @@ mjG
 fQL
 hQE
 hQE
-uvI
+tbE
 gQR
-uvI
-uvI
+tbE
+tbE
 buN
 uPr
 uPr
@@ -80125,9 +80558,9 @@ dii
 dii
 dii
 dii
-kcf
+dNa
 dii
-kcf
+dNa
 wFD
 mNE
 wFD
@@ -80354,15 +80787,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 uPr
 dXE
@@ -80382,9 +80815,9 @@ dii
 dii
 dii
 dii
-kcf
+dNa
 dii
-kcf
+dNa
 wFD
 mNE
 wFD
@@ -80611,15 +81044,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 hzR
-rSB
+dHw
 flj
-rSB
+dHw
 hQE
 uPr
 dXE
@@ -80632,7 +81065,7 @@ hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 buN
 hQE
@@ -80868,15 +81301,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
-rSB
+dHw
 flj
-rSB
-gBM
+dHw
+dhF
 hQE
 uPr
 dXE
@@ -80890,7 +81323,7 @@ uPr
 uPr
 uPr
 uPr
-rGe
+eLq
 uPr
 hQE
 cSY
@@ -81125,15 +81558,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
+tbE
 uCP
-uvI
-uvI
+tbE
+tbE
 hQE
 flj
-rSB
-rSB
-mnK
+dHw
+dHw
+qFM
 hQE
 uPr
 dXE
@@ -81382,22 +81815,22 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 cLS
-rSB
-rSB
-rSB
+dHw
+dHw
+dHw
 hQE
 uPr
 uPr
 uPr
 uPr
 uPr
-rGe
+eLq
 uPr
 dXE
 dXE
@@ -81639,15 +82072,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-wam
-uvI
+tbE
+tbE
+cIZ
+tbE
 hQE
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -81896,14 +82329,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
-uPr
-uPr
-uPr
+dXE
+dXE
+dXE
 uPr
 uPr
 uPr
@@ -82153,30 +82586,30 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 uPr
 uPr
 uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
-uPr
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
 hQE
 cSY
 cSY
@@ -82410,15 +82843,15 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
+tbE
+tbE
 gQR
-uvI
+tbE
 hQE
 uPr
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
@@ -82667,14 +83100,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 dXE
@@ -82924,14 +83357,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -83181,14 +83614,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 fLU
 eCe
@@ -83438,14 +83871,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 fLU
 pYd
@@ -83695,14 +84128,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 fLU
 pYd
@@ -83952,14 +84385,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
-uvI
-uvI
+tbE
+tbE
+tbE
+tbE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 fLU
 pYd
@@ -84207,16 +84640,16 @@ wFD
 wFD
 dtk
 fQL
-uvI
-uvI
-uvI
-uvI
-uvI
-uvI
-rGe
+nEz
+tbE
+tbE
+tbE
+tbE
+tbE
+eLq
 uPr
 hQE
-uPr
+dXE
 uPr
 fLU
 pYd
@@ -84467,13 +84900,13 @@ fQL
 hQE
 hQE
 hQE
-uvI
+nEz
 hQE
 hQE
 hQE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -84723,14 +85156,14 @@ mjG
 fQL
 hQE
 hQE
-uvI
-uvI
+tbE
+tbE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -84981,13 +85414,13 @@ fQL
 hQE
 hQE
 gQR
-uvI
+tbE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -85237,14 +85670,14 @@ bbB
 fQL
 hQE
 hQE
-uvI
-uvI
+tbE
+tbE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -85494,14 +85927,14 @@ bbB
 fQL
 hQE
 hQE
-uvI
-uvI
+tbE
+tbE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -85751,14 +86184,14 @@ bbB
 fQL
 hQE
 hQE
-uvI
-uvI
+tbE
+tbE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 gFC
@@ -86008,14 +86441,14 @@ mjG
 fQL
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
-uPr
-uPr
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 hQE
@@ -86266,13 +86699,13 @@ fQL
 hQE
 hQE
 uPr
-uPr
-uPr
-uPr
-uPr
+dXE
+dXE
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 hQE
@@ -86523,13 +86956,13 @@ fQL
 hQE
 hQE
 uPr
-uPr
-uPr
-uPr
-uPr
+dXE
+dXE
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 hQE
@@ -86780,13 +87213,13 @@ fQL
 hQE
 hQE
 uPr
-uPr
-uPr
-uPr
-uPr
+dXE
+dXE
+dXE
+dXE
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 hQE
@@ -87043,7 +87476,7 @@ uPr
 uPr
 uPr
 hQE
-uPr
+dXE
 uPr
 hQE
 hQE
@@ -87294,14 +87727,14 @@ fQL
 hQE
 hQE
 hQE
-rGe
+eLq
 hQE
 hQE
 hQE
 hQE
 hQE
-uPr
-uPr
+dXE
+buN
 hQE
 hQE
 dXE
@@ -87322,8 +87755,8 @@ dXE
 dXE
 dXE
 dXE
-woj
-ooI
+wGF
+sOm
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -60,9 +60,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"acI" = (
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "acL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -412,11 +409,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "anK" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "anM" = (
 /obj/structure/rack,
@@ -486,12 +481,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/space/basic,
 /area/f13/den)
 "aqn" = (
 /obj/effect/decal/waste,
@@ -504,24 +499,10 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"aqQ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"aqW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_couch,
-/turf/closed/wall/rust,
-/area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice/d20,
@@ -590,10 +571,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ava" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -969,10 +949,12 @@
 	},
 /area/f13/tunnel)
 "aEe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
 /area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
@@ -1153,12 +1135,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"aJI" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1223,15 +1199,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"aLA" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1324,9 +1291,13 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor1-broken"
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "aPG" = (
@@ -1352,10 +1323,6 @@
 /obj/item/key/scollar,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"aQw" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -1545,11 +1512,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/brotherhood/archives)
-"aXd" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1804,10 +1766,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"bdf" = (
-/obj/structure/sign/poster/contraband/pinup_topless,
-/turf/closed/wall/rust,
-/area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -1839,10 +1797,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bdL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -1972,13 +1926,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2108,11 +2062,10 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/chair/wood{
+	dir = 8
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2306,10 +2259,6 @@
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bqI" = (
-/obj/structure/shelf_wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2477,10 +2426,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bup" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2501,15 +2446,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"bve" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/stack/medical/suture/emergency/fifteen,
-/obj/item/stack/medical/suture/emergency/fifteen,
-/obj/item/stack/medical/gauze/adv,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2518,13 +2454,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
-"bvs" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/cabinet,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -2547,8 +2476,8 @@
 	},
 /area/f13/tunnel)
 "bwq" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/water,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "bwt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2618,13 +2547,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"bxH" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2707,8 +2629,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2902,12 +2832,8 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/chair/f13chair2,
-/obj/machinery/light/floor,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
+/obj/item/reagent_containers/pill/patch/turbo,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -2978,27 +2904,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"bHA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
-"bHI" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -3049,13 +2954,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operating)
-"bIT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/shelf_wood,
-/obj/item/lock_construct,
-/obj/item/key,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3113,8 +3011,15 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3179,19 +3084,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"bMH" = (
-/obj/machinery/autolathe,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"bMI" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3220,16 +3112,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
-"bNI" = (
-/obj/machinery/cell_charger,
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/caps/fivezerozero,
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "KEEP. THE MONEY. IN. A PILE. DO NOT KEEP IT IN YOUR INVENTORY.";
-	name = "READ: ON THE SHOP"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -3238,12 +3120,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3307,25 +3187,22 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"bPA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "bPB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bPD" = (
-/obj/item/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "bPG" = (
@@ -3383,7 +3260,11 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor{
+	density = 0;
+	pixel_x = 30
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bRu" = (
@@ -3424,11 +3305,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
 "bSl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "bSL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3623,8 +3505,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "bXn" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/wood_large,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3721,11 +3604,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"caw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3762,23 +3640,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"cbu" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "cbG" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/smartfridge/bottlerack/drug_storage{
-	density = 0;
-	pixel_y = 32
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -3831,7 +3699,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/machinery/gear_painter,
+/obj/structure/simple_door/wood,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "ccq" = (
@@ -3894,9 +3762,16 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
 /area/f13/den)
 "cdu" = (
@@ -4063,22 +3938,11 @@
 	dir = 10
 	},
 /area/f13/bunker)
-"ciU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "cjc" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"cjg" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/den)
 "cjA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -4131,9 +3995,6 @@
 	},
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
-"ckD" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "ckH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4317,14 +4178,10 @@
 	},
 /area/f13/caves)
 "cqu" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/machinery/gear_painter{
-	density = 0;
-	pixel_x = 32
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cqC" = (
 /obj/machinery/light/small{
@@ -4354,10 +4211,6 @@
 "crb" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"crx" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/rust,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4463,10 +4316,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4565,14 +4415,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"cxY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4627,16 +4469,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"czr" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4745,11 +4577,20 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4806,11 +4647,6 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"cBZ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/billboard/den,
-/turf/open/water,
-/area/f13/den)
 "cCj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4863,10 +4699,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"cCO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/f13/matrix,
-/area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -5041,41 +4873,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"cIZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"cJI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"cKb" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/den)
 "cKA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -5130,11 +4934,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "cLd" = (
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "cLe" = (
 /obj/machinery/microwave/stove,
@@ -5157,12 +4961,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/enclave)
-"cLS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "cLU" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall/r_wall,
@@ -5174,13 +4972,14 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
@@ -5217,13 +5016,7 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
 "cPI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/obj/item/clothing/mask/cigarette/rollie/mindbreaker,
-/obj/item/clothing/mask/cigarette/rollie/mindbreaker,
-/obj/item/clothing/mask/cigarette/rollie/mindbreaker,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/closed/mineral/random/high_chance,
 /area/f13/den)
 "cPP" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -5235,20 +5028,18 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
-"cQc" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
@@ -5294,10 +5085,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "cSe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5318,14 +5107,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
 "cSN" = (
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cSV" = (
 /obj/structure/simple_door/metal/dirtystore,
@@ -5357,14 +5143,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"cTL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -5411,11 +5189,23 @@
 	},
 /area/f13/den)
 "cUt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 3;
+	termtag = "Security"
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	desc = "Smoked by the real cowboys.";
+	name = "\improper Marlboro packet";
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/paper_bin{
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cVg" = (
 /obj/item/chair/wood,
@@ -5474,13 +5264,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "cWc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cWe" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5510,10 +5302,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor4-broken"
-	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5542,12 +5332,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"cYs" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5606,22 +5390,8 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
-"daE" = (
-/obj/structure/table/wood,
-/obj/item/restraints/handcuffs/cable/random,
-/obj/item/restraints/handcuffs/cable/random,
-/obj/item/restraints/legcuffs,
-/obj/item/restraints/legcuffs,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "daL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	dir = 8;
-	icon_state = "rampdowntop"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5655,15 +5425,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "dcd" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/machinery/button/door{
-	id = "denshutters";
-	name = "Den shutters";
-	pixel_x = -28
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dcf" = (
 /obj/structure/decoration/rag,
@@ -5704,15 +5471,11 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "ddx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"ddI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/chem_dispenser,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5737,14 +5500,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
@@ -5783,13 +5548,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
-"dgO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5816,16 +5574,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
-"dhF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5975,12 +5723,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"dli" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -6078,22 +5820,11 @@
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
-"dnc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"dnP" = (
-/obj/machinery/workbench,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "dnQ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/filingcabinet,
@@ -6124,10 +5855,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dok" = (
-/obj/structure/sign/poster/contraband/pinup_ride,
-/turf/closed/wall/rust,
-/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6160,17 +5887,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
-"dpu" = (
-/obj/structure/barricade/concrete,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "dpD" = (
@@ -6181,20 +5902,6 @@
 /obj/structure/nest/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dpW" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2"
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
-"dqh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/wiki/cit/chem_recipies,
@@ -6266,12 +5973,6 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"dsx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6304,10 +6005,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"dtr" = (
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/wall/rust,
-/area/f13/den)
 "dty" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6493,25 +6190,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/decoration/vent/rusty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"dyH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
-/turf/closed/wall/rust,
-/area/f13/den)
 "dyQ" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6561,18 +6250,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "dzP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/rust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dAp" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"dAO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/rust,
-/area/f13/den)
 "dBj" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -6619,18 +6305,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6650,11 +6326,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"dDz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "dDC" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/small,
@@ -6677,17 +6348,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"dEl" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/reagentgrinder{
-	pixel_x = -11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6699,14 +6359,6 @@
 	icon_state = "greenrustycorner"
 	},
 /area/f13/sewer)
-"dEL" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed/old,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer";
@@ -6735,15 +6387,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"dFt" = (
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
-"dFv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/shelf_wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6769,13 +6412,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/f13/stinger,
+/obj/item/grenade/f13/stinger,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "dHc" = (
@@ -6784,24 +6429,10 @@
 	dir = 1
 	},
 /area/f13/bunker)
-"dHg" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
-/area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"dHw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6813,16 +6444,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
-"dIm" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/fluff/railing{
-	dir = 4;
-	pixel_x = -29
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6830,10 +6451,9 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -6943,11 +6563,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6985,13 +6603,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
-"dNa" = (
-/obj/machinery/smartfridge/bottlerack/alchemy_rack{
-	density = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -7047,15 +6658,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"dOg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -7092,9 +6694,8 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/atmosia_independence,
-/turf/closed/wall/rust,
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7155,14 +6756,10 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "dQG" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/structure/railing,
-/obj/machinery/door/poddoor/shutters{
-	id = "denshutters";
-	name = "Den Shutters"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "dQL" = (
 /obj/structure/dresser,
@@ -7240,13 +6837,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/bunker)
-"dTr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7257,9 +6847,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
@@ -7282,8 +6876,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/chem_master/advanced,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7302,12 +6903,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"dUO" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -7393,21 +6988,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
-"dWg" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
 /turf/open/water,
+/area/f13/den)
+"dWg" = (
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "dWB" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7524,10 +7116,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dZR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7565,10 +7161,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/bundle/f13/armor/combat/dark,
-/obj/effect/spawner/bundle/f13/armor/combat/dark,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7787,11 +7381,6 @@
 /obj/effect/light_emitter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"egc" = (
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor1-broken"
-	},
-/area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -7818,13 +7407,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"ehc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor1-broken"
-	},
-/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7859,18 +7441,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
-"ehL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	density = 0;
-	pixel_x = -31
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7879,10 +7449,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"eiz" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -7895,10 +7461,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "eiS" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/grass/green,
+/turf/open/floor/grass,
 /area/f13/den)
 "ejk" = (
 /obj/structure/barricade/wooden/strong,
@@ -8074,16 +7638,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"emK" = (
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/obj/structure/railing,
-/obj/machinery/door/poddoor/shutters{
-	id = "denshutters";
-	name = "Den Shutters"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
 "emN" = (
 /turf/open/floor/wood/f13/oakbroken,
 /area/f13/den)
@@ -8098,8 +7652,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "emV" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/red,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "enc" = (
 /obj/effect/decal/cleanable/dirt{
@@ -8149,11 +7705,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8340,10 +7893,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8414,19 +7965,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "exf" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/rock/jungle,
-/turf/open/water,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "exg" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "exl" = (
@@ -8477,12 +8032,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
-"exN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8521,13 +8070,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"ezs" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/f13{
@@ -8602,13 +8144,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/f13/tcoms)
-"eCs" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot_white,
@@ -8729,10 +8264,6 @@
 /obj/item/key,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
-"eFq" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8779,10 +8310,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"eGQ" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant,
@@ -8795,10 +8322,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"eHr" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "eHs" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -8898,18 +8421,11 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor2-broken"
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
-/area/f13/den)
-"eJW" = (
-/obj/item/reagent_containers/glass/bucket{
-	desc = "It smells awful.";
-	name = "waste bucket"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eJX" = (
 /obj/structure/bed/mattress{
@@ -8941,11 +8457,7 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/plating/tunnel,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -8965,13 +8477,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/red,
-/area/f13/den)
-"eLq" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
-	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9024,15 +8529,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
-"eMH" = (
-/obj/machinery/light/floor,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -9119,16 +8615,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/fo13colored/Red{
-	desc = "A lighting fixture.";
-	dir = 8;
-	light_color = "#008000";
-	name = "light tube"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
@@ -9300,11 +8788,6 @@
 	dir = 5
 	},
 /area/f13/brotherhood/mining)
-"eTS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9354,13 +8837,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"eVt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor3-broken"
-	},
-/area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9391,14 +8867,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"eWL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -9499,14 +8967,16 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/machinery/vending/autodrobe,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
 /area/f13/den)
 "faq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/indestructible/f13vaultrusted,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9632,10 +9102,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ffZ" = (
-/obj/structure/sign/poster/contraband/pinup_shower,
-/turf/closed/wall/rust,
-/area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9694,11 +9160,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
-"fhe" = (
-/obj/structure/chair/stool/retro/tan,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9712,11 +9173,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"fis" = (
-/obj/machinery/recharger,
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9764,18 +9220,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
-"fjJ" = (
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9790,8 +9234,7 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjU" = (
-/obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
@@ -9816,12 +9259,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/f13/old,
 /area/f13/enclave)
-"flj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/tan,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fls" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -9837,15 +9274,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/lattice/catwalk,
 /turf/open/water,
-/area/f13/den)
-"flP" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
-"flT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9887,15 +9315,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"fmW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/den)
-"fnc" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9991,8 +9410,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fpJ" = (
@@ -10016,10 +9438,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"fpT" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -10040,21 +9458,16 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"fqB" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical"
-	},
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "fqF" = (
+/obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10241,15 +9654,6 @@
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
-"fws" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -10276,10 +9680,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"fxi" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -10295,16 +9695,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fyd" = (
@@ -10319,11 +9715,13 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
@@ -10354,11 +9752,6 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"fyC" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
 /turf/open/floor/carpet/vault,
@@ -10385,21 +9778,6 @@
 "fzc" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
-"fzj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"fzD" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -10414,10 +9792,6 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustychess"
 	},
-/area/f13/den)
-"fzY" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10592,11 +9966,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fGK" = (
-/obj/structure/table/wood/junk,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
@@ -10698,17 +10071,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"fJp" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10764,8 +10126,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
+/obj/structure/table,
+/obj/item/stack/medical/gauze,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/den)
@@ -10859,20 +10223,16 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/archives)
 "fOg" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor3-broken"
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_y = -34
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fOp" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
-"fOr" = (
-/obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -10910,14 +10270,16 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/clothing/bos,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"fPt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "fPu" = (
 /obj/structure/closet,
@@ -10949,14 +10311,41 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "fQz" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
-"fQB" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -10969,9 +10358,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor2-broken"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -11108,20 +10497,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
-"fUu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "fUv" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	dir = 4;
-	pixel_x = -29
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "fUy" = (
 /obj/machinery/light/small{
@@ -11153,11 +10532,6 @@
 "fVi" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
-"fVm" = (
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor3-broken"
-	},
-/area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 4;
@@ -11221,9 +10595,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/water,
+/turf/open/floor/grass,
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -11491,12 +10863,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
-"geR" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11609,16 +10975,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"gkm" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11643,16 +10999,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/rnd)
-"gkY" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11748,9 +11094,8 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/machinery/vending/snack,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11797,14 +11142,9 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "gqt" = (
 /obj/structure/rack,
@@ -11990,12 +11330,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/machinery/vending/hydronutrients{
-	density = 0;
-	pixel_y = 30
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
 /area/f13/den)
 "gwm" = (
@@ -12034,11 +11373,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
@@ -12058,17 +11394,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "gyB" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/den)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -12161,17 +11494,11 @@
 	},
 /area/f13/clinic)
 "gBD" = (
-/obj/structure/table/booth,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/area/f13/den)
-"gBM" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/floor,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "gCa" = (
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -12307,15 +11634,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
-"gFp" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/blood/gibs/human/body,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -12412,13 +11730,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/offices2nd)
-"gHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -12445,13 +11756,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"gIt" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12589,12 +11893,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
@@ -12691,20 +11992,9 @@
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gQR" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
-"gQW" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/den)
 "gRa" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12872,12 +12162,6 @@
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
-"gWk" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13019,11 +12303,6 @@
 	dir = 8
 	},
 /area/f13/bunker)
-"gZB" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
-/area/f13/den)
 "gZF" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
@@ -13346,15 +12625,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
-"hlO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/tool{
-	density = 0;
-	pixel_y = -29
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -13484,21 +12754,8 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/water,
-/area/f13/den)
-"hri" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13673,18 +12930,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
-"hxB" = (
-/obj/structure/table/wood/settler,
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/structure/mirror{
-	pixel_y = -32
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "hxF" = (
 /obj/machinery/light{
 	dir = 8
@@ -13740,11 +12985,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"hzR" = (
-/obj/structure/chair/stool/retro/tan,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "hAk" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -13940,9 +13180,19 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/optable,
-/turf/open/floor/wood/wood_large,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -13988,16 +13238,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"hKN" = (
-/obj/item/clothing/mask/cigarette/bigboss,
-/obj/item/clothing/mask/cigarette/bigboss,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "hKS" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -14576,14 +13816,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "ibo" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/machinery/vending/boozeomat/syndicate_access{
+	pixel_y = -33;
+	density = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ibs" = (
 /obj/structure/table,
@@ -14609,9 +13846,10 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15245,12 +14483,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"ixi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/wall/rust,
-/area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -15393,8 +14625,11 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/rust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "iDh" = (
 /obj/structure/rack,
@@ -15606,10 +14841,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
-"iLY" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15760,10 +14991,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
-"iPX" = (
-/obj/structure/legion_extractor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
@@ -15922,12 +15149,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/black,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
@@ -15955,13 +15178,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
-"iVF" = (
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	dir = 8;
-	icon_state = "rampdowntop"
-	},
-/area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -16147,12 +15363,6 @@
 /obj/structure/stalkeregg,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"jaG" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "jaU" = (
 /obj/structure/table,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -16176,13 +15386,6 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jbM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -16693,13 +15896,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"juA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -16904,13 +16100,6 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"jBt" = (
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibmid3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16971,10 +16160,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"jEr" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17014,12 +16199,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_large,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
@@ -17067,11 +16250,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"jHj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17093,11 +16271,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jIs" = (
-/obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17769,18 +16942,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"kcf" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -18024,10 +17185,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"kjh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18822,10 +17979,8 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -18857,15 +18012,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
-"kJu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "kJB" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -19128,12 +18274,6 @@
 /obj/structure/debris/v4,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"kTJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19438,11 +18578,6 @@
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
-"kZh" = (
-/obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
 	dir = 4;
@@ -19726,23 +18861,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"liN" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -19887,14 +19005,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"lmD" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "lmG" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -20059,11 +19169,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20097,17 +19209,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"ltu" = (
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "ltN" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/structure/lattice/catwalk,
@@ -20193,9 +19294,14 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor3-broken"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "lwU" = (
@@ -20226,12 +19332,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
-"lyd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/closed/indestructible/f13/matrix,
-/area/f13/den)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20300,11 +19400,6 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"lAv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/wall/rust,
-/area/f13/den)
 "lAw" = (
 /obj/structure/girder/reinforced,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20359,11 +19454,10 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "lAR" = (
-/obj/structure/barricade/bars,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/den)
 "lBm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20488,13 +19582,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"lFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/smoke{
@@ -20626,12 +19713,6 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
-"lLo" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "lLs" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -20921,11 +20002,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lTs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "lTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20943,13 +20019,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/red,
+/obj/structure/bed/mattress,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20995,8 +20066,15 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
 "lVK" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/indestructible/f13vaultrusted,
+/obj/machinery/button/door{
+	id = "densouthgate";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "lWb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21018,18 +20096,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lWO" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
 	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
@@ -21534,9 +20600,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/machinery/hydroponics/soil/pot,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "mnU" = (
@@ -21880,9 +20946,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mCP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/rust,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
@@ -22180,11 +21247,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22306,43 +21371,6 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"mSP" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/pizzabox/meat,
-/obj/item/pizzabox/meat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -22502,13 +21530,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
-"mYc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22552,13 +21573,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"mZs" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -22640,8 +21654,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22739,14 +21754,6 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"ndz" = (
-/obj/machinery/light/floor,
-/obj/machinery/chem_dispenser,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23062,19 +22069,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"npc" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/chair/stool/retro/tan,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "npf" = (
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -23173,10 +22172,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"nsf" = (
-/obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/rust,
-/area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -23405,11 +22400,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
@@ -23427,14 +22420,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"nyG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -23470,11 +22455,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
+/turf/open/water,
 /area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23550,31 +22536,9 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"nBV" = (
-/obj/structure/table/wood,
-/obj/item/restraints/handcuffs/cable/random,
-/obj/item/restraints/handcuffs/cable/random,
-/obj/item/restraints/legcuffs,
-/obj/item/restraints/legcuffs,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "nCl" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"nCx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/door{
-	id = "densouthgate";
-	name = "South Den Gate";
-	pixel_x = 6;
-	pixel_y = -25
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "nCF" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
@@ -23621,50 +22585,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "nEz" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "nEK" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
-"nEP" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human,
-/obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human,
-/obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/fly,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/fly,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/fly,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
@@ -23700,8 +22632,13 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/indestructible/f13vaultrusted,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23798,20 +22735,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
-"nHE" = (
-/obj/effect/decal/cleanable/blood/gibs/human/core,
-/obj/effect/decal/cleanable/blood/gibs/human/body,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib1-old"
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
-"nHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/drone,
@@ -23864,9 +22787,12 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/effect/decal/cleanable/blood/gibs/human/core,
-/obj/effect/decal/cleanable/blood/gibs/human/body,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24189,14 +23115,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"nUx" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -24377,15 +23295,6 @@
 	dir = 4
 	},
 /area/f13/brotherhood/mining)
-"nZC" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -24455,46 +23364,6 @@
 /obj/machinery/workbench/advanced,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"ocq" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/snacks/donut/meat,
-/obj/item/reagent_containers/food/snacks/donut/meat,
-/obj/item/reagent_containers/food/snacks/donut/meat,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/avian,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/avian,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/avian,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24714,8 +23583,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/obj/effect/light_emitter,
-/turf/open/floor/carpet/red,
+/turf/open/floor/f13{
+	icon_state = "greenrusty"
+	},
 /area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
@@ -24813,8 +23683,15 @@
 	},
 /area/f13/brotherhood/mining)
 "okb" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "okH" = (
 /obj/structure/window/reinforced{
@@ -24963,11 +23840,12 @@
 	},
 /area/f13/brotherhood/operations)
 "ooI" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/closed/indestructible/f13vaultrusted,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "ooJ" = (
 /obj/machinery/light/fo13colored/Pink{
@@ -24980,17 +23858,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"opa" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
@@ -25191,13 +24058,13 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/caves)
+/turf/open/water,
+/area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -25341,10 +24208,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"oBq" = (
-/obj/structure/sign/barsign,
-/turf/closed/wall/rust,
-/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -25854,14 +24717,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"oVS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -26734,13 +25589,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"pBk" = (
-/obj/structure/chair/right,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
 	density = 1
@@ -26779,10 +25627,7 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/chair/middle,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -26957,15 +25802,6 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
 /area/f13/building)
-"pJN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor1-broken"
-	},
-/area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -26979,16 +25815,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"pKf" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -27165,8 +25991,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/sewer)
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -27299,11 +26128,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
-"pSU" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable{
@@ -27703,11 +26527,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"qfj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -27807,10 +26626,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
@@ -27892,16 +26715,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"qjN" = (
-/obj/machinery/hydroponics/soil/pot,
-/obj/machinery/vending/hydroseeds{
-	density = 0;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -27913,15 +26726,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"qjU" = (
-/obj/structure/fence/pole_b,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -28207,12 +27011,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"qtc" = (
-/obj/structure/table,
-/obj/structure/barricade/bars,
-/obj/structure/obstacle/barbedwire,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
 "qtf" = (
 /obj/structure/rack,
 /obj/item/clothing/under/misc/bathrobe,
@@ -28318,10 +27116,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/obj/machinery/light/floor,
 /obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "qxN" = (
@@ -28543,13 +27341,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/item/reagent_containers/glass/bucket{
-	desc = "It smells awful.";
-	name = "waste bucket"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood/wood_large,
+/turf/open/water,
 /area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -28627,13 +27422,6 @@
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"qFM" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -28693,16 +27481,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/obj/machinery/light/floor,
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "1. The Boss gets 35% of any earning. 2. Slavery should not be practiced. 3. DO NOT DRAIN CAPTURES OF BLOOD. Make sure they are indebt to the Mob. 4. Do not keep the earnings of the shop on your person, keep it in the shop itself as a stockpile. 5. The Boss has full say over things.";
-	name = "DEN: RULES"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -29069,11 +27854,25 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -29562,11 +28361,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rjD" = (
-/obj/structure/lattice/catwalk,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
-/turf/open/water,
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rjM" = (
 /obj/structure/lattice{
@@ -29861,9 +28662,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rsi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/wood_large,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
@@ -30259,12 +29067,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/window/fulltile/ruins,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30280,13 +29085,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
-	},
-/area/f13/den)
-"rAd" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "rAj" = (
@@ -30579,10 +29377,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"rGe" = (
-/obj/machinery/light/small,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30639,16 +29433,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"rIU" = (
-/obj/structure/fence/pole_t,
-/obj/structure/chair/sofa,
-/obj/machinery/light/fo13colored/Red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -30808,9 +29592,11 @@
 /area/f13/bunker)
 "rLJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "rLN" = (
@@ -31039,22 +29825,13 @@
 	},
 /area/f13/brotherhood/operating)
 "rSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/light_emitter,
-/turf/open/floor/carpet/red,
-/area/f13/den)
-"rSO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/light_emitter,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "rSU" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "rTg" = (
@@ -31440,11 +30217,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"sfM" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -32285,14 +31057,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"sIa" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -32459,12 +31223,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sOm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32636,12 +31394,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"sTs" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "sTW" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/water,
@@ -32701,17 +31453,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "sVP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"sVT" = (
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "sWe" = (
 /obj/machinery/light{
@@ -32868,18 +31614,8 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/structure/table/wood,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/encryptionkey/headset_den,
-/obj/item/megaphone/command,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
@@ -32892,23 +31628,10 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
-"tco" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/workbench,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"tda" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -33012,13 +31735,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"thm" = (
-/obj/machinery/chem_master,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33156,15 +31872,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tlZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled/bloody/docsdeathnote{
-	info = "It is custom to humiliate your rivals by making them wear the chicken suit and making them do the chicken dance.";
-	name = "READ: IMPORTANT"
-	},
-/obj/structure/table/booth,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -33397,10 +32104,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/structure/chair/left,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
@@ -33412,13 +32117,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"tsX" = (
-/obj/machinery/smartfridge/chemistry{
-	density = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -33445,14 +32143,14 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "tuB" = (
@@ -33629,14 +32327,6 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"tzz" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33721,14 +32411,25 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
-"tCl" = (
-/obj/structure/fence/end/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
 "tCQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/rust,
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34016,14 +32717,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"tKj" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "tKk" = (
 /obj/structure/curtain,
 /obj/structure/lattice/catwalk,
@@ -34113,20 +32806,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = 3;
-	termtag = "Security"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	desc = "Smoked by the real cowboys.";
-	name = "\improper Marlboro packet";
-	pixel_x = 9;
-	pixel_y = 4
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/vest/old,
+/obj/item/clothing/suit/armor/vest/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34401,23 +33089,15 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/turf/open/floor/f13{
+	icon_state = "greenrusty"
 	},
 /area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"tXl" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
 "tXr" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -34667,10 +33347,6 @@
 	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood/rnd)
-"uhB" = (
-/obj/structure/sign/poster/contraband/pinup_couch,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
 	dir = 8
@@ -34950,10 +33626,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "uqb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
@@ -35069,18 +33747,6 @@
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"uso" = (
-/obj/structure/table/wood,
-/obj/item/key,
-/obj/item/key,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -35135,10 +33801,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"uuq" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "uur" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -35161,22 +33823,16 @@
 	},
 /area/f13/brotherhood/rnd)
 "uuD" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
-"uvj" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs/human/body,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib1-old"
-	},
-/obj/effect/mob_spawn/human/corpse/raidermelee,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -35188,20 +33844,8 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/colt357/lucky{
-	armour_penetration = 0.1;
-	desc = "The Brass Gun, a weapon made from a Vet Rangers Sequoia it seems. You feel like a true gunslinger with this.";
-	extra_damage = 38;
-	flags_ricochet = 1;
-	name = "Brass Gun";
-	ricochet_damage_mod = 0.99
-	},
-/obj/item/pda,
-/obj/item/paper_bin{
-	pixel_x = -7
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35240,11 +33884,6 @@
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
-"uyC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35283,34 +33922,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"uBk" = (
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/cloth/thirty,
-/obj/item/stack/sheet/cloth/thirty,
-/obj/item/stack/sheet/cloth/thirty,
-/obj/item/stack/sheet/hay/fifty,
-/obj/item/stack/sheet/hay/fifty,
-/obj/item/stack/crafting/metalparts/five,
-/obj/item/stack/crafting/metalparts/five,
-/obj/item/stack/crafting/metalparts/five,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "uBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -35393,12 +34004,6 @@
 /obj/item/key/bcollar,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
-"uCP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "uCR" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/showcase/machinery/cloning_pod,
@@ -35526,13 +34131,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/machinery/button/door{
-	id = "dennorthgate";
-	name = "North Den Gate";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35610,14 +34217,6 @@
 "uLI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"uLP" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -35867,10 +34466,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
-"uUB" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -36098,10 +34693,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
-"vbx" = (
-/obj/machinery/hydroponics/soil/pot,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "vbU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
@@ -36137,19 +34728,6 @@
 /turf/closed/wall/r_wall,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
-"vct" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
-"vcx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "vcC" = (
 /obj/structure/chair/f13chair1,
 /obj/effect/decal/cleanable/dirt,
@@ -36278,13 +34856,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/water,
+/turf/closed/indestructible/f13/matrix,
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -36357,11 +34929,9 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36425,53 +34995,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"vkI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36553,8 +35084,10 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
@@ -36626,17 +35159,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"vra" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36681,14 +35203,6 @@
 /obj/structure/flora/wasteplant/wild_yucca,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vsF" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
@@ -37460,13 +35974,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vPv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37491,13 +35998,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"vQn" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37512,9 +36012,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "vQM" = (
@@ -37651,9 +36154,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/chair/wood{
+	dir = 1
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -37796,10 +36300,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wam" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -37982,13 +36482,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"wgS" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -38009,9 +36502,6 @@
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
-"wif" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
@@ -38121,11 +36611,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
-"wms" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
-/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -38149,14 +36634,8 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/item/clothing/mask/cigarette/rollie/nicotine,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38173,14 +36652,11 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor{
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/den)
-"wpc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38203,10 +36679,6 @@
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/den)
-"wpF" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/den)
 "wqt" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -38241,13 +36713,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"wrg" = (
-/obj/structure/table/booth,
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -38314,9 +36779,12 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -38505,12 +36973,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
-"wzt" = (
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -38740,12 +37202,6 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/den)
-"wGF" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "wGG" = (
 /obj/structure/wreck/trash/engine{
 	pixel_x = 9
@@ -38789,12 +37245,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
 "wIN" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "wIO" = (
@@ -38860,33 +37314,6 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"wKN" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
-	desc = "A steak with an unfamiliar flavor... almost like turkey, or veal.";
-	name = "strange meat"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/snacks/burger/human{
-	desc = "A bloody burger with a strange, unfamiliar taste.";
-	name = "strange burger"
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -39048,10 +37475,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
-"wPZ" = (
-/obj/structure/simple_door/metal/fence/wooden,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -39350,9 +37773,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "wYo" = (
@@ -39960,10 +38386,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "xpf" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "xpg" = (
@@ -40032,16 +38459,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"xsf" = (
-/obj/machinery/chem_heater,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6;
@@ -40118,10 +38535,13 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40334,16 +38754,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"xzj" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/fence/pole_t,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40956,12 +39366,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"xTi" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41004,14 +39408,6 @@
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xVD" = (
-/obj/effect/decal/cleanable/blood/gibs/human/core,
-/obj/effect/decal/cleanable/blood/gibs/human/body,
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib1-old"
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/den)
 "xVK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41217,14 +39613,6 @@
 /obj/machinery/computer/security/telescreen,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"yck" = (
-/obj/machinery/door/unpowered/celldoor{
-	name = "REPOSSESSIONS"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -41500,22 +39888,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ylp" = (
-/obj/structure/table,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/seeds/datura,
-/obj/item/seeds/punga,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/mesquite,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -41542,13 +39914,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
-"ylL" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -66663,8 +65028,8 @@ mjG
 mjG
 mjG
 mjG
-mjG
-abB
+ddv
+ddv
 wFD
 wFD
 wFD
@@ -66920,8 +65285,8 @@ mjG
 mjG
 mjG
 mjG
-mjG
-abB
+ddv
+ddv
 wFD
 wFD
 wFD
@@ -67164,21 +65529,21 @@ dXE
 dXE
 dXE
 dXE
+buN
 dXE
-dXE
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-nGD
+wYo
+wYo
+wYo
+wYo
+wYo
+wYo
+wYo
 hRI
 hRI
 hRI
@@ -67421,20 +65786,20 @@ dXE
 dXE
 dXE
 hQE
+uPr
 hQE
-hQE
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
+vgV
+vgV
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -67678,20 +66043,20 @@ dXE
 hQE
 hQE
 kUN
+eKX
+kUN
+anK
+anK
+anK
+anK
 kUN
 kUN
-jaG
-jaG
-jaG
-wvj
-yck
-vgV
-gkm
 vgV
 vgV
 vgV
 vgV
-kUN
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -67930,25 +66295,25 @@ dXE
 wFD
 wFD
 bbB
-ddv
-dXE
-hQE
-hQE
+gBD
+uPr
+uPr
+uPr
+eKX
+eKX
+kUN
+anK
+anK
+anK
+anK
 kUN
 kUN
-kUN
-aqh
 vgV
 vgV
 vgV
-kUN
-vgV
-kUN
-aqh
 vgV
 vgV
 vgV
-kUN
 nGD
 hRI
 hRI
@@ -68194,18 +66559,18 @@ hQE
 kUN
 kUN
 kUN
-jaG
-jaG
-jaG
-vgV
+anK
+anK
+anK
+anK
 kUN
-wvj
 kUN
-wvj
 vgV
 vgV
-wvj
-kUN
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -68451,18 +66816,18 @@ hQE
 kUN
 kUN
 kUN
-aqh
-vgV
-vgV
-wvj
+anK
+anK
+anK
+anK
+kUN
 kUN
 vgV
-kUN
-bxH
-jaG
-jaG
 vgV
-kUN
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -68708,18 +67073,18 @@ wCB
 kUN
 kUN
 kUN
-jaG
-jaG
-jaG
+anK
+anK
+anK
+anK
+kUN
+kUN
 vgV
-kUN
 vgV
-kUN
-kUN
-kUN
-kUN
-gkm
-kUN
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -68966,17 +67331,17 @@ kUN
 kUN
 kUN
 aqh
+kUN
+kUN
+kUN
+kUN
+kUN
 vgV
 vgV
-wvj
-kUN
-wvj
-kUN
-jaG
-jaG
-jaG
 vgV
-kUN
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -69222,18 +67587,18 @@ kUN
 kUN
 kUN
 kUN
-jaG
-jaG
-jaG
-vgV
+anK
+anK
+anK
+anK
+kUN
 kUN
 vgV
-kUN
-wvj
 vgV
 vgV
-wvj
-kUN
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -69479,18 +67844,18 @@ kUN
 kUN
 kUN
 kUN
-aqh
-vgV
-vgV
-wvj
+anK
+anK
+anK
+anK
+kUN
 kUN
 vgV
-kUN
-aqh
 vgV
 vgV
 vgV
-kUN
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -69734,20 +68099,20 @@ vjW
 rQv
 eBU
 tiS
+ohx
 kUN
+anK
+anK
+anK
+anK
 kUN
-jaG
-jaG
-jaG
-jaG
-kUN
-wvj
 kUN
 vgV
 vgV
 vgV
 vgV
-kUN
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -69991,20 +68356,20 @@ wRa
 wvj
 vgV
 dmS
+tXd
+exg
+anK
+anK
+anK
+anK
 kUN
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-gkm
-kUN
-qtc
-qtc
-qtc
-qtc
-kUN
+vgV
+vgV
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -70248,20 +68613,20 @@ ekK
 ajO
 sMl
 itn
+tXd
 kUN
-kUN
-kUN
-kUN
-kUN
-kUN
+bKb
+bKb
+bKb
+bKb
 hFt
-vgV
-vgV
-dpu
-dpu
-dpu
-dpu
 kUN
+vgV
+vgV
+vgV
+vgV
+vgV
+vgV
 nGD
 hRI
 hRI
@@ -70511,7 +68876,7 @@ vgV
 vgV
 vgV
 vgV
-vgV
+nFt
 vgV
 vgV
 vgV
@@ -70756,8 +69121,8 @@ hRI
 hRI
 hRI
 hRI
-hRI
-hRI
+esc
+esc
 esc
 esc
 kQt
@@ -70771,10 +69136,10 @@ vgV
 wvj
 vgV
 vgV
-wvj
 vgV
 vgV
-wvj
+vgV
+vgV
 vgV
 nGD
 wFD
@@ -70981,46 +69346,46 @@ wFD
 wWB
 mjG
 bzC
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-hRI
-hRI
-hRI
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
 hRI
 hRI
 hRI
 esc
 xwm
 gMZ
+iDK
 auj
-gmI
-iDK
-iDK
+auj
+rSU
+fIf
+fIf
 vgV
 vgV
 fIf
@@ -71028,7 +69393,7 @@ vgV
 vgV
 vgV
 vgV
-kQO
+vgV
 vgV
 vgV
 vgV
@@ -71238,51 +69603,51 @@ wFD
 wFD
 mjG
 aou
-blx
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-wYo
-blx
-blx
-hRI
-hRI
-hRI
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+bPD
+anK
+anK
+mnK
+anK
+anK
+mnK
+anK
+anK
+bPD
+kUN
+anK
+anK
+dZO
+anK
+anK
+anK
+anK
+kUN
 hRI
 hRI
 hRI
 xwm
 pjR
 fEW
-auj
 iDK
 auj
+iDK
+uDa
+uDa
 auj
-auj
-hOB
-uhB
-kUN
-kUN
+blx
+diR
+diR
+diR
+diR
 kUN
 kUN
 kUN
@@ -71495,60 +69860,60 @@ wFD
 wFD
 mjG
 bzl
-blx
-efa
-gJz
-efa
-cbu
-bFe
-gJz
-bFe
-dAO
-efa
-bIT
-dFv
-dAO
-bqI
-bIT
-dFv
-dAO
-efa
-bFe
-gqj
-efa
-cMf
-efa
-efa
-dUk
-blx
-blx
-hRI
-hRI
-hRI
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+anK
+kUN
+cqu
+anK
+anK
+kUN
+anK
+anK
+kUN
+anK
+anK
+cqu
+kUN
+anK
+anK
+kUN
+kUN
+anK
+anK
+anK
+kUN
 hRI
 hRI
 hRI
 qFJ
 iDK
 vWZ
-auj
 iDK
-uDa
-uDa
-auj
 iDK
-dli
-dyB
+gJA
+vBZ
+bVO
+auj
+blx
+gKU
+aVZ
 eOP
-ylL
-vVu
-vVu
+eOP
+gCa
+gCa
 kUN
 kUN
 kUN
 kUN
 kUN
-eLE
+kUN
+hQE
 eLE
 eLE
 eLE
@@ -71752,61 +70117,61 @@ wFD
 wFD
 mjG
 bzl
-blx
-efa
-bFe
-cTL
-wYo
-efa
-efa
-eTS
-dAO
-bFe
-efa
-efa
-dAO
-bFe
-efa
-efa
-wYo
-fPo
-efa
-efa
-bFe
-blx
-efa
-efa
-dUk
-blx
-blx
-hRI
-hRI
-hRI
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+kUN
+kUN
+anK
+anK
+anK
+kUN
 hRI
 hRI
 hRI
 bLc
 iDK
 gDU
-uUB
-gJA
-vBZ
-bVO
-auj
+gmI
 iDK
-pSU
-xzj
-rAd
-ylL
-vVu
-wGF
-czr
-wGF
-vVu
-vVu
-kUN
+lCp
+gvC
+fjA
+auj
+blx
+gKU
+aVZ
+gCa
+bmJ
+gCa
+gCa
+blx
+dPt
+ekQ
+dLn
+gJz
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -72009,61 +70374,61 @@ wFD
 wWB
 mjG
 agK
-blx
-dZO
-bFe
-fzj
-dtr
-efa
-bFe
-fpD
-dAO
+kUN
+anK
+anK
+anK
+kUN
+anK
+anK
+anK
+kUN
 cAU
-efa
-aLf
-dAO
 cAU
-efa
-aLf
-dAO
-fPt
-fpD
-ehc
-bFe
-nFt
-efa
-bFe
-sOm
-blx
-blx
-hRI
-hRI
-hRI
+cAU
+kUN
+anK
+anK
+kUN
+cAU
+cAU
+cAU
+kUN
+anK
+anK
+kUN
+kUN
+anK
+anK
+anK
+kUN
 hRI
 hRI
 hRI
 mZU
 gMZ
 auj
-auj
+iDK
+iDK
 lCp
-gvC
-fjA
+tUT
+vBZ
 auj
-auj
+kDG
+fqF
 okb
 dyB
-dIq
-ylL
-vVu
-vVu
-crx
-rzy
-vVu
-vVu
-hFt
+gCa
+gCa
+gCa
+blx
+xXZ
+tBY
+xbj
+efa
+aLf
+dLC
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -72266,61 +70631,61 @@ bbB
 bbB
 mjG
 aEg
-blx
+kUN
 uII
-bFe
-dTG
-dtr
-fpD
-bFe
-wpc
-lAv
-fxi
-cRY
-cRY
-lAv
-fxi
-cRY
-cRY
-lAv
-bFe
-aPF
-bFe
-aLf
-nFt
-dZO
-bFe
-aLf
-blx
-blx
-hRI
-hRI
-hRI
+uII
+uII
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+kUN
+anK
+anK
+anK
+kUN
 hRI
 hRI
 hRI
 oYU
 qDc
 bMt
+iDK
+iDK
+cAC
+gVL
+gVL
 auj
-lCp
-tUT
-vBZ
-auj
-auj
-mCP
-wYo
-wYo
-wYo
-wYo
-xTi
-wYo
-fzD
-vsF
-vVu
-kUN
+rjD
+iDK
+gMZ
+cbQ
+bIC
+gCa
+gCa
+blx
+mbT
+jyQ
+flC
+efa
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -72522,62 +70887,62 @@ ryY
 bbB
 bbB
 mjG
-aJI
-blx
-aqQ
-aqQ
-aqQ
-aqW
-dZO
-egc
-bFe
-dTG
-efa
-efa
-efa
-nbd
-efa
-aPF
-bFe
-dTG
-bFe
-bFe
-efa
-efa
-blx
-efa
-bFe
-nCx
-blx
-ooI
-esc
-esc
-esc
-esc
-esc
-esc
-mZU
-uOX
-auj
-auj
-cAC
-gVL
-gVL
-auj
-auj
-tus
-vVu
-vVu
-vVu
-vVu
-wGF
-wYo
-rIU
-qjU
-wGF
+mjG
+vQw
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+anK
 kUN
+kUN
+anK
+anK
+anK
+kUN
+hRI
+hRI
+hRI
+mZU
+auj
+auj
+auj
+iDK
+auj
+auj
+auj
+auj
+fpD
+nfB
+dTK
+bMt
+pxK
+gCa
+gCa
+blx
+cij
+hlg
+bTE
+efa
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -72780,61 +71145,61 @@ wFD
 wWB
 mjG
 bzl
-vjM
-egc
-efa
-bFe
-bFe
-fpD
-ehc
-bFe
-efa
-bFe
-efa
-bFe
-bFe
-bFe
-bFe
-efa
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+gyu
+fXU
+fXU
 eiS
-efa
-efa
-efa
-efa
-nFt
-aqQ
-aqQ
-aqQ
-blx
-lVK
-gBM
-xdj
-rjD
-xdj
-xdj
-xdj
-fsN
-gNZ
-auj
-iDK
-auj
-iDK
-iDK
-fPh
-auj
-tCQ
-fxX
-vra
-vVu
-vVu
-vVu
-wYo
-kIf
-nUx
-vVu
+fXU
+epg
+fXU
+gyu
+anK
 kUN
+kUN
+anK
+anK
+lVK
+kUN
+hRI
+hRI
+hRI
+mZU
+uOX
+auj
+iDK
+auj
+iDK
+auj
+iDK
+iDK
+fpD
+qMr
+dyu
+bMt
+bIC
+gCa
+kNM
+blx
+wLR
+kLD
+txw
+efa
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -73037,62 +71402,62 @@ wFD
 wWB
 mjG
 bzl
-nbd
-efa
-ezs
-bFe
-bFe
-fpD
-uqb
-efa
-fpD
-fpD
-efa
-egc
-efa
-efa
-aPF
-efa
-efa
-bFe
-aPF
-efa
-efa
-gJz
-efa
-efa
-bFe
-vct
-xdj
-xdj
-xdj
-xdj
-xdj
-xdj
-xdj
-ftm
-rzR
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+gyu
+fXU
+iFg
+okH
+maO
+rvK
+fXU
+gyu
+anK
+anK
+kUN
+cAU
+cAU
+cAU
+kUN
+owJ
+owJ
+owJ
+owJ
+owJ
+fsN
+gNZ
 auj
 fUQ
 auj
-wYo
-iDd
-cjg
-cjg
-wYo
-wYo
-wYo
-rzy
-wYl
-hxB
-wYo
-rzy
-vVu
-vVu
-kUN
+auj
+auj
+fpD
+eLg
+dyu
+dxH
+bIC
+gCa
+gCa
+blx
+kOS
+ekQ
+dke
+efa
+efa
+hQE
 eLE
 yhT
-aoj
 yhT
 yhT
 yhT
@@ -73293,62 +71658,62 @@ abB
 wFD
 wFD
 mjG
-bzl
-efa
-fVm
-bFe
-eJq
-efa
-bFe
-tda
-efa
-egc
-bFe
-fpD
-fpD
-efa
-bFe
-aPF
-efa
-efa
-bFe
-bFe
-efa
-efa
-efa
-efa
-aPF
-bFe
-efa
-rjD
+mjG
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+anK
+gyu
+gqj
+kbT
+uVE
+eyK
+ghs
+vlM
+gyu
+gyu
+gyu
+fUv
+anK
+anK
+anK
+exf
 xdj
 xdj
 xdj
 xdj
 xdj
-xdj
-bzg
+ftm
 rzR
 iDK
 jLx
 auj
-wLY
-tKj
-rSU
-wIN
-tKj
-rSU
-wYo
-vVu
-wYl
-hxB
-wYo
-wGF
-vVu
-vVu
-kUN
+auj
+auj
+fpD
+auj
+vWZ
+hOB
+bIC
+gCa
+gCa
+blx
+xXZ
+wQp
+xbj
+efa
+crb
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -73550,62 +71915,62 @@ abB
 wFD
 wFD
 aLB
-blx
-blx
-dIm
+vgV
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+anK
+gyu
+fXU
+bUh
+dVW
+nye
+bhu
+fXU
+gyu
+gyu
+gyu
 fUv
-fUv
-nsf
-dZO
-efa
-bFe
-fpD
-bFe
-bFe
-bFe
-aEe
-bFe
-dTG
-efa
-efa
-efa
-efa
-bFe
-tda
-fqF
-efa
-bFe
-bFe
-efa
+anK
+anK
+anK
+emV
 xdj
 xdj
 xdj
 xdj
 xdj
-gol
-flG
-fuL
-eiA
+bzg
+rzR
 auj
 fjh
 auj
-oBq
-vPv
-vPv
-wGF
-vPv
-vPv
-wYo
-xTi
-ffZ
-bdf
-wYo
-dGU
-wYo
-wYo
-kUN
+auj
+blx
+qQR
+fjH
+fjH
+fjH
+bmJ
+gCa
+gCa
+qQR
+mbT
+bIh
+pHQ
+efa
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -73807,62 +72172,62 @@ mjG
 wFD
 wWB
 mjG
-blx
-blx
-efa
-bFe
+vgV
+kUN
+kUN
+dzP
 nbd
-wYo
-fpD
-bFe
-bFe
-fRv
-fpD
-fpD
-iFg
-okH
-dHg
-okH
-maO
-rvK
-bFe
-bFe
-efa
-efa
-qQR
-dIm
+dLs
+kUN
+gCa
+gCa
+gCa
+gCa
+gCa
+dZO
+anK
+gyu
+fXU
+xtg
+uVE
+eyK
+nzO
+fXU
+gyu
+gyu
+gyu
 fUv
-fUv
-blx
-lVK
-gBM
-rjD
+anK
+dQG
+anK
+anK
 xdj
 xdj
 xdj
-xdj
-wRQ
-wpv
+gol
+flG
+fuL
+eiA
 iDK
 fjh
 iDK
-wYo
-sIa
-kJu
-vVu
-vVu
-exN
-juA
-gQW
-exN
-vVu
-czr
-uuD
-oVS
+auj
+rzy
+gKU
+aVZ
+gCa
+gCa
+fGK
+gCa
+gCa
+blx
+ibY
+gVp
+fVQ
 cuS
-kUN
+ccg
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -74064,62 +72429,62 @@ abB
 wFD
 wWB
 mjG
-blx
-blx
-efa
-bFe
-cUt
-dyH
-efa
-bFe
-eJq
-eJq
-bFe
-efa
-kbT
-uVE
-eyK
-uVE
-eyK
-ghs
-efa
-bFe
-egc
-efa
-qQR
-efa
-bFe
-efa
-blx
-blx
-fEj
-fEj
-fEj
-fEj
-fEj
-fEj
-goO
-fOp
-iDK
-iDK
-iDK
-cjg
-rzy
-vQw
-vVu
-vQn
-nZC
-hri
-xpf
-gWk
-vVu
-wms
-gwf
-uuD
-dUO
+vgV
 kUN
+kUN
+tst
+cUt
+tqC
+kUN
+gow
+dIq
+cXP
+gCa
+gCa
+kUN
+anK
+gyu
+hqt
+hJy
+aEe
+qia
+fPo
+fXU
+gyu
+anK
+anK
+kUN
+kUN
+kUN
+kUN
+kUN
+xdj
+xdj
+xdj
+xdj
+xdj
+wRQ
+wpv
+iDK
+iDK
+iDK
+auj
+rzy
+gKU
+aVZ
+gCa
+ava
+npf
+vVu
+gCa
+bmJ
+exn
+bFe
+uuD
+efa
+efa
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -74321,62 +72686,62 @@ adr
 wFD
 wWB
 aLB
-blx
-blx
-dZO
-efa
+vgV
+kUN
+kUN
+gCa
 cWc
 dzP
-dZO
-bFe
-bFe
-bFe
-bFe
-efa
-bUh
-fXU
-cBZ
-fXU
-exf
-bhu
-bFe
-fpD
-bFe
+kUN
+gow
+dIq
+cXP
+gCa
+gCa
+kUN
+anK
 gyu
-nFt
-pJN
-uqb
-aLf
-blx
-blx
-hRI
-hRI
-hRI
-hRI
-hRI
-hRI
-fws
-fOr
+fXU
+fXU
+hqt
+fXU
+fXU
+gqj
+gyu
+anK
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+iDd
+fEj
+fEj
+fEj
+fEj
+goO
+fOp
 fjh
 gmI
 iDK
-cjg
-pBk
-gBD
-fmW
-fmW
-exg
+auj
+rzy
+lxs
+aVZ
+gCa
+gCa
 blG
-vVu
-vVu
-vVu
-wYo
-qjN
-uuD
-mnK
-kUN
+gCa
+gCa
+gCa
+gAy
+efa
+efa
+efa
+akT
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -74578,36 +72943,36 @@ abB
 wFD
 wFD
 mjG
-blx
-blx
-efa
-efa
-bFe
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+kUN
 dPc
-efa
-efa
-bFe
-bFe
-fpD
-nbd
-vfF
-wzt
-bwq
-wzt
-bwq
-bhO
-dTG
-fpD
-bFe
-hlO
-blx
-bFe
-fpD
+sVP
+cXP
+gCa
+gCa
+kUN
+anK
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
+anK
+kUN
+kUN
 ddx
-blx
-blx
-hRI
-hRI
+dUk
+bAz
+kUN
+kUN
 hRI
 hRI
 hRI
@@ -74617,23 +72982,23 @@ gza
 fjh
 hOB
 iDK
-cjg
-pCO
-wgS
-gQW
-exN
-dVW
-fGK
-exN
-gQW
-wKN
-wYo
-vkI
-uuD
-uuD
-kUN
+auj
+rzy
+gKU
+aVZ
+gCa
+gCa
+gCa
+gMt
+gCa
+bmJ
+rqX
+efa
+ucR
+efa
+bwW
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -74835,36 +73200,36 @@ abB
 wFD
 wFD
 mjG
-blx
-blx
-dqh
-wYo
-wYo
-dzP
-tda
-efa
-bFe
-fRv
-efa
-efa
-hqt
-gZB
-eyK
-uVE
-eyK
-ghs
-efa
-efa
-efa
-efa
-dqh
-bFe
-bFe
-ddx
-blx
-blx
-hRI
-hRI
+vgV
+kUN
+kUN
+kUN
+kUN
+ohV
+kUN
+gow
+dIq
+cXP
+gCa
+gCa
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+kUN
+wpa
+bSl
+ooI
+kUN
+kUN
 hRI
 hRI
 hRI
@@ -74874,23 +73239,23 @@ iDK
 fjh
 iDK
 tZP
-dok
-tst
-wrg
-gRa
-bPD
-dnc
+auj
+auj
+eiA
+gCa
+gCa
+gCa
 fGK
-fmW
-gQW
-tXd
-wYo
-mnK
-eWL
-mnK
-kUN
+gCa
+gCa
+gCa
+ccG
+efa
+psU
+efa
+lGH
+hQE
 eLE
-yhT
 yhT
 yhT
 yhT
@@ -75092,36 +73457,36 @@ abB
 wFD
 wFD
 aLB
-blx
-blx
-efa
-bFe
-efa
-dzP
-ica
-bFe
-bFe
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+eiA
+gow
+dIq
 cXP
-bFe
-efa
-cKb
+gCa
+gCa
+kUN
+anK
+anK
 dWg
-aLA
+anK
+anK
+anK
 dWg
-aLA
-bHI
-efa
-efa
-efa
-efa
-blx
-blx
-flT
-qQR
-blx
-blx
-hRI
-hRI
+anK
+anK
+dWg
+kUN
+kUN
+mOS
+xpf
+gwf
+kUN
+kUN
 hRI
 hRI
 hRI
@@ -75132,23 +73497,23 @@ iDK
 iDK
 iDK
 iDK
-tzz
-pKf
-exN
-vQn
+iDK
+eiA
+gCa
+gCa
 ava
 npf
 vVu
-vVu
+gCa
 ibo
-kUN
-kUN
-kUN
-kUN
-kUN
+lsh
+xac
+bRm
+efa
+fKK
+hQE
 eLE
-vPg
-vPg
+yhT
 vPg
 vPg
 eLE
@@ -75349,36 +73714,36 @@ mjG
 wFD
 wFD
 mjG
-aQw
-blx
-efa
-fpD
-ddx
-dzP
-tco
-bFe
-eVt
-bFe
-bFe
-efa
-bFe
-efa
-efa
-nbd
-bFe
-efa
-efa
-efa
-efa
-fpD
-blx
-blx
-qQR
-blx
-qQR
-blx
-blx
-blx
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+eiA
+gCa
+gCa
+gCa
+gCa
+gCa
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+kUN
+nEz
+gNv
+gNv
+kUN
+kUN
 hRI
 hRI
 hRI
@@ -75391,21 +73756,21 @@ iDK
 auj
 gmI
 eiA
-wGF
-fmW
-nzO
-fGK
-rLJ
-npf
+fjS
+eOP
+gCa
+blG
+gCa
+gCa
+gCa
+gCa
 kUN
 kUN
 wYo
 wYo
-wYo
-wYo
+dXE
+hQE
 eLE
-vPg
-vPg
 eLE
 eLE
 eLE
@@ -75606,37 +73971,37 @@ mjG
 wFD
 wFD
 aLB
-blx
-blx
-dZO
-fpD
-ddI
-ixi
-bFe
-bFe
-efa
-bFe
-bFe
-efa
-eJq
-eJq
-efa
-efa
-efa
-fqF
-efa
-efa
-efa
-nye
-blx
-blx
-dPt
-ekQ
-dLn
-gJz
-efa
-blx
-blx
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+eiA
+gCa
+gCa
+gCa
+gCa
+cSN
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+kUN
+gNv
+gNv
+gNv
+kUN
+kUN
+hRI
 hRI
 bVp
 kUN
@@ -75654,14 +74019,14 @@ qNg
 qNg
 tZF
 qNg
-auj
-auj
+qNg
+qNg
 auj
 gmI
 wYo
 wYo
 eLE
-vPg
+eLE
 eLE
 yhT
 yhT
@@ -75863,37 +74228,37 @@ mjG
 wFD
 wFD
 mjG
-diR
-blx
-efa
-efa
-dUk
-wYo
-cAU
-fpD
-efa
-efa
-efa
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+eiA
+gCa
+gCa
+gCa
+gCa
 fOg
-efa
-efa
-efa
-efa
-crb
-kDG
-qQR
-qQR
-blx
-blx
-blx
-blx
-xXZ
-tBY
-xbj
-efa
-aLf
-blx
-blx
+kUN
+anK
+anK
+dWg
+anK
+anK
+anK
+dWg
+anK
+anK
+dWg
+kUN
+kUN
+nJC
+gNv
+gNv
+kUN
+kUN
+hRI
 bBU
 exl
 kUN
@@ -76120,37 +74485,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-efa
-efa
-efa
-dqh
-efa
-fqF
-efa
-efa
-bFe
-eJq
-efa
-efa
-fRv
-efa
-efa
-nyG
-iDK
-gMZ
-cbQ
-bIC
+vgV
+kUN
+kUN
 gCa
-blx
-mbT
-jyQ
-flC
-efa
-efa
-blx
-blx
+gCa
+gCa
+eiA
+gCa
+gCa
+gCa
+gCa
+eJq
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+kUN
+kUN
+cbG
+gNv
+gNv
+kUN
+kUN
+hRI
 lqf
 exl
 kUN
@@ -76377,37 +74742,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-dqh
-blx
-blx
-blx
-nFt
-blx
-nFt
-dZO
-efa
-bFe
-efa
-efa
-efa
-efa
-fpD
-anK
-nfB
-dTK
-bMt
-pxK
+vgV
+kUN
+kUN
 gCa
-blx
-cij
-hlg
-bTE
-efa
-efa
-blx
-blx
+gCa
+gCa
+kUN
+kUN
+kUN
+dZO
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+fpD
+fpD
+bNV
+bNV
+fpD
+fpD
+kUN
+dpl
+gNv
+gNv
+gNv
+fLy
+kUN
+kUN
+hRI
 hNO
 hNO
 kUN
@@ -76634,37 +74999,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-dZO
-gJz
-fjJ
-qTe
-bMI
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+kUN
 dcd
-emK
-nbd
-bFe
-bFe
-efa
-efa
-efa
-efa
-aLf
 anK
-qMr
-dyu
-bMt
-bIC
-kNM
-blx
-wLR
-kLD
-txw
-efa
-efa
-blx
-blx
+anK
+anK
+voL
+qIj
+uqb
+qxm
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+dTG
+gNv
+gNv
+gNv
+bhO
+cRY
+kUN
+hRI
 lqf
 lqf
 kUN
@@ -76891,37 +75256,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-fis
-efa
-efa
-efa
-efa
-efa
-dQG
-efa
-efa
-bFe
-aEe
-fpD
-fpD
-efa
-bFe
-anK
-eLg
-dyu
-dxH
-bIC
+vgV
+kUN
+kUN
 gCa
-blx
-kOS
-ekQ
-dke
-efa
-efa
-blx
-blx
+gCa
+gCa
+kUN
+mCP
+anK
+anK
+anK
+uqb
+uqb
+uqb
+rsi
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+tus
+gNv
+gNv
+gNv
+wYl
+kUN
+kUN
+hRI
 bVp
 exl
 wYo
@@ -77148,37 +75513,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-dnP
-efa
-ccg
-sVT
-geR
-efa
-emK
-efa
-aPF
-bFe
-egc
-fpD
-bFe
-bFe
-fpD
-anK
-auj
-vWZ
-hOB
-bIC
+vgV
+kUN
+kUN
 gCa
-blx
-xXZ
-wQp
-xbj
-efa
-crb
-blx
-blx
+gCa
+gCa
+kUN
+fyh
+anK
+anK
+aPF
+fxX
+uqb
+uqb
+dGU
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+fQz
+gNv
+gNv
+gNv
+fQz
+kUN
+kUN
+hRI
 hRI
 bBU
 wYo
@@ -77405,37 +75770,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-cQp
-efa
-efa
-efa
-efa
-efa
-emK
-nbd
-bFe
-bFe
+vgV
+kUN
+kUN
+gCa
+gCa
+gCa
+kUN
+jFq
+anK
+anK
+aPF
+tMr
 lwv
 uqb
-bFe
-efa
-efa
-qQR
-fjH
-fjH
-fjH
-bmJ
-gCa
-qQR
-mbT
-bIh
-pHQ
-efa
-efa
-blx
-blx
+rLJ
+kUN
+dZO
+dgg
+dgg
+dgg
+dgg
+dgg
+kUN
+kUN
+kUN
+kUN
+dZO
+kUN
+kUN
+kUN
+hRI
 exl
 bVp
 xdj
@@ -77662,37 +76027,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-bMH
-efa
+vgV
+kUN
+kUN
 eay
-cSN
-ltu
-efa
+eay
+eay
+kUN
+anK
 dQG
-efa
-efa
-eJq
-egc
-bFe
-bFe
-bFe
-aLf
-blx
-gKU
-aVZ
-gCa
-fjS
-gCa
-blx
-ibY
-gVp
-fVQ
-efa
-efa
-blx
-blx
+anK
+wuU
+cQp
+anK
+uqb
+wIN
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+woj
+pCO
+pCO
+pCO
+dCp
+kUN
+kUN
+hRI
 hRI
 hRI
 xdj
@@ -77919,37 +76284,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-bNI
-efa
-efa
-efa
-efa
-efa
-emK
-efa
-fRv
-bFe
-efa
-bFe
-efa
-bFe
-bFe
-eHr
-gCa
-gCa
-gCa
-gCa
-gCa
-bmJ
-exn
-bFe
-bFe
-efa
-akT
-blx
-blx
+vgV
+kUN
+kUN
+vfF
+vfF
+vfF
+kUN
+bPB
+anK
+anK
+anK
+anK
+anK
+uqb
+cMf
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+cLd
+pCO
+cLd
+pCO
+pCO
+kUN
+kUN
+hRI
 hRI
 hRI
 xdj
@@ -78176,37 +76541,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-dZO
-efa
-uBk
-dCp
-liN
-fqF
-emK
-nbd
+vgV
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
 cqu
-bFe
-efa
-fqF
-bFe
-bFe
-aLf
-blx
-gKU
-aVZ
-gCa
-bmJ
-bmJ
-gCa
-gAy
-efa
-efa
-efa
-fKK
-blx
-blx
+cqu
+cqu
+cqu
+anK
+anK
+lwv
+uqb
+cdh
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
+ica
+pCO
+pCO
+pCO
+gRa
+kUN
+kUN
+hRI
 hRI
 hRI
 fdw
@@ -78433,37 +76798,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-gNv
-gNv
-diR
-blx
-blx
-blx
-blx
-dqh
-blx
-qQR
-blx
-blx
-fJp
-fqB
-eHr
-blx
-blx
-blx
-lxs
-aVZ
-gMt
-bmJ
-rqX
-efa
-ucR
+vgV
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+kUN
 cLd
-efa
-blx
-blx
+pCO
+cLd
+pCO
+cLd
+kUN
+kUN
+hRI
 hRI
 hRI
 fdw
@@ -78690,37 +77055,37 @@ mjG
 wFD
 wFD
 mjG
-blx
-blx
-auj
-iDK
-diR
-lyd
-cCO
-lyd
-blx
-auj
-auj
-fjU
-blx
-blx
-lmD
-wpa
-wpa
-wpa
-sTs
-blx
-gKU
-aVZ
-bmJ
-gCa
-ccG
-efa
-psU
-efa
-bwW
-blx
-blx
+vgV
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+anK
+anK
+anK
+anK
+anK
+anK
+dZO
+pCO
+pCO
+tCQ
+qTe
+kIf
+kUN
+kUN
+hRI
 hRI
 hRI
 cGg
@@ -78947,37 +77312,37 @@ mjG
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-auj
-iDK
-blx
-iVF
+kUN
+cPI
+cPI
+cPI
 daL
-iVF
-blx
-gmI
-auj
+wjM
 fjU
-blx
-blx
-kcf
-wpa
-fLy
-wpa
-bEV
-blx
-lxs
-aVZ
-cJI
-gCa
-ccG
-xac
-psU
-efa
-lGH
-blx
-blx
+cPI
+cPI
+cPI
+fjU
+eKX
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+hRI
 hRI
 hRI
 cGg
@@ -79204,37 +77569,37 @@ mjG
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-vcx
-iDK
-dhF
-iDK
-auj
-emV
-blx
-auj
-iDK
+kUN
+wjM
+wjM
+bwq
+daL
+daL
+bEV
+cPI
+cPI
 fjU
-blx
-blx
-gIt
-sfM
-wpa
-wpa
-wpa
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
+fjU
+eKX
+eKX
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -79461,37 +77826,37 @@ mjG
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-vcx
-iDK
-dhF
-auj
-auj
-dEL
-blx
-vcx
-gmI
-rGe
-blx
-blx
-gxS
-gxS
-gxS
+kUN
+wjM
+wjM
+uvI
+daL
+daL
+pPI
+cPI
+cPI
+eKX
+cPI
+eKX
+eKX
+eKX
+fjU
 lAR
-gkY
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -79718,37 +78083,37 @@ mjG
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-auj
-auj
-diR
-emV
-iDK
-emV
-blx
-iDK
-iDK
+kUN
+wjM
+wjM
+wjM
+iUU
+iUU
+cPI
+cPI
+cPI
+eKX
+cPI
+eKX
+eKX
+eKX
+eKX
+kUN
 fjU
-blx
-blx
-ckD
-ckD
-ckD
-ckD
-wpa
-wpa
-dqh
-efa
-vbx
-gJz
-vbx
-opa
-blx
-eGQ
-xVD
-blx
-blx
+fjU
+eKX
+eKX
+eKX
+eKX
+fjU
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -79975,37 +78340,37 @@ agK
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-auj
-auj
-diR
-dEL
-iDK
+kUN
+wYo
+wYo
+wYo
+wYo
 iUU
-blx
-iDK
-auj
+wYo
+cPI
+cPI
+eKX
+eKX
+cPI
+eKX
 fjU
-blx
-blx
-cbG
-cdh
-fLy
-wpa
-wpa
-fQB
-blx
-iPX
-efa
-efa
-efa
-efa
-blx
-eGQ
-flP
-blx
-blx
+eKX
+kUN
+fjU
+eKX
+fjU
+fjU
+fjU
+fjU
+eKX
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -80232,37 +78597,37 @@ abB
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-gNv
-gNv
-diR
-blx
-blx
-diR
-caw
-iDK
-auj
+kUN
+wYo
+bXn
+eup
+fRv
+tbE
+wYo
+eKX
+eKX
 fjU
-blx
-blx
-dNa
-cdh
-ckD
-cdh
-ckD
-ckD
-blx
-bKb
-vbx
-efa
-vbx
-efa
-blx
-wif
-nHE
-blx
-blx
+eKX
+cPI
+cPI
+cPI
+fjU
+kUN
+eKX
+eKX
+fjU
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -80489,37 +78854,37 @@ abB
 wFD
 wFD
 mjG
-pPI
+mjG
 kUN
-efa
-efa
-efa
-psU
-eiA
+kUN
+wYo
+faq
 rSB
-ehL
-iDK
-auj
-rGe
-blx
-blx
-mYc
-hKN
+rSB
+rSB
+wYo
+fjU
+eKX
+fjU
+fjU
+eKX
+eKX
+fjU
 cPI
-woj
-wpa
-ckD
-blx
-fzY
-efa
-efa
-efa
-efa
-wPZ
-tXl
-wif
-blx
-blx
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -80746,37 +79111,37 @@ abB
 wFD
 wFD
 mjG
-snI
+mjG
 kUN
-dZO
-efa
-psU
-dHw
-eiA
+kUN
+wYo
+gxS
 rSB
-auj
-auj
-gmI
-gow
-blx
-blx
-diR
-blx
-blx
-diR
-faq
-uLP
-blx
-ylp
-vbx
-efa
-vbx
-crb
-blx
-tXl
-nJC
-blx
-blx
+rSB
+lUs
+wYo
+fjU
+eKX
+eKX
+eKX
+fjU
+fjU
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -81003,37 +79368,37 @@ mjG
 wFD
 wFD
 dtk
-snI
+mjG
 kUN
-efa
-efa
-efa
-efa
-eiA
-rSO
-iDK
-auj
-gmI
+kUN
+wYo
+wYo
+wYo
+nEK
+wYo
+wYo
+kUN
+kUN
 eZw
-blx
-wjM
-blx
-xsf
-ckD
-xtg
-wpa
-ckD
-blx
-efa
-efa
-efa
-eLq
-efa
-blx
-wif
-flP
-blx
-blx
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+qEH
+kUN
+kUN
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -81260,40 +79625,40 @@ abB
 wFD
 wFD
 mjG
-snI
+mjG
 kUN
-efa
-jHj
-psU
-sVP
-epg
-auj
-iDK
-iDK
-iDK
-ohx
-blx
-bdL
-blx
-eMH
-ckD
-ckD
-qfj
-ckD
-blx
-dqh
-blx
-blx
-blx
-blx
-blx
-tCl
-tCl
-blx
-blx
-hRI
-hRI
+kUN
+gyB
+gyB
+gyB
+gyB
+eZw
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eZw
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
 xdj
+xdj
+xdj
+xdj
+vjM
+xdj
+vjM
 wFD
 mNE
 wFD
@@ -81517,40 +79882,40 @@ abB
 wFD
 wWB
 mjG
-snI
-blx
-efa
-uyC
-uuq
-dTr
-lUs
-fEW
-fyC
-iDK
-iDK
-auj
-blx
-wjM
-blx
-thm
-iLY
-wpa
-cYs
-ckD
-blx
-wpF
-mSP
-ocq
-nEP
-uvj
-ckD
-wpF
-ckD
-blx
-blx
-hRI
-hRI
+mjG
+kUN
+kUN
+gyB
+gyB
+gyB
+gyB
+kUN
+kUN
+kUN
+kUN
+qEH
+kUN
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
 xdj
+xdj
+xdj
+xdj
+vjM
+xdj
+vjM
 wFD
 mNE
 wFD
@@ -81774,37 +80139,37 @@ abB
 wFD
 wWB
 mjG
-snI
-blx
-efa
-efa
-uuq
-efa
-npc
-tlZ
-hzR
-iDK
-iDK
-rGe
-blx
-blx
-blx
-ndz
-mOS
-eiz
-qxm
-ckD
-blx
-kTJ
-ckD
-ckD
-ckD
-ckD
-ckD
-ckD
-qFM
-blx
-blx
+mjG
+kUN
+kUN
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+qEH
+kUN
+eZw
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 cGg
@@ -82031,37 +80396,37 @@ mjG
 wFD
 wWB
 mjG
-snI
-blx
-dZO
-bRm
-bPB
-dLC
-mZs
-qIj
-fhe
-fUQ
-iDK
-iDK
-uLP
-ckD
-ckD
-wpF
-ckD
-ckD
-wpF
-ckD
-uLP
-ckD
-ckD
-ckD
-ckD
-ckD
-ckD
-ckD
-eCs
-blx
-blx
+mjG
+kUN
+kUN
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+qEH
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -82288,37 +80653,37 @@ mjG
 wFD
 wWB
 mjG
-snI
-blx
-efa
-psU
-uCP
-psU
-npc
-lTs
-flj
-iDK
-auj
-auj
-uLP
-ckD
-bAz
-ckD
-bAz
-bAz
-ckD
-tsX
-blx
-ckD
-ckD
-eFq
-eFq
-eFq
-ckD
-ckD
-dEl
-blx
-blx
+mjG
+kUN
+kUN
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -82545,37 +80910,37 @@ mjG
 wFD
 wWB
 mjG
-snI
-blx
-efa
-uyC
-uuq
-dTr
-cxY
-fUu
-cLS
-gmI
-gmI
-iDK
+mjG
 kUN
 kUN
+gyB
+gyB
+gyB
+gyB
 kUN
+eKX
+eKX
+eKX
+eKX
 kUN
-vlM
-kjh
-fnc
-fpT
-blx
-kTJ
-wpF
-ckD
-ckD
-ckD
-ckD
-ckD
-wuU
-blx
-blx
+eKX
+eKX
+eKX
+eKX
+eKX
+qEH
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 fdw
@@ -82802,37 +81167,37 @@ abB
 wFD
 wFD
 mjG
-snI
-blx
-dZO
-bRm
-efa
-efa
-qia
-rSO
-auj
-iDK
-iDK
-rGe
+mjG
 kUN
-wjM
-wjM
 kUN
-voL
-fnc
-jBt
-gFp
-blx
-eFq
-eFq
-eFq
-eFq
-eFq
-ckD
-dgg
-kZh
-blx
-blx
+gyB
+gyB
+gyB
+gyB
+kUN
+kUN
+kUN
+kUN
+qEH
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+kUN
+eKX
+kUN
+hRI
+hRI
+hRI
 hRI
 hRI
 xdj
@@ -83059,37 +81424,37 @@ abB
 wFD
 wFD
 mjG
-snI
+mjG
 kUN
 kUN
-dFt
-dpW
+gyB
+gyB
+gyB
+gyB
 kUN
-dFt
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
 kUN
-kUN
-cIZ
-iDK
-auj
-kUN
-wjM
-wjM
-kUN
-wam
-fnc
-bNV
-jEr
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-blx
-blx
+hRI
+hRI
+hRI
 hRI
 hRI
 xdj
@@ -83316,37 +81681,37 @@ abB
 wFD
 wFD
 mjG
-dtk
+mjG
 kUN
 kUN
-lsh
-gCa
-fjS
-gCa
-bup
+gyB
+gyB
+gyB
+gyB
 kUN
-auj
-auj
-iDK
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
 kUN
-wjM
-wjM
-kUN
-kUN
-kUN
-kUN
-kUN
-wYo
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
-blx
+hRI
+hRI
+hRI
 hRI
 hRI
 xdj
@@ -83575,16 +81940,16 @@ wFD
 mjG
 mjG
 hQE
-dFt
-gCa
-gCa
-gCa
-gCa
-gCa
 kUN
-auj
-gmI
-iDK
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+kUN
+kUN
+qEH
 hQE
 hQE
 hQE
@@ -83833,15 +82198,15 @@ mjG
 fQL
 hQE
 kUN
-gCa
-tbE
-dLs
-gCa
-gCa
-ohV
-auj
-bPA
-auj
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+kUN
+eKX
+eKX
 hQE
 dXE
 dXE
@@ -84089,16 +82454,16 @@ wFD
 mjG
 fQL
 hQE
-dFt
-jIs
-uvI
-dLs
-gCa
-gCa
-ohV
-iDK
-bPA
-auj
+kUN
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -84347,15 +82712,15 @@ mjG
 fQL
 hQE
 kUN
-gCa
-tMr
-tqC
-gCa
-gCa
+gyB
+gyB
+gyB
+gyB
 kUN
-iDK
-iDK
-rGe
+eKX
+kUN
+eKX
+eKX
 fLU
 eCe
 pYd
@@ -84603,16 +82968,16 @@ wFD
 mjG
 fQL
 hQE
-dFt
-bvs
-gCa
-fjS
-gCa
-gCa
 kUN
-vcx
-auj
-iDK
+gyB
+gyB
+gyB
+gyB
+kUN
+eKX
+kUN
+eKX
+eKX
 fLU
 pYd
 eEt
@@ -84861,15 +83226,15 @@ mjG
 fQL
 hQE
 kUN
+gyB
+gyB
+gyB
+gyB
 kUN
-dFt
+eKX
 kUN
-kUN
-dFt
-kUN
-kUN
-jiE
-gNv
+eKX
+eKX
 fLU
 pYd
 eFi
@@ -85118,15 +83483,15 @@ mjG
 fQL
 hQE
 kUN
-nEK
-dDz
 gyB
-nBV
-daE
-fyh
-gHU
-acI
-dpl
+gyB
+gyB
+gyB
+kUN
+eKX
+kUN
+eKX
+eKX
 fLU
 pYd
 eHs
@@ -85373,17 +83738,17 @@ wFD
 wFD
 dtk
 fQL
-hQE
+uPr
+eKX
+eKX
+eKX
+eKX
+eKX
+qEH
+eKX
 kUN
-bSl
-acI
-aXd
-bXn
-dDz
-dDz
-nHM
-ciU
-ciU
+eKX
+eKX
 fLU
 pYd
 pYd
@@ -85632,15 +83997,15 @@ mjG
 fQL
 hQE
 kUN
-eJW
-nEz
-fQz
-acI
-cQc
-ciU
-ciU
-dgO
-ciU
+kUN
+kUN
+kUN
+kUN
+kUN
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -85889,15 +84254,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-fQz
-gyB
-uso
-acI
-ciU
-jbM
-dsx
-acI
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -86146,15 +84511,15 @@ mjG
 fQL
 hQE
 kUN
-gQR
-ciU
-fQz
-bXn
-acI
-ciU
-nHM
-ciU
-cQc
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -86403,15 +84768,15 @@ bbB
 fQL
 hQE
 kUN
-ciU
-ciU
-aXd
-acI
-acI
-dsx
-dOg
-dDz
-ciU
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -86660,15 +85025,15 @@ bbB
 mjG
 hQE
 kUN
-lWO
-dDz
-gyB
-acI
-lFt
-nHM
-jFq
-rsi
-hJy
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 pYd
@@ -86917,15 +85282,15 @@ bbB
 fQL
 hQE
 kUN
-ciU
-acI
-aXd
-acI
-ciU
-dDz
-dDz
-ciU
-bve
+eKX
+eKX
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 gFC
 eCe
@@ -87175,14 +85540,14 @@ fQL
 hQE
 kUN
 qEH
-lLo
-fQz
-bXn
-dDz
-bHA
-bHA
-ciU
-lFt
+kUN
+kUN
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 hQE
 dXE
@@ -87431,15 +85796,15 @@ mjG
 fQL
 hQE
 kUN
-gyB
-fQz
-gyB
-uso
-dDz
-ciU
-dDz
-nHM
-acI
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 hQE
 dXE
@@ -87685,18 +86050,18 @@ mjG
 wFD
 wWB
 mjG
-owJ
+fQL
 hQE
 kUN
-gQR
-ciU
-fQz
-acI
-dDz
-acI
-acI
-rsi
-acI
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 hQE
 dXE
@@ -87945,15 +86310,15 @@ mjG
 fQL
 hQE
 kUN
-bSl
-ciU
-aXd
 eKX
-acI
-acI
-eup
-dDz
-rsi
+eKX
+eKX
+eKX
+eKX
+eKX
+kUN
+eKX
+eKX
 hQE
 hQE
 dXE
@@ -88202,15 +86567,15 @@ mjG
 fQL
 hQE
 kUN
+eKX
+eKX
+eKX
+eKX
+eKX
+eKX
 kUN
-jiE
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
+eKX
+eKX
 hQE
 hQE
 dXE
@@ -88460,14 +86825,14 @@ fQL
 hQE
 kUN
 kUN
+qEH
 kUN
 kUN
 kUN
 kUN
 kUN
-kUN
-kUN
-kUN
+eKX
+eKX
 snI
 hQE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,11 +302,12 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/obj/item/fishyegg/shrimp,
+/obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/den)
 "ajR" = (
@@ -334,13 +335,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/area/f13/caves)
 "alv" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -489,7 +488,14 @@
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
 /obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence/corner{
 	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -509,24 +515,21 @@
 	},
 /area/f13/brotherhood/rnd)
 "aqQ" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/official/build,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/structure/handrail/g_central{
+/obj/machinery/light/small{
 	dir = 8;
-	pixel_x = -20
+	pixel_y = -7
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -1162,14 +1165,10 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1235,12 +1234,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "aLB" = (
@@ -1335,12 +1334,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
 /area/f13/den)
 "aPG" = (
 /obj/structure/cable{
@@ -1366,6 +1362,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -1560,11 +1560,8 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
@@ -1821,17 +1818,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1865,8 +1857,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1997,8 +1992,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2326,12 +2322,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
@@ -2501,10 +2493,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bux" = (
@@ -2528,13 +2519,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -2545,10 +2538,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
@@ -2605,17 +2597,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bwW" = (
-/obj/structure/fence{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/fence{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
@@ -2655,9 +2642,16 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2740,14 +2734,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/fence{
-	dir = 1
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2941,11 +2934,14 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -3017,26 +3013,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHA" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bHI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
+/area/f13/caves)
 "bIa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -3153,21 +3151,13 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3233,23 +3223,37 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
+"bMI" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
 	id = "denmedshutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
-"bMI" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
 	},
 /area/f13/den)
 "bMS" = (
@@ -3281,8 +3285,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "bNI" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
@@ -3292,15 +3300,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3365,29 +3370,28 @@
 	},
 /area/f13/tunnel)
 "bPA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "bPB" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "bPD" = (
-/obj/structure/table{
-	pixel_x = 6
-	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "bPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3443,10 +3447,9 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/f13/den)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3653,14 +3656,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
@@ -3788,10 +3791,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "caw" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine{
@@ -3837,15 +3848,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3863,10 +3870,11 @@
 	},
 /area/f13/tunnel)
 "cbQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "cbX" = (
@@ -3962,9 +3970,10 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/caves)
 "cdu" = (
 /obj/structure/cable{
@@ -4131,9 +4140,12 @@
 	},
 /area/f13/bunker)
 "ciU" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/water,
+/area/f13/den)
 "cjc" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/stripes/white/line,
@@ -4390,6 +4402,10 @@
 /area/f13/caves)
 "cqu" = (
 /obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -4424,8 +4440,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/machinery/light,
-/turf/open/floor/wood/wood_large,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4531,7 +4551,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/obj/machinery/light/floor,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -4634,9 +4656,8 @@
 	},
 /area/f13/tunnel)
 "cxY" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "cyb" = (
 /obj/structure/bed/mattress{
@@ -4693,9 +4714,12 @@
 	},
 /area/f13/tunnel)
 "czr" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "czF" = (
 /obj/machinery/light,
@@ -4805,8 +4829,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -4931,9 +4963,11 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/item/clothing/gloves/boxing,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
@@ -5110,18 +5144,27 @@
 	},
 /area/f13/brotherhood/armory)
 "cIZ" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
@@ -5227,13 +5270,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -5284,17 +5325,10 @@
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
 "cQc" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
@@ -5352,10 +5386,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -5417,7 +5447,17 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "cTL" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5553,6 +5593,7 @@
 /obj/item/card/id/denid,
 /obj/item/card/id/denid,
 /obj/item/card/id/denid,
+/obj/item/stack/f13Cash/caps/onezerozerozero,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "cWe" = (
@@ -5616,11 +5657,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
 	},
-/area/f13/caves)
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5680,18 +5722,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
+	},
+/turf/open/water,
 /area/f13/den)
 "daL" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5778,12 +5820,12 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5808,15 +5850,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
@@ -5856,9 +5893,13 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "dgO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
@@ -5887,12 +5928,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6044,34 +6087,9 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
-	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -6170,9 +6188,15 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -6216,9 +6240,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -6251,8 +6279,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/sign/poster/official/build,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dpu" = (
 /obj/structure/table/wood/settler,
@@ -6279,12 +6316,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "dqh" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -6363,7 +6398,7 @@
 /area/f13/building)
 "dsx" = (
 /obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "dsz" = (
@@ -6587,7 +6622,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6708,14 +6746,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/area/f13/den)
+/area/f13/sewer)
 "dCK" = (
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
@@ -6762,12 +6800,12 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "dEr" = (
@@ -6782,16 +6820,10 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
@@ -6822,18 +6854,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/machinery/smartfridge/bottlerack/lootshelf/books,
+/turf/open/floor/f13/wood,
 /area/f13/caves)
 "dFv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "dGP" = (
 /obj/structure/cable{
@@ -6860,11 +6891,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -6873,18 +6902,28 @@
 	},
 /area/f13/bunker)
 "dHg" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "dHw" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6897,9 +6936,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "dIo" = (
 /obj/structure/cable{
@@ -6908,18 +6950,12 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "denmedshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -7029,11 +7065,13 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/water,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
@@ -7076,8 +7114,12 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dNb" = (
@@ -7136,14 +7178,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/structure/fence{
-	dir = 8
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/area/f13/caves)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -7180,10 +7221,17 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7244,7 +7292,6 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "dQG" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -7326,20 +7373,9 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/water,
-/area/f13/den)
+/area/f13/sewer)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7350,9 +7386,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "dennorthshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
@@ -7375,9 +7420,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dUn" = (
@@ -7398,12 +7444,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dUO" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
@@ -7490,13 +7535,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
@@ -7620,10 +7662,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -7665,12 +7705,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7890,12 +7926,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
@@ -7924,11 +7955,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7963,11 +7992,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
-"ehL" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7977,11 +8001,11 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
 /area/f13/den)
 "eiA" = (
@@ -8177,6 +8201,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "emK" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -8246,12 +8273,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8435,14 +8462,13 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8494,9 +8520,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "ewe" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -8516,12 +8543,33 @@
 /turf/open/floor/grass,
 /area/f13/den)
 "exg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
 	},
-/turf/open/water,
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8616,13 +8664,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8695,11 +8738,11 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/table/wood/settler,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	light_color = "red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -8822,10 +8865,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/poker,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8874,8 +8917,14 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
@@ -8996,12 +9045,10 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -9041,12 +9088,15 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
+/turf/open/floor/plasteel/stairs,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -9062,21 +9112,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "eLq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9130,9 +9175,9 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9220,13 +9265,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "ePe" = (
@@ -9400,8 +9441,16 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
@@ -9453,12 +9502,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eVt" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
 	},
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
@@ -9491,8 +9541,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -9594,13 +9644,20 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "faq" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9726,15 +9783,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/vaultdoor,
@@ -9794,13 +9846,8 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9815,11 +9862,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
@@ -9839,12 +9887,18 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/fence/corner{
+	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9869,8 +9923,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fjL" = (
 /obj/structure/grille,
@@ -9886,8 +9940,11 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjU" = (
-/obj/structure/table/booth,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
@@ -9935,14 +9992,17 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/structure/barricade/bars,
+/obj/structure/pondlily_small,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "flT" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9985,12 +10045,12 @@
 	},
 /area/f13/clinic)
 "fmW" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -10087,12 +10147,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -10116,9 +10172,12 @@
 	},
 /area/f13/caves)
 "fpT" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -10140,12 +10199,23 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
-"fqF" = (
+"fqB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/carpet/red,
+/area/f13/den)
+"fqF" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -10335,7 +10405,7 @@
 "fws" = (
 /obj/machinery/light,
 /obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -10358,15 +10428,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fxi" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -10382,10 +10456,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
@@ -10399,15 +10477,15 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/caves)
+/area/f13/den)
 "fym" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable{
@@ -10438,11 +10516,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10471,32 +10547,14 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fzD" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10515,9 +10573,12 @@
 /area/f13/den)
 "fzY" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "fAi" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -10666,11 +10727,8 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/operations)
 "fEW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/structure/table/booth,
+/obj/machinery/light/floor,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fFv" = (
@@ -10694,10 +10752,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fGK" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
@@ -10800,13 +10864,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10863,20 +10924,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29;
-	id = "dennorthshutters"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "fLK" = (
@@ -10983,8 +11036,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -11020,29 +11080,22 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
-"fPt" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
+/area/f13/den)
+"fPt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fPu" = (
 /obj/structure/closet,
@@ -11079,12 +11132,8 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "aesculapius"
 	},
 /area/f13/den)
 "fQL" = (
@@ -11238,7 +11287,8 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/structure/chair/stool/retro/black,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fUv" = (
@@ -11277,16 +11327,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -11351,7 +11399,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/turf/open/floor/grass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -11620,16 +11673,16 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "geR" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
@@ -11774,11 +11827,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11874,10 +11925,12 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11924,11 +11977,14 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
 	},
+/turf/open/water,
 /area/f13/den)
 "gqt" = (
 /obj/structure/rack,
@@ -12099,11 +12155,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
-	icon_state = "floordirty"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "gvL" = (
@@ -12114,11 +12169,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -12156,10 +12208,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
@@ -12179,11 +12229,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/area/f13/sewer)
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_large,
@@ -12206,15 +12256,10 @@
 	},
 /area/f13/bunker)
 "gza" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
@@ -12295,15 +12340,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12397,10 +12437,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
@@ -12442,7 +12484,12 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/structure/pondlily_small,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "gFC" = (
@@ -12542,14 +12589,10 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
@@ -12578,11 +12621,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gIt" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12688,11 +12734,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gMt" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/area/f13/den)
 "gMw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -12846,11 +12892,12 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gRa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13019,11 +13066,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13494,8 +13540,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
 "hlO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "hmM" = (
@@ -13627,18 +13676,19 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
+	},
+/turf/open/water,
+/area/f13/den)
+"hri" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
-"hri" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
 "hrM" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -13813,13 +13863,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13952,10 +13999,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/fence{
+	dir = 8
 	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14078,8 +14128,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -14271,12 +14321,13 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
 /area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14735,11 +14786,10 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -15199,41 +15249,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
@@ -15403,8 +15421,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "ixD" = (
@@ -15549,13 +15567,12 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "iDh" = (
 /obj/structure/rack,
@@ -15768,14 +15785,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/structure/rack/shelf_metal,
+/obj/structure/table/wood/junk,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "iMa" = (
@@ -15929,11 +15945,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
 /turf/closed/wall/r_wall,
@@ -16091,6 +16108,14 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"iUU" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood/f13/stage_t,
@@ -16118,11 +16143,12 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
@@ -16310,8 +16336,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16337,11 +16363,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jbM" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/chem_master,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -16856,10 +16880,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "juA" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
@@ -16948,14 +16972,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jxS" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
@@ -17069,9 +17087,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "jBt" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
@@ -17134,10 +17151,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17178,40 +17194,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -17259,9 +17246,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17284,14 +17275,13 @@
 	},
 /area/f13/building)
 "jIs" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "jIw" = (
@@ -17879,13 +17869,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/den)
+/area/f13/caves)
 "kbf" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17964,26 +17952,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18229,12 +18199,10 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "kjq" = (
 /obj/structure/rack,
@@ -19030,16 +18998,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -19072,16 +19035,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
+/turf/open/water,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -19114,9 +19073,16 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
 	icon_state = "interior"
@@ -19244,9 +19210,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -19260,13 +19227,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kQO" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kQU" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -19341,10 +19308,11 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19650,9 +19618,12 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/structure/simple_door/glass,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "kZo" = (
@@ -19939,10 +19910,11 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "liS" = (
 /obj/machinery/telecomms/server/presets/security,
@@ -20089,12 +20061,7 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
-	},
-/obj/machinery/light/floor,
+/obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "lmG" = (
@@ -20261,13 +20228,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20396,15 +20363,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "lwU" = (
 /obj/structure/girder/reinforced,
@@ -20415,7 +20379,14 @@
 /area/f13/bunker)
 "lxs" = (
 /obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "lxH" = (
@@ -20703,10 +20674,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "lFR" = (
@@ -21048,11 +21026,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "lQs" = (
@@ -21155,15 +21130,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "lUw" = (
@@ -21241,8 +21217,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
@@ -21748,10 +21736,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "mnU" = (
 /obj/structure/cable{
@@ -22094,8 +22088,16 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mCP" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
@@ -22345,10 +22347,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "mNt" = (
@@ -22391,13 +22393,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/microwave{
+	pixel_x = -6
 	},
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22520,8 +22526,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
@@ -22683,9 +22697,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mYc" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22730,13 +22744,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/area/f13/caves)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -22924,9 +22935,7 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/obj/machinery/light/floor,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -23251,13 +23260,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "npf" = (
 /obj/structure/table/booth,
@@ -23363,11 +23367,11 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
@@ -23624,10 +23628,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23664,15 +23666,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23815,15 +23812,15 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nEP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/fulltile/store,
@@ -23858,10 +23855,11 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23910,8 +23908,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "nGN" = (
 /obj/machinery/light/small{
@@ -23954,29 +23951,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "nHM" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24030,12 +24014,11 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24359,15 +24342,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
@@ -24550,11 +24527,8 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -24626,12 +24600,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24851,10 +24824,6 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
-"ohx" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -25130,14 +25099,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25339,9 +25302,14 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/machinery/light,
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "owU" = (
@@ -25488,10 +25456,10 @@
 	},
 /area/f13/building)
 "oBq" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -26002,12 +25970,9 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -26408,16 +26373,9 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "pkj" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -26886,6 +26844,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/ruins{
 	max_integrity = 700
@@ -26930,13 +26889,11 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -27129,17 +27086,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = "denmedshutters"
 	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "pKC" = (
 /obj/structure/table/booth,
@@ -27317,12 +27271,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -27457,13 +27425,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -27865,12 +27834,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/flora/junglebush/large,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "qfw" = (
@@ -27972,13 +27941,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -28060,10 +28027,9 @@
 	},
 /area/f13/bunker)
 "qjN" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -28076,11 +28042,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
+/obj/structure/table,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
 "qki" = (
@@ -28369,7 +28337,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -28475,14 +28444,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qxm" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
-/area/f13/den)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -28667,19 +28628,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28711,14 +28663,11 @@
 /area/f13/bunker)
 "qEH" = (
 /obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -28798,14 +28747,6 @@
 /area/f13/den)
 "qFM" = (
 /obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "qFP" = (
@@ -28826,9 +28767,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/barricade/bars,
+/turf/open/water,
 /area/f13/caves)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28868,13 +28808,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -29359,12 +29295,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/structure/pondlily_small,
-/turf/open/water,
 /area/f13/den)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30021,12 +29955,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rsi" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "rsj" = (
@@ -30423,10 +30357,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30445,17 +30377,14 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/structure/fence/corner{
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30748,13 +30677,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
@@ -30813,9 +30738,8 @@
 	},
 /area/f13/brotherhood/operations)
 "rIU" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30975,16 +30899,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -31157,23 +31075,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
@@ -31225,18 +31129,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "rSU" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31487,10 +31394,19 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "saS" = (
 /obj/item/mine/shrapnel,
@@ -31619,9 +31535,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "sfM" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32464,12 +32383,8 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "sIA" = (
 /obj/structure/rack,
@@ -32590,15 +32505,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -32642,10 +32551,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33056,13 +32969,9 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "tbT" = (
@@ -33077,10 +32986,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -33088,10 +32997,9 @@
 /area/f13/building)
 "tda" = (
 /obj/machinery/light/floor,
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "tdv" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -33197,13 +33105,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "thm" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33338,11 +33244,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33482,9 +33389,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tqC" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
@@ -33572,11 +33481,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/fence{
+	dir = 1
 	},
-/area/f13/sewer)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -33588,11 +33501,9 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
@@ -33620,8 +33531,14 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
@@ -33798,15 +33715,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
@@ -33893,16 +33804,48 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/structure/fence{
-	dir = 8
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
+"tCQ" = (
+/obj/structure/table/wood,
+/obj/item/pda,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34047,11 +33990,13 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34287,17 +34232,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34572,16 +34514,21 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34733,12 +34680,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "ube" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
@@ -34836,9 +34786,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -35119,8 +35071,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "uqb" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
@@ -35237,15 +35193,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/area/f13/sewer)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -35333,13 +35285,17 @@
 	dir = 4;
 	pixel_x = -13
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
 "uvj" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "uvE" = (
@@ -35353,10 +35309,15 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35663,18 +35624,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/table{
+	pixel_x = 6
 	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "dennorthshutters"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35753,9 +35711,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/books,
-/turf/open/floor/f13/wood,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -36006,11 +35967,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -36240,12 +36198,10 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vbU" = (
 /obj/structure/bed,
@@ -36435,11 +36391,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/machinery/light,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -36511,24 +36465,12 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/water,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36569,9 +36511,12 @@
 	},
 /area/f13/brotherhood/mining)
 "vkj" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
 /area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
@@ -36589,12 +36534,8 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
@@ -36602,18 +36543,16 @@
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/structure/fence/corner{
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
 	dir = 4
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36695,14 +36634,42 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
 	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/sewer)
+/area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36774,16 +36741,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36829,12 +36790,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -37110,8 +37070,14 @@
 	},
 /area/f13/sewer)
 "vBZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "vCe" = (
@@ -37608,17 +37574,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
 	pixel_y = -16
 	},
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37645,8 +37611,9 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
+/obj/item/clothing/gloves/boxing,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37662,13 +37629,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37804,8 +37774,12 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/water,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -37950,13 +37924,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38141,12 +38116,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
-/turf/open/water,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
@@ -38169,10 +38145,11 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -38216,15 +38193,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -38292,15 +38277,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
 	},
 /area/f13/den)
 "wmL" = (
@@ -38326,8 +38313,15 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38344,18 +38338,24 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/obj/machinery/light/floor,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wpc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -38419,9 +38419,16 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38489,16 +38496,17 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
 	},
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -38507,8 +38515,8 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -39098,8 +39106,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "wMb" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/leather/twenty,
@@ -39209,8 +39226,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wQb" = (
 /obj/structure/rack,
@@ -39555,15 +39575,10 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -40193,13 +40208,15 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -40277,16 +40294,18 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "xtk" = (
@@ -40498,14 +40517,12 @@
 	},
 /area/f13/bunker)
 "xzj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41119,15 +41136,10 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41172,13 +41184,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVD" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "xVK" = (
 /obj/structure/cable{
@@ -41386,11 +41394,8 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ycl" = (
 /obj/structure/closet,
@@ -41668,17 +41673,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -41707,16 +41716,10 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
 "ylL" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
 	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -66837,8 +66840,8 @@ wFD
 wFD
 wFD
 wFD
-bxH
-nEP
+dTr
+fxi
 wFD
 mjG
 dXE
@@ -67085,19 +67088,19 @@ wFD
 lYx
 wFD
 wFD
-bxH
-tst
-tst
-tst
-tst
-tst
-tst
-tst
-tst
-tst
-nEP
-fzY
-tst
+dTr
+kTJ
+kTJ
+kTJ
+kTJ
+kTJ
+kTJ
+kTJ
+kTJ
+kTJ
+fxi
+oBq
+kTJ
 dXE
 dXE
 dXE
@@ -67346,13 +67349,13 @@ kUN
 kUN
 kUN
 kUN
-vkI
+fzY
 dAO
 dAO
 dAO
 dAO
-tst
-hri
+kTJ
+xzj
 wFD
 mjG
 dXE
@@ -67596,20 +67599,20 @@ hQE
 uPr
 hQE
 gMZ
-lFt
-ezs
-lFt
-lFt
+wif
+dLC
+wif
+wif
 auj
 auj
 auj
-wpc
-mnK
-jaG
-bdf
-gRa
+dgg
+bup
+yck
+wuU
+dAO
 mjG
-nEP
+fxi
 wFD
 mjG
 fQL
@@ -67853,20 +67856,20 @@ hQE
 uPr
 kUN
 gkm
-rSO
-jaG
-jaG
-jaG
+tsX
+yck
+yck
+yck
 auj
 gkm
-jaG
-wpc
+yck
+dgg
 gAy
-jaG
-hlO
+yck
+dGU
 dzP
-tst
-fzY
+kTJ
+oBq
 wFD
 wFD
 wFD
@@ -68109,23 +68112,23 @@ uPr
 uPr
 uPr
 kUN
-bKb
-bwW
-nzO
-nzO
-nzO
-rAd
+aqh
+dpl
+tst
+tst
+tst
+vPv
 auj
 auj
-gwf
-pKf
-jaG
-bPD
+tqC
+dPc
+yck
+vBZ
 dAO
-tst
-tst
-tst
-tst
+kTJ
+kTJ
+kTJ
+kTJ
 wFD
 wFD
 wFD
@@ -68366,24 +68369,24 @@ hQE
 hQE
 hQE
 kUN
-aqh
-fwZ
+eGQ
+xVD
 bzg
 bzg
-mCP
-dOg
-auj
 jaG
-jaG
-rGe
+hFt
 auj
-pSU
+yck
+yck
+lsh
+auj
+sOm
 wYo
 wYo
 ddv
 ddv
 mjG
-gyu
+uso
 mjG
 mjG
 mjG
@@ -68623,24 +68626,24 @@ hQE
 hQE
 hQE
 kUN
-aqh
+eGQ
 bzg
 bzg
-wvj
+aXd
 bzg
-tCl
+geR
 auj
 auj
-dgO
-qtc
+nUx
+nGD
 bTE
-qtc
-qtc
-qtc
-qtc
+nGD
+nGD
+nGD
+nGD
 ddv
 ddv
-gMt
+cbG
 ddv
 ddv
 ddv
@@ -68880,21 +68883,21 @@ wCB
 hQE
 hQE
 kUN
-aqh
+eGQ
 bzg
 bzg
-mCP
-bzg
-tqC
-pjR
 jaG
+bzg
+eMH
+eKX
+yck
 auj
-mSP
-sMl
-tGq
+nZC
+bve
+wPZ
+qFM
+fzj
 nGD
-cTL
-qtc
 ddv
 ddv
 jqn
@@ -69137,21 +69140,21 @@ hQE
 hQE
 hQE
 kUN
-aqh
-dHg
+eGQ
+nEP
 bzg
 bzg
-juA
-tCl
+kjh
+geR
 auj
 auj
-jaG
-mSP
-dEL
-lxs
+yck
+nZC
+fGK
+nHM
+qFM
+fzj
 nGD
-cTL
-qtc
 ddv
 ddv
 jqn
@@ -69394,21 +69397,21 @@ hQE
 hQE
 hQE
 kUN
-aqh
-mCP
+eGQ
+jaG
 bzg
 bzg
-cCO
-dOg
+vQn
+hFt
 auj
-jaG
-jaG
-liN
-sMl
+yck
+yck
+gWk
+bve
+qFM
+ffZ
+nyG
 nGD
-wrg
-ohx
-qtc
 ddv
 ddv
 jqn
@@ -69651,21 +69654,21 @@ hQE
 qTe
 qTe
 kUN
-vlM
-bAz
-bAz
-bAz
-bAz
-ylp
+fju
+fVm
+fVm
+fVm
+fVm
+bHA
 auj
+tsX
+yck
+nZC
 rSO
-jaG
-mSP
-fzj
-lxs
-wrg
-bPA
-qtc
+nHM
+ffZ
+fJp
+nGD
 ddv
 ddv
 jqn
@@ -69907,7 +69910,7 @@ hOB
 eBU
 tiS
 auj
-gWk
+fzD
 auj
 auj
 auj
@@ -69915,14 +69918,14 @@ auj
 auj
 auj
 tac
-jaG
+yck
 auj
-mSP
-sMl
-eCs
-wrg
-eWL
-qtc
+nZC
+bve
+uLP
+ffZ
+fjJ
+nGD
 ddv
 ddv
 jqn
@@ -70154,7 +70157,7 @@ fIf
 bQP
 fIf
 lBm
-uUB
+fqB
 fIf
 fIf
 fIf
@@ -70162,31 +70165,31 @@ fIf
 wRa
 auj
 auj
-jaG
-jaG
+yck
+yck
 auj
 uOX
 uOX
 uOX
 uOX
-oVS
-jaG
-jaG
+wpc
+yck
+yck
 wYo
 wYo
 wYo
-qtc
-qtc
-qtc
+nGD
+nGD
+nGD
 yiv
-qtc
+nGD
 ddv
 ddv
 jqn
 jqn
 jqn
 jqn
-gMt
+cbG
 mjG
 wFD
 wFD
@@ -70418,25 +70421,25 @@ eFv
 eFv
 ekK
 tac
-jaG
-jaG
+yck
+yck
 auj
-rSO
-jaG
-auj
-auj
-jaG
+tsX
+yck
 auj
 auj
-rSO
+yck
+auj
+auj
+tsX
 wYo
 dpu
-eLq
-qtc
-wam
-gBM
-cTL
-qtc
+fPt
+nGD
+lxs
+jHj
+nEK
+nGD
 ddv
 ddv
 jqn
@@ -70639,61 +70642,61 @@ wFD
 wFD
 mjG
 abB
-thm
-vQw
-thm
-thm
-eay
-ocq
+iUU
+gFp
+iUU
+iUU
+eZw
+tlZ
 fEj
-qXj
-kjh
+dok
+gow
 fEj
-eay
+eZw
 fEj
-eay
-lsh
-aqW
-xsf
-thm
-eay
-thm
-ocq
+eZw
+rsi
+dgO
+qfj
+iUU
+eZw
+iUU
+tlZ
 fEj
-kjh
-thm
-ajO
+gow
+iUU
+dIm
 fEj
-hxB
+flT
 fEj
-thm
-ajO
-hOx
-nJC
+iUU
+dIm
+qEH
+bNV
 fEj
 fEj
-qxm
+bdf
 fEj
 mZU
 gMZ
 auj
 auj
-uhB
-jaG
-jaG
+fyC
+yck
+yck
 tac
 auj
 auj
 gkm
-rSO
+tsX
 wYo
-qFM
-gHU
-qtc
-xVD
-gHU
-dpW
-qtc
+mCP
+kKb
+nGD
+mCP
+fxX
+nJC
+nGD
 ddv
 ddv
 jqn
@@ -70896,61 +70899,61 @@ wFD
 wWB
 mjG
 abB
-bNI
-dTG
-fpT
-bNI
+opa
+rSU
+ica
+opa
 hRI
-wPZ
-bNI
+jxS
+opa
 hRI
-bNI
-fxX
-gFp
-hRI
-hRI
-bNI
+opa
+vbx
+flP
 hRI
 hRI
-czr
-gFp
-bNI
+opa
+hRI
+hRI
+kQt
+flP
+opa
 esc
-bNI
+opa
 esc
-ixi
+qIj
 hRI
-bNI
-kTJ
+opa
+bvs
 esc
 uVE
-gFp
+flP
 esc
 esc
-rIU
+rQv
 hRI
-vkj
+rGe
 hRI
 vWZ
-fjU
+fEW
 bMt
 auj
 auj
 auj
 auj
-jaG
+yck
 auj
-jaG
-jaG
-dgO
+yck
+yck
+nUx
 wYo
-saE
-cTL
-tXl
-eWL
-bPA
-bPA
-qtc
+hxB
+fzj
+wvj
+fjJ
+fJp
+fJp
+nGD
 ddv
 ddv
 jqn
@@ -71182,32 +71185,32 @@ kUN
 kUN
 kUN
 hRI
-fjJ
+gwf
 esc
-rsi
+eVt
 uVE
 gZB
 hRI
-eVt
+fpT
 uOX
 auj
 auj
 iDK
-eZw
-bup
-eZw
-bup
+uUB
+cYs
+uUB
+cYs
 auj
-jaG
-rSO
-iDd
-nUx
-cAU
-yiv
-cTL
+yck
+tsX
 kQO
-pPI
-qtc
+xsf
+dZO
+yiv
+fzj
+gIt
+crx
+nGD
 ddv
 ddv
 ddv
@@ -71226,7 +71229,7 @@ mjG
 mjG
 mjG
 mjG
-voL
+dCp
 xse
 mjG
 mjG
@@ -71411,41 +71414,41 @@ wFD
 mjG
 aou
 kUN
-eiz
+sfM
+aqW
 cRY
-fxi
-dZO
-fxi
+bVO
 cRY
-fxi
+aqW
+cRY
 kUN
-ube
-bMI
-fxi
-rzy
-cAU
-fxi
-rzy
-fxi
-bMI
-ube
-kUN
+gDU
+pSU
 cRY
-fxi
+ewe
 dZO
-fxi
-fxi
-qjU
-eiz
+cRY
+ewe
+cRY
+pSU
+gDU
+kUN
+aqW
+cRY
+bVO
+cRY
+cRY
+bNI
+sfM
 kUN
 hRI
-dLC
+dUO
 hRI
-eMH
+jEr
 esc
 xwm
 hRI
-fEW
+lwv
 gMZ
 iDK
 auj
@@ -71453,18 +71456,18 @@ auj
 blx
 diR
 diR
-bve
-bve
-gkY
-gkY
+wgS
+wgS
+gyu
+gyu
 kUN
-qtc
+nGD
 bTE
-qtc
+nGD
 yiv
-qtc
-wLY
-wLY
+nGD
+bPD
+bPD
 ddv
 ddv
 ddv
@@ -71668,50 +71671,50 @@ wFD
 mjG
 bzl
 kUN
-eiz
-fxi
-fxi
+sfM
+cRY
+cRY
 kUN
-fxi
-nyG
-fxi
+cRY
+fPo
+cRY
 kUN
-hFt
-fxi
-fxi
+ndz
+cRY
+cRY
 kUN
-bqI
+fXU
 bIT
 kUN
-fxi
-fxi
-hFt
+cRY
+cRY
+ndz
 kUN
-fxi
-fxi
-vQn
+cRY
+cRY
+fnc
 wYo
-fxi
-nyG
-eiz
+cRY
+fPo
+sfM
 kUN
 esc
 hRI
 esc
-iVF
+vsF
 rjD
-fjJ
+gwf
 hRI
 vWZ
-fjU
+fEW
 bMt
 auj
 iDK
 blx
 gKU
 aVZ
-dyB
-dyB
+fmW
+fmW
 gCa
 fjS
 wYo
@@ -71720,7 +71723,7 @@ ekQ
 dLn
 efa
 bFe
-wLY
+bPD
 eLE
 eLE
 eLE
@@ -71925,38 +71928,38 @@ wFD
 mjG
 bzl
 kUN
-fLy
+ylp
 nCx
-cTL
+fzj
 kUN
-fxi
-fxi
-fxi
+cRY
+cRY
+cRY
 kUN
-fxi
-nyG
-fxi
+cRY
+fPo
+cRY
 kUN
-fxi
-cAU
-vVu
-fxi
-nyG
-fxi
+cRY
+dZO
+rIU
+cRY
+fPo
+cRY
 kUN
-fxi
-fxi
+cRY
+cRY
 kUN
 wYo
-fxi
-fxi
-eiz
+cRY
+cRY
+sfM
 kUN
 hRI
 esc
 esc
-dGU
-bHA
+daE
+ciU
 rjD
 hRI
 mZU
@@ -71977,7 +71980,7 @@ tBY
 xbj
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -72182,49 +72185,49 @@ wWB
 mjG
 agK
 kUN
-ylL
-cTL
-cTL
+xtg
+fzj
+fzj
 kUN
-bqI
-fxi
-jEr
-bdL
-fPt
-fPt
-fPt
-woj
+fXU
+cRY
+tco
+eay
 cAU
 cAU
+cAU
+gxS
+dZO
+dZO
 cKb
-fPt
-fPt
-fPt
+cAU
+cAU
+cAU
 kUN
-fxi
-fxi
-fOr
+cRY
+cRY
+hJy
 wYo
-fxi
-fxi
-fxi
+cRY
+cRY
+cRY
 kUN
 rjD
 uVE
 hRI
 esc
-wgS
-rIU
+hqt
+rQv
 hRI
-dUO
+hlO
 iDK
 auj
 iDK
 auj
 kDG
-gza
+cJI
 okb
-yck
+dyB
 gCa
 gCa
 gCa
@@ -72234,7 +72237,7 @@ jyQ
 flC
 efa
 aLf
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -72438,47 +72441,47 @@ bbB
 bbB
 mjG
 aEg
-dnc
-uII
-uII
-uII
+qtc
+dTG
+dTG
+dTG
 dtr
-cAU
-cAU
+dZO
+dZO
 nye
 lAv
-fxi
-fxi
-fxi
 cRY
-cAU
-fxi
 cRY
-fxi
-fxi
-fxi
 cRY
-fxi
-fxi
+aqW
+dZO
+cRY
+aqW
+cRY
+cRY
+cRY
+aqW
+cRY
+cRY
 kUN
 wYo
-bqI
-nyG
-jEr
+fXU
+fPo
+tco
 kUN
 hRI
-fjJ
+gwf
 esc
 esc
 esc
 oYU
 hRI
 qFJ
-gmI
+fUQ
 iDK
 uDa
 iDK
-ddI
+pBk
 cjg
 auj
 hOB
@@ -72491,7 +72494,7 @@ hlg
 bTE
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -72695,35 +72698,35 @@ bbB
 bbB
 mjG
 mjG
-fQB
-fxi
-fxi
-fxi
+kZh
 cRY
-cAU
-fxi
-fxi
-cAU
-fxi
-fxi
-fxi
-fxi
-ehc
-dIm
-dIm
-dIm
-ehc
-dIm
-dIm
-ehc
-fxi
+cRY
+cRY
+aqW
+dZO
+cRY
+cRY
+dZO
+cRY
+cRY
+cRY
+cRY
+tda
+bhO
+bhO
+bhO
+tda
+bhO
+bhO
+tda
+cRY
 kUN
 wYo
 nCx
-epg
+fis
 ooI
 kUN
-fjJ
+gwf
 rjD
 hRI
 uVE
@@ -72735,7 +72738,7 @@ iDK
 uDa
 tUT
 gmI
-pBk
+pCO
 wIN
 dTK
 bMt
@@ -72748,7 +72751,7 @@ kLD
 txw
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -72952,32 +72955,32 @@ wFD
 wWB
 mjG
 bzl
-dIm
-dIm
-dIm
-dIm
-jIs
-dIm
-ehc
-dIm
+bhO
+bhO
+bhO
+bhO
+owJ
+bhO
+tda
+bhO
 wzt
 wzt
 wzt
-dIm
-dIm
-dIm
-fXU
+bhO
+bhO
+bhO
+egc
 exf
 eiS
-fXU
+egc
 exf
-fXU
-dIm
-fxi
-dpl
-wYo
+egc
+bhO
+cRY
 aqQ
-cTL
+wYo
+cCO
+fzj
 lVK
 kUN
 hRI
@@ -72990,10 +72993,10 @@ hRI
 mZU
 auj
 gJA
-vBZ
+eFq
 fjA
-pBk
-qDc
+pCO
+lFt
 dyu
 bMt
 bIC
@@ -73005,7 +73008,7 @@ ekQ
 dke
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -73209,39 +73212,39 @@ wFD
 wWB
 mjG
 bzl
-fxi
-egc
-fxi
-fxi
-fxi
-fxi
-fxi
-egc
-fxi
-fxi
-fxi
-egc
-fxi
+cRY
+iVF
+cRY
+cRY
+cRY
+cRY
+cRY
+iVF
+cRY
+cRY
+cRY
+iVF
+cRY
 wzt
-fXU
+egc
 iFg
 okH
 maO
 rvK
-fXU
-dIm
-fxi
-fxi
+egc
+bhO
+cRY
+cRY
 kUN
 vct
 vct
 vct
 kUN
-dFv
-dFv
-dFv
-dFv
-dFv
+vVu
+vVu
+vVu
+vVu
+vVu
 fsN
 gNZ
 auj
@@ -73249,9 +73252,9 @@ fUQ
 lCp
 tUT
 iDK
-pBk
+pCO
 cjg
-rQv
+wjM
 dxH
 bIC
 gCa
@@ -73262,7 +73265,7 @@ wQp
 xbj
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -73471,29 +73474,29 @@ kUN
 kUN
 kUN
 kUN
-woj
+gxS
 kUN
 kUN
 kUN
 kUN
 kUN
 pJN
-fxi
-dIm
-oBq
+cRY
+bhO
+aPF
 kbT
 uVE
 eyK
 ghs
-eGQ
-dIm
-dIm
-dIm
-aPF
-fxi
-fxi
-fxi
-aJI
+bRm
+bhO
+bhO
+bhO
+eiz
+cRY
+cRY
+cRY
+ylL
 xdj
 xdj
 xdj
@@ -73506,7 +73509,7 @@ jLx
 cAC
 gVL
 tKj
-pBk
+pCO
 wIN
 iDK
 hOB
@@ -73519,7 +73522,7 @@ bIh
 pHQ
 efa
 crb
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -73735,22 +73738,22 @@ kUN
 kUN
 kUN
 kUN
-fxi
-kIf
-fXU
+cRY
+mnK
+egc
 bUh
-eup
-jBt
+gqj
+ixi
 bhu
-fXU
-ehc
-dIm
-dIm
+egc
+tda
+bhO
+bhO
 fUv
-fxi
-fxi
-fxi
-nyG
+cRY
+cRY
+cRY
+fPo
 xdj
 xdj
 xdj
@@ -73771,12 +73774,12 @@ bmJ
 gCa
 gCa
 dAO
-qtc
-qtc
-qtc
+nGD
+nGD
+nGD
 efa
 efa
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -73982,32 +73985,32 @@ mjG
 vgV
 kUN
 kUN
-kcf
-pCO
+pPI
+tCQ
 gCa
 fjS
 kUN
 gCa
-tda
+uhB
 gCa
 gCa
-dZO
-fxi
+bVO
+cRY
 wzt
-fXU
-qfj
+egc
+ajO
 uVE
 eyK
-exg
-fXU
-dIm
-dIm
-dIm
+kJu
+egc
+bhO
+bhO
+bhO
 fUv
-fxi
-dUk
-fxi
-fxi
+cRY
+eOP
+cRY
+cRY
 xdj
 xdj
 xdj
@@ -74016,24 +74019,24 @@ flG
 fuL
 eiA
 iDK
-fjh
+cIZ
 iDK
 auj
-pBk
-kJu
+pCO
+vQw
 aVZ
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 wYo
 ibY
 gVp
 fVQ
-qtc
+nGD
 cbu
-wLY
+bPD
 eLE
 yhT
 yhT
@@ -74239,27 +74242,27 @@ mjG
 vgV
 kUN
 kUN
-cxY
+tzz
 cUt
 dyH
 dLs
 kUN
-eJq
+fwZ
 fRv
-cIZ
+sMl
 gCa
-lWO
-fxi
-wzt
-hJy
-dTr
 sIa
-cbG
-geR
-fXU
-dIm
-fxi
-fxi
+cRY
+wzt
+rzy
+saE
+vjM
+tMr
+vlM
+egc
+bhO
+cRY
+cRY
 kUN
 kUN
 kUN
@@ -74276,8 +74279,8 @@ iDK
 iDK
 iDK
 auj
-pBk
-kJu
+pCO
+vQw
 aVZ
 gCa
 ava
@@ -74289,7 +74292,7 @@ exn
 bFe
 uuD
 efa
-akT
+epg
 hQE
 eLE
 yhT
@@ -74496,33 +74499,33 @@ aLB
 vgV
 kUN
 kUN
-fhe
+ocq
 cWc
 dyH
 fjS
 kUN
-qjN
+fUu
 fRv
-cIZ
-mYc
+sMl
+lmD
 kUN
-bqI
+fXU
 cBZ
-fXU
+egc
 exf
-hJy
-fXU
+rzy
+egc
 exf
-oBq
-dIm
-fxi
+aPF
+bhO
+cRY
 pJN
 kUN
 kUN
 kUN
 kUN
 kUN
-nZC
+nHE
 fEj
 fEj
 fEj
@@ -74533,7 +74536,7 @@ fjh
 gmI
 iDK
 auj
-pBk
+pCO
 gBD
 aVZ
 gCa
@@ -74546,7 +74549,7 @@ gAy
 efa
 efa
 efa
-cQc
+mOS
 hQE
 eLE
 yhT
@@ -74753,26 +74756,26 @@ mjG
 vgV
 kUN
 kUN
-lmD
-bEV
+fjS
+eCs
 gCa
-tXd
+npc
 kUN
-uqb
-daE
-fUu
+vkI
+gRa
+fpD
 gCa
 kUN
-fxi
+cRY
 bwq
 wzt
-dIm
-dIm
-ehc
-dIm
-dIm
-ehc
-fxi
+bhO
+bhO
+tda
+bhO
+bhO
+tda
+cRY
 kUN
 kUN
 kUN
@@ -74790,8 +74793,8 @@ fjh
 hOB
 iDK
 auj
-pBk
-kJu
+pCO
+vQw
 gQW
 gCa
 fjS
@@ -74799,11 +74802,11 @@ gCa
 exN
 gCa
 wKN
-xTi
+uvI
 efa
 ucR
 efa
-wjM
+uII
 hQE
 eLE
 yhT
@@ -75015,34 +75018,34 @@ kUN
 ohV
 kUN
 kUN
-eJq
+fwZ
 fRv
-cIZ
+sMl
 gCa
 kUN
-fxi
-fxi
-fxi
-cAU
+cRY
+cRY
+cRY
+dZO
 nye
-fxi
-fxi
-fxi
-fxi
-fxi
+cRY
+cRY
+cRY
+cRY
+cRY
 kUN
 kUN
 ddx
-jbM
-wuU
+qjU
+mSP
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-qEH
-fqF
+bxH
+nsf
 fjh
 iDK
 tZP
@@ -75052,7 +75055,7 @@ kUN
 gCa
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 gCa
@@ -75271,27 +75274,27 @@ gCa
 gCa
 gCa
 eiA
-tco
-qjN
+cQc
+fUu
 cXP
-cIZ
-mYc
+sMl
+lmD
 cKb
-bqI
-fxi
+fXU
+cRY
 dWg
-fxi
-fxi
-fxi
-opa
-fxi
-fxi
-ndz
-vVu
+cRY
+cRY
+cRY
+iLY
+cRY
+cRY
+cbQ
+rIU
 kUN
-tlZ
 gvC
-aQw
+vkj
+lQm
 kUN
 kUN
 hRI
@@ -75313,9 +75316,9 @@ npf
 xpf
 gCa
 ibo
-npc
+bKb
 xac
-aXd
+fjU
 efa
 fKK
 hQE
@@ -75534,28 +75537,28 @@ gCa
 gCa
 gCa
 kUN
-fxi
-fxi
-fxi
-fxi
-nyG
-fxi
-fxi
-fxi
-cAU
-fxi
+cRY
+cRY
+cRY
+cRY
+fPo
+cRY
+cRY
+cRY
+dZO
+cRY
 kUN
 kUN
-bHI
-vsF
-dNa
+wms
+jbM
+bwW
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-bhO
+kcf
 iDK
 iDK
 iDK
@@ -75564,7 +75567,7 @@ auj
 gmI
 eiA
 fjS
-dyB
+fmW
 gCa
 blG
 gCa
@@ -75781,7 +75784,7 @@ aLB
 vgV
 kUN
 kUN
-gDU
+dEL
 fjS
 gCa
 eiA
@@ -75789,21 +75792,21 @@ gCa
 gCa
 fjS
 gCa
-mZs
+dHw
 kUN
-fxi
-fxi
-fxi
-fxi
-fxi
-fxi
-fxi
-fxi
+cRY
+cRY
+cRY
+cRY
+cRY
+cRY
+cRY
+cRY
 nye
-fxi
+cRY
 kUN
 kUN
-fzD
+lWO
 gJz
 gJz
 kUN
@@ -76048,28 +76051,28 @@ gCa
 gCa
 fOg
 kUN
-bqI
-fxi
+fXU
+cRY
 dWg
-fxi
-fxi
-fxi
+cRY
+cRY
+cRY
 dWg
-fxi
-cAU
-ndz
+cRY
+dZO
+cbQ
 kUN
 kUN
-vra
-daL
-rSU
+woj
+nFt
+bAz
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-ewe
+tXd
 gmI
 pVU
 tac
@@ -76300,26 +76303,26 @@ gCa
 gCa
 eiA
 gCa
-eFq
+rLJ
 gCa
 gCa
-fju
+dIq
 kUN
-fxi
-fxi
-tzz
-fxi
-nyG
-fxi
-fxi
-fxi
-fxi
+cRY
+cRY
+bPA
+cRY
+fPo
+cRY
+cRY
+cRY
+cRY
 kUN
 kUN
 kUN
-qia
-aQw
-gow
+tXl
+lQm
+tbE
 kUN
 kUN
 hRI
@@ -76552,31 +76555,31 @@ mjG
 vgV
 kUN
 kUN
-nEK
-nEK
-nEK
+jBt
+jBt
+jBt
 kUN
 kUN
 kUN
-dZO
+bVO
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-kZh
+gza
 nfB
 nfB
 kUN
 kUN
 kUN
 kUN
-aLA
-kaQ
+dFv
+ddI
+lQm
+lQm
 aQw
-aQw
-dVW
 kUN
 kUN
 hRI
@@ -76814,26 +76817,26 @@ qTe
 qTe
 kUN
 dcd
-eKX
 emK
-emK
-hqt
-dCp
-fpD
-mNi
+dQG
+dQG
+gBM
+eup
+uqb
+dUk
 kUN
-eLg
+fQB
 anK
 qMr
-dIq
+bMI
 qMr
-fis
+iPX
 kUN
-jxS
-aQw
+tus
+lQm
+cMf
+lQm
 cuS
-aQw
-vbx
 kUN
 kUN
 hRI
@@ -77070,27 +77073,27 @@ kUN
 kUN
 kUN
 kUN
-gxS
-emK
-fVm
-emK
-fpD
+eLq
+dQG
+dNa
+dQG
+uqb
 aEe
-fpD
-lUs
+uqb
+eTS
 kUN
-xzj
+dEl
 anK
 anK
-dIq
+bMI
 anK
-fws
+czr
 kUN
-fJp
-aQw
-aQw
-aQw
-eOP
+hOx
+lQm
+lQm
+lQm
+bEV
 kUN
 kUN
 hRI
@@ -77327,27 +77330,27 @@ dDz
 ccg
 sVT
 kUN
-fPo
-emK
-emK
-tbE
-bPB
-fpD
-fpD
-wms
+aLA
+dQG
+dQG
+cqu
+bdL
+uqb
+uqb
+wrg
 kUN
-uvI
+gHU
 anK
 anK
-dIq
+bMI
 anK
 anK
-wZU
-aQw
-qIj
-aQw
-aQw
-itn
+dhF
+lQm
+tGq
+lQm
+lQm
+voL
 kUN
 kUN
 hRI
@@ -77581,35 +77584,35 @@ vgV
 kUN
 cQp
 acI
-dhF
+iDd
 acI
 kUN
-wif
-emK
-emK
-tbE
-bNV
-lwv
-fpD
-dEl
+eLg
+dQG
+dQG
+cqu
+fOr
+fqF
+uqb
+fLy
 kUN
-dPc
+xTi
 anK
 anK
-nHE
+fyh
 anK
 anK
 kUN
 kUN
 kUN
 kUN
-dZO
+bVO
 kUN
 kUN
 kUN
 cSY
-ehL
-nFt
+dpW
+qDc
 xdj
 dXE
 dXE
@@ -77841,27 +77844,27 @@ lLo
 fQz
 cSN
 ltu
-flT
+gMt
+hri
+fqF
+dHg
+eJq
 dQG
-lwv
-iLY
-cqu
-emK
-fpD
-cbQ
+uqb
+liN
 kUN
-dIq
-dIq
-dIq
+bMI
+bMI
+bMI
 kUN
 anK
-bMH
+pKf
 kUN
-tus
-bvs
+bqI
+dVW
 rqX
 rqX
-fmW
+cxY
 kUN
 kUN
 cSY
@@ -78096,29 +78099,29 @@ kUN
 gyB
 gyB
 gyB
-dgg
+ube
 kUN
-tMr
-fpD
-flT
-fpD
-emK
-flT
-fpD
-uso
+cTL
+uqb
+gMt
+uqb
+dQG
+gMt
+uqb
+wam
 kUN
-mOS
+bPB
 anK
 anK
 qMr
 anK
-lQm
+fws
 kUN
-nsf
+kIf
 rqX
-nsf
+kIf
 rqX
-eTS
+eWL
 kUN
 kUN
 cSY
@@ -78355,21 +78358,21 @@ acI
 uBk
 bXn
 kUN
-cqu
-cqu
+eJq
+eJq
 nbd
-cqu
-rLJ
-emK
-lwv
-fpD
-xtg
+eJq
+wLY
+dQG
+fqF
+uqb
+caw
 anK
 anK
 anK
 anK
 anK
-gqj
+mNi
 kUN
 rqX
 rqX
@@ -78609,8 +78612,8 @@ vgV
 kUN
 gNv
 acI
-fyC
-crx
+daL
+vfF
 kUN
 kUN
 kUN
@@ -78626,11 +78629,11 @@ anK
 anK
 anK
 anK
-owJ
+qXj
 kUN
-bVO
+rAd
 rqX
-nsf
+kIf
 rqX
 cLd
 kUN
@@ -78865,8 +78868,8 @@ mjG
 vgV
 kUN
 bXn
-dli
-sfM
+exg
+itn
 lyd
 kUN
 kUN
@@ -78878,18 +78881,18 @@ kUN
 kUN
 kUN
 kUN
+jIs
 wpa
-nHM
 sTs
-vPv
+lUs
 anK
 qMr
 ltu
 rqX
-tsX
-vjM
-jFq
-fnc
+faq
+bMH
+tCl
+ezs
 kUN
 kUN
 cSY
@@ -79638,10 +79641,10 @@ hQE
 hQE
 aoj
 aoj
-caw
+vra
 aoj
 aoj
-gIt
+jFq
 vcx
 aoj
 aoj
@@ -79896,7 +79899,7 @@ hQE
 aoj
 aoj
 aoj
-faq
+ehc
 emV
 aoj
 aoj
@@ -80408,10 +80411,10 @@ fQL
 hQE
 hQE
 dXE
-cdh
-kQt
-qGl
 uvj
+pjR
+dsx
+dli
 dXE
 aoj
 vcx
@@ -80665,17 +80668,17 @@ fQL
 hQE
 hQE
 dXE
-ica
-dHw
-dHw
-dHw
+thm
+fhe
+fhe
+fhe
 dXE
 aoj
 aoj
 aoj
 aoj
 aoj
-ciU
+mYc
 hKN
 cPI
 hQE
@@ -80922,9 +80925,9 @@ fQL
 hQE
 hQE
 dXE
-dok
-dHw
-dHw
+oVS
+fhe
+fhe
 rSB
 dXE
 aoj
@@ -80934,7 +80937,7 @@ aoj
 aoj
 uPr
 cPI
-cJI
+nzO
 hQE
 dXE
 dXE
@@ -81181,7 +81184,7 @@ hQE
 dXE
 dXE
 dXE
-jHj
+qjN
 dXE
 dXE
 hQE
@@ -81436,9 +81439,9 @@ fQL
 hQE
 hQE
 uyC
-ffZ
+bHI
 sVP
-bRm
+mZs
 buN
 aoj
 aoj
@@ -81448,7 +81451,7 @@ aoj
 aoj
 aoj
 buN
-ciU
+mYc
 aoj
 aoj
 aoj
@@ -81463,9 +81466,9 @@ dii
 dii
 dii
 dii
-sOm
+wZU
 dii
-sOm
+wZU
 wFD
 mNE
 wFD
@@ -81694,8 +81697,8 @@ hQE
 hQE
 uyC
 uuq
-bRm
-bRm
+mZs
+mZs
 hQE
 hQE
 hQE
@@ -81720,9 +81723,9 @@ dii
 dii
 dii
 dii
-sOm
+wZU
 dii
-sOm
+wZU
 wFD
 mNE
 wFD
@@ -81949,15 +81952,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-vfF
-bRm
+mZs
+mZs
+akT
+mZs
 hQE
 hzR
-dHw
+fhe
 flj
-dHw
+fhe
 hQE
 aoj
 dXE
@@ -82206,15 +82209,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
-bRm
+mZs
+mZs
+mZs
+mZs
 hQE
-dHw
+fhe
 flj
-dHw
-dsx
+fhe
+aJI
 hQE
 aoj
 dXE
@@ -82463,15 +82466,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 uCP
-bRm
-bRm
+mZs
+mZs
 hQE
 flj
-dHw
-dHw
-kKb
+fhe
+fhe
+gkY
 hQE
 aoj
 dXE
@@ -82720,15 +82723,15 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
-bRm
+mZs
+mZs
+mZs
+mZs
 hQE
 cLS
-dHw
-dHw
-dHw
+fhe
+fhe
+fhe
 hQE
 aoj
 aoj
@@ -82977,9 +82980,9 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 jPC
-iPX
+qia
 jPC
 hQE
 hQE
@@ -83234,10 +83237,10 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 jPC
 jzO
-uLP
+dFt
 hQE
 dXE
 dXE
@@ -83491,7 +83494,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 jPC
 lzb
 uqE
@@ -83748,7 +83751,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 jPC
 wDa
 gSS
@@ -84005,7 +84008,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 lQz
 uqE
 ncJ
@@ -84262,7 +84265,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 rCl
 fxD
 gSS
@@ -84519,7 +84522,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 ngX
 dXE
 dXE
@@ -84776,7 +84779,7 @@ mjG
 fQL
 hQE
 hQE
-bRm
+mZs
 lNw
 jPC
 jPC
@@ -85033,10 +85036,10 @@ mjG
 fQL
 hQE
 hQE
-bRm
-dFt
-bRm
-fyh
+mZs
+cdh
+mZs
+dnc
 hQE
 aoj
 hQE
@@ -85290,9 +85293,9 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
-bRm
+mZs
+mZs
+mZs
 nBV
 hQE
 aoj
@@ -85544,15 +85547,15 @@ mjG
 wFD
 wFD
 dtk
-cMf
+dOg
 nEz
 uCP
 bSl
-bRm
-bRm
-bRm
+mZs
+mZs
+mZs
 ckD
-ciU
+mYc
 hQE
 dXE
 aoj
@@ -85809,7 +85812,7 @@ nEz
 hQE
 hQE
 hQE
-ciU
+mYc
 hQE
 dXE
 aoj
@@ -86061,8 +86064,8 @@ mjG
 fQL
 hQE
 hQE
-bRm
-bRm
+mZs
+mZs
 hQE
 dXE
 dXE
@@ -86319,7 +86322,7 @@ fQL
 hQE
 hQE
 gQR
-bRm
+mZs
 hQE
 dXE
 dXE
@@ -86575,8 +86578,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+mZs
+mZs
 hQE
 dXE
 dXE
@@ -86832,8 +86835,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+mZs
+mZs
 hQE
 dXE
 dXE
@@ -87089,8 +87092,8 @@ bbB
 fQL
 hQE
 hQE
-bRm
-bRm
+mZs
+mZs
 hQE
 dXE
 dXE
@@ -88660,8 +88663,8 @@ dXE
 dXE
 dXE
 dXE
-flP
-cYs
+qGl
+kaQ
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,13 +302,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -335,11 +330,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
 "akT" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -487,21 +480,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "aqn" = (
 /obj/effect/decal/waste,
@@ -515,21 +496,23 @@
 	},
 /area/f13/brotherhood/rnd)
 "aqQ" = (
-/obj/structure/sign/poster/official/build,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -599,9 +582,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ava" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "avj" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1165,10 +1149,10 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1234,14 +1218,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1362,12 +1342,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "aQU" = (
@@ -1560,9 +1537,10 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1818,12 +1796,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1857,8 +1831,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -1992,9 +1965,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2124,10 +2096,8 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2322,8 +2292,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "bqO" = (
 /obj/machinery/light/small{
@@ -2493,10 +2468,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -2519,16 +2492,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2538,10 +2504,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "bvG" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -2597,12 +2564,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bwW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
@@ -2642,15 +2606,13 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2734,13 +2696,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2934,14 +2894,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bEY" = (
 /obj/structure/closet/cabinet,
@@ -3013,28 +2969,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "bHA" = (
-/obj/structure/fence/corner{
-	dir = 6
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bHI" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -3151,13 +3098,9 @@
 	},
 /area/f13/tunnel)
 "bKb" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
@@ -3223,39 +3166,20 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
 /obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
-"bMI" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "denmedshutters"
-	},
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
+"bMI" = (
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3285,12 +3209,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "bNI" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
@@ -3300,12 +3226,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bNV" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3370,28 +3299,33 @@
 	},
 /area/f13/tunnel)
 "bPA" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
+"bPB" = (
+/obj/structure/fence/corner{
 	dir = 4
 	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/area/f13/den)
-"bPB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bPD" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3447,9 +3381,13 @@
 	},
 /area/f13/tunnel)
 "bRm" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/caves)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3600,6 +3538,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/dorms)
+"bUD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "bUR" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3656,14 +3604,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
@@ -3791,17 +3735,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "caw" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
@@ -3848,11 +3791,13 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "cbG" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3870,12 +3815,8 @@
 	},
 /area/f13/tunnel)
 "cbQ" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "cbX" = (
 /obj/structure/lattice{
@@ -3971,10 +3912,12 @@
 /area/f13/tunnel)
 "cdh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4140,11 +4083,11 @@
 	},
 /area/f13/bunker)
 "ciU" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cjc" = (
 /obj/structure/curtain,
@@ -4213,10 +4156,8 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/water,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "ckH" = (
 /obj/structure/cable{
@@ -4402,10 +4343,6 @@
 /area/f13/caves)
 "cqu" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -4440,12 +4377,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4551,12 +4487,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 1
 	},
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4656,9 +4601,10 @@
 	},
 /area/f13/tunnel)
 "cxY" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4714,12 +4660,12 @@
 	},
 /area/f13/tunnel)
 "czr" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "czF" = (
 /obj/machinery/light,
@@ -4829,20 +4775,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
 	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/water,
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4963,10 +4903,10 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cDP" = (
@@ -5144,26 +5084,18 @@
 	},
 /area/f13/brotherhood/armory)
 "cIZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "cJI" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
@@ -5270,10 +5202,8 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "cMJ" = (
 /obj/structure/table/wood/settler,
@@ -5325,11 +5255,8 @@
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
 "cQc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
@@ -5447,17 +5374,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "cTL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5657,11 +5574,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5722,18 +5639,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "daL" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5820,11 +5737,9 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "deM" = (
@@ -5850,8 +5765,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/den)
@@ -5893,13 +5809,13 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "dgO" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
@@ -5928,11 +5844,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -6087,9 +6001,10 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -6188,15 +6103,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -6240,12 +6151,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/pondlily_small,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -6279,17 +6190,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dpl" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence{
-	dir = 1
-	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "dpu" = (
 /obj/structure/table/wood/settler,
@@ -6316,10 +6222,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "dqh" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -6397,10 +6307,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6622,10 +6532,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "dyB" = (
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "dyC" = (
@@ -6746,14 +6653,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
-	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
@@ -6800,12 +6704,13 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/chair/f13foldupchair,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "dEr" = (
@@ -6820,10 +6725,12 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "dES" = (
 /obj/machinery/door/airlock/freezer{
@@ -6859,12 +6766,8 @@
 /area/f13/caves)
 "dFv" = (
 /obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "dGP" = (
 /obj/structure/cable{
@@ -6891,9 +6794,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "dGU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
-/turf/open/floor/carpet/red,
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -6902,12 +6804,8 @@
 	},
 /area/f13/bunker)
 "dHg" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -6917,13 +6815,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "dHw" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
-	},
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6936,12 +6829,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "dIo" = (
 /obj/structure/cable{
@@ -6950,12 +6848,14 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
@@ -7065,14 +6965,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -7111,16 +7007,11 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7178,13 +7069,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/microwave{
+	pixel_x = -6
 	},
-/area/f13/caves)
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -7221,17 +7117,8 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7292,6 +7179,7 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "dQG" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -7373,9 +7261,17 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7386,18 +7282,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dTG" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "dennorthshutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "dTK" = (
 /obj/structure/table/wood/poker,
@@ -7420,11 +7305,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7444,11 +7332,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dUO" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
@@ -7535,10 +7422,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
@@ -7662,9 +7551,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7705,8 +7601,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7926,7 +7830,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
@@ -7955,9 +7861,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7992,6 +7900,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
+"ehL" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
+/area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -8001,12 +7918,9 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "eiA" = (
 /turf/open/floor/f13{
@@ -8273,12 +8187,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "epg" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/obj/machinery/light/floor,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
@@ -8365,7 +8281,7 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/den)
 "esg" = (
@@ -8462,13 +8378,9 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8520,10 +8432,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "ewe" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -8543,34 +8456,11 @@
 /turf/open/floor/grass,
 /area/f13/den)
 "exg" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/area/f13/caves)
 "exl" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -8664,8 +8554,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8738,9 +8632,8 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -8865,10 +8758,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/poker,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8917,12 +8820,8 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
@@ -9045,10 +8944,12 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
 /obj/item/reagent_containers/glass/bucket{
@@ -9088,15 +8989,16 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
-/turf/open/floor/plasteel/stairs,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -9112,15 +9014,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "eLq" = (
-/obj/machinery/workbench,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "eLy" = (
@@ -9175,8 +9086,8 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/machinery/light/floor,
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eMK" = (
@@ -9265,7 +9176,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -9441,16 +9354,17 @@
 	},
 /area/f13/brotherhood/mining)
 "eTS" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/fence{
+	dir = 1
 	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
@@ -9502,13 +9416,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "eVt" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
 	},
-/turf/open/water,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
@@ -9541,8 +9453,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eWL" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -9648,15 +9561,11 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "faq" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9783,9 +9692,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
@@ -9846,8 +9755,19 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9862,12 +9782,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
@@ -9887,18 +9808,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
 /obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/pondlily_small,
+/turf/open/water,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9923,8 +9838,7 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/indestructible/f13/matrix,
 /area/f13/den)
 "fjL" = (
 /obj/structure/grille,
@@ -9941,10 +9855,9 @@
 /area/f13/den)
 "fjU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/table/wood/poker,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
@@ -9992,17 +9905,18 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
-/area/f13/den)
-"flT" = (
+/obj/structure/fence{
+	dir = 1
+	},
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
+"flT" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -10045,13 +9959,19 @@
 	},
 /area/f13/clinic)
 "fmW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fnq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10147,8 +10067,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -10172,12 +10104,17 @@
 	},
 /area/f13/caves)
 "fpT" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
 /area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -10200,11 +10137,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqB" = (
+/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fqF" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10403,11 +10341,14 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "fww" = (
@@ -10428,19 +10369,21 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
+	},
 /area/f13/den)
 "fxi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -10456,14 +10399,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fxX" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
@@ -10477,13 +10415,14 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/den)
 "fym" = (
@@ -10516,9 +10455,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fyC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
@@ -10547,14 +10493,22 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "fzD" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
+/obj/structure/table,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10572,12 +10526,9 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10752,16 +10703,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fGK" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
@@ -10864,10 +10809,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10924,12 +10873,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "fLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "fLK" = (
@@ -11036,15 +10986,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/item/clothing/gloves/boxing,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -11086,16 +11030,10 @@
 	},
 /area/f13/den)
 "fPt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fPu" = (
 /obj/structure/closet,
@@ -11132,9 +11070,9 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -11287,9 +11225,14 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -11327,14 +11270,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -11673,16 +11610,13 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "geR" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
 /obj/structure/handrail/g_central{
-	pixel_y = -16
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gfu" = (
 /obj/machinery/light/small{
@@ -11827,9 +11761,24 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11925,12 +11874,14 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11977,13 +11928,11 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/item/fishyegg/shrimp,
 /turf/open/water,
 /area/f13/den)
 "gqt" = (
@@ -12155,11 +12104,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -12169,8 +12120,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -12208,7 +12166,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/structure/sign/poster/contraband/power,
+/obj/structure/sign/poster/official/build,
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "gxY" = (
@@ -12229,10 +12187,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
@@ -12256,10 +12213,8 @@
 	},
 /area/f13/bunker)
 "gza" = (
-/obj/structure/simple_door/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
@@ -12340,10 +12295,14 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12437,12 +12396,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "gDU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gEn" = (
 /obj/structure/janitorialcart,
@@ -12484,13 +12443,10 @@
 	},
 /area/f13/brotherhood/operations)
 "gFp" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/den)
 "gFC" = (
 /turf/closed/wall/rust,
@@ -12589,10 +12545,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
@@ -12621,14 +12579,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gIt" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12734,10 +12693,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gMt" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "gMw" = (
 /obj/machinery/light/small{
@@ -12892,12 +12849,13 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gRa" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13066,10 +13024,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13541,11 +13498,11 @@
 /area/f13/brotherhood/leisure)
 "hlO" = (
 /obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "hmM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13676,18 +13633,19 @@
 	},
 /area/f13/brotherhood/operations)
 "hqt" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/turf/open/water,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "hri" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
 	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13863,10 +13821,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13999,14 +13959,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker{
@@ -14128,8 +14083,11 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
@@ -14321,14 +14279,11 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/area/f13/den)
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -14786,9 +14741,10 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15249,9 +15205,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "itB" = (
 /obj/machinery/conveyor/inverted,
@@ -15421,9 +15377,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
@@ -15567,12 +15526,17 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "iDh" = (
 /obj/structure/rack,
@@ -15785,13 +15749,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "iMa" = (
@@ -15945,10 +15907,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "iQf" = (
@@ -16109,12 +16070,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
@@ -16143,13 +16108,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -16336,8 +16299,7 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16363,12 +16325,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jbM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "jco" = (
 /obj/structure/lattice{
@@ -16661,6 +16619,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"jmR" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs,
+/area/f13/den)
 "jmS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -16972,8 +16941,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jxS" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
@@ -17087,8 +17060,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "jBt" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
@@ -17151,9 +17131,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17194,11 +17177,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/machinery/light/floor,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -17246,13 +17230,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/area/f13/caves)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17275,14 +17258,11 @@
 	},
 /area/f13/building)
 "jIs" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
@@ -17869,11 +17849,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/caves)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17952,8 +17931,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18199,11 +18180,10 @@
 	},
 /area/f13/bunker)
 "kjh" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18998,11 +18978,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "kIf" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/water,
 /area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
@@ -19035,12 +19015,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "kJu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
 	},
-/turf/open/water,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -19073,15 +19062,13 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
@@ -19210,9 +19197,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19228,12 +19218,8 @@
 /area/f13/building)
 "kQO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/simple_door/wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "kQU" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -19308,11 +19294,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/sewer)
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "kTO" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -19618,12 +19603,17 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "denmedshutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "kZo" = (
@@ -19910,8 +19900,13 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -20061,8 +20056,10 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/green,
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "lmG" = (
 /obj/structure/rack,
@@ -20228,13 +20225,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20363,12 +20361,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "lwU" = (
 /obj/structure/girder/reinforced,
@@ -20378,17 +20374,11 @@
 	},
 /area/f13/bunker)
 "lxs" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/area/f13/caves)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20480,9 +20470,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "lAv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_y = -7
@@ -20674,18 +20661,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
 /obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21026,10 +21007,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lQm" = (
+/obj/structure/decoration/vent/rusty,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustyfull"
 	},
-/area/f13/den)
+/area/f13/sewer)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -21130,16 +21112,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "lUw" = (
@@ -21217,20 +21195,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "lWO" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "lWW" = (
 /obj/machinery/light/sign{
@@ -21736,15 +21705,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "mnU" = (
@@ -22088,16 +22052,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "mCP" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
@@ -22347,11 +22305,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/light,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "mNt" = (
 /obj/structure/rack,
@@ -22393,17 +22348,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/water,
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22526,17 +22476,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -22697,9 +22640,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "mYc" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -22744,10 +22698,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
 /obj/item/clothing/glasses/meson,
@@ -22829,14 +22789,13 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/structure/table/wood,
+/obj/item/pda,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22935,10 +22894,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "ndz" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "nee" = (
 /obj/structure/cable{
@@ -23260,8 +23219,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "npf" = (
 /obj/structure/table/booth,
@@ -23367,11 +23327,11 @@
 	},
 /area/f13/caves)
 "nsf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
@@ -23601,15 +23561,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "nyq" = (
 /obj/machinery/light/small,
@@ -23628,8 +23589,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23666,10 +23629,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "nzO" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/water,
+/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23812,14 +23777,24 @@
 	},
 /area/f13/caves)
 "nEK" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "nEP" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "nFc" = (
 /obj/structure/table/reinforced,
@@ -23855,10 +23830,12 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23908,7 +23885,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nGN" = (
 /obj/machinery/light/small{
@@ -23951,16 +23931,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "nHM" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24014,10 +23994,15 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/light/fo13colored/Red,
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nJG" = (
@@ -24342,9 +24327,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "nUA" = (
 /obj/structure/nest/supermutant,
@@ -24527,8 +24516,9 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -24600,12 +24590,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "ocy" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24824,6 +24811,10 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
+"ohx" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "ohV" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -25099,8 +25090,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25302,16 +25295,11 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "owU" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -25457,9 +25445,9 @@
 /area/f13/building)
 "oBq" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/machinery/light/small,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -25970,9 +25958,14 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -26373,7 +26366,7 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/item/flashlight,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "pkj" = (
@@ -26844,12 +26837,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26889,11 +26888,17 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -27086,11 +27091,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = "denmedshutters"
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -27271,26 +27275,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -27425,14 +27411,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/machinery/light/floor,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
+/obj/structure/table{
+	pixel_x = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -27834,13 +27821,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27941,11 +27927,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
+/area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -28027,9 +28015,11 @@
 	},
 /area/f13/bunker)
 "qjN" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -28042,14 +28032,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
@@ -28337,8 +28325,13 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -28444,6 +28437,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qxm" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -28628,10 +28627,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "qDw" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -28662,12 +28667,13 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -28746,8 +28752,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
@@ -28767,9 +28773,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/barricade/wooden/strong,
@@ -28808,9 +28817,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -29175,7 +29201,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/turf/closed/indestructible/f13/matrix,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
@@ -29295,9 +29330,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "qXl" = (
@@ -29522,6 +29562,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/enclave)
+"rdP" = (
+/obj/machinery/light,
+/turf/open/floor/wood/wood_large,
+/area/f13/den)
 "rdT" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet/black,
@@ -29959,7 +30003,7 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
@@ -30357,8 +30401,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30377,14 +30424,12 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/superstimpaks5,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30677,10 +30722,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
 /turf/open/water,
-/area/f13/den)
+/area/f13/caves)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30738,8 +30784,9 @@
 	},
 /area/f13/brotherhood/operations)
 "rIU" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30899,10 +30946,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -31075,9 +31121,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "rQO" = (
 /obj/structure/spider/stickyweb,
@@ -31129,21 +31176,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
+/obj/machinery/chem_master/condimaster{
+	density = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/space/basic,
 /area/f13/den)
 "rSU" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31394,19 +31442,9 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "saS" = (
 /obj/item/mine/shrapnel,
@@ -31535,11 +31573,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "sfM" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "sfN" = (
@@ -32383,9 +32422,9 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "sIa" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -32505,9 +32544,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "sMl" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "sMO" = (
 /obj/structure/flora/grass/jungle/b,
@@ -32551,13 +32589,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
@@ -32969,10 +33018,8 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
@@ -32986,19 +33033,23 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
 	},
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "tda" = (
-/obj/machinery/light/floor,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "tdv" = (
@@ -33105,11 +33156,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "thm" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33244,12 +33300,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tlZ" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33389,11 +33448,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tqC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "tqE" = (
 /obj/effect/decal/waste{
@@ -33481,14 +33546,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
@@ -33501,9 +33563,13 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "tte" = (
 /obj/machinery/workbench/advanced,
@@ -33531,14 +33597,12 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/water,
 /area/f13/den)
 "tuB" = (
 /obj/effect/turf_decal/box,
@@ -33715,9 +33779,39 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
@@ -33804,48 +33898,20 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCQ" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33990,13 +34056,8 @@
 	},
 /area/f13/enclave)
 "tGq" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34232,14 +34293,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34514,18 +34573,52 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = "denmedshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
 	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -34680,15 +34773,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "ube" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
@@ -34786,11 +34872,15 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/machinery/light/floor,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -35193,10 +35283,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
 /area/f13/sewer)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -35294,10 +35385,9 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
 "uvj" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -35309,15 +35399,33 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35357,11 +35465,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "uyC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/barricade/bars,
+/turf/open/water,
 /area/f13/caves)
 "uyS" = (
 /obj/machinery/light/small{
@@ -35551,6 +35656,10 @@
 	icon_state = "housewood_stage_top_right"
 	},
 /area/f13/brotherhood/archives)
+"uFe" = (
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "uFh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
@@ -35624,15 +35733,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "dennorthshutters"
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
@@ -35711,12 +35823,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -35967,7 +36078,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/machinery/computer/slot_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
+	},
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "uUH" = (
@@ -36198,10 +36318,9 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
+	},
 /area/f13/den)
 "vbU" = (
 /obj/structure/bed,
@@ -36391,8 +36510,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/machinery/light,
-/turf/open/floor/wood/wood_large,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vfU" = (
 /obj/structure/lattice/catwalk,
@@ -36465,12 +36589,16 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36511,11 +36639,13 @@
 	},
 /area/f13/brotherhood/mining)
 "vkj" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "vkp" = (
@@ -36534,8 +36664,16 @@
 	},
 /area/f13/bunker)
 "vkI" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
@@ -36543,16 +36681,13 @@
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36634,41 +36769,9 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "voL" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
@@ -36741,10 +36844,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36790,11 +36897,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
@@ -37070,15 +37182,11 @@
 	},
 /area/f13/sewer)
 "vBZ" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "vCe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37574,17 +37682,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/structure/fence/corner{
-	dir = 1
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
 	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37611,9 +37715,8 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/item/clothing/gloves/boxing,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37629,17 +37732,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37774,12 +37870,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/water,
 /area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
@@ -37924,13 +38018,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "waB" = (
@@ -38116,12 +38211,15 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "whA" = (
@@ -38145,11 +38243,10 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -38193,23 +38290,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -38277,18 +38361,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/turf/open/water,
 /area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
@@ -38313,15 +38391,8 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38338,26 +38409,25 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
 	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wpc" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38419,16 +38489,14 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/mirror{
+	pixel_y = 32
 	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38496,17 +38564,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -38515,8 +38577,15 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -39106,16 +39175,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/water,
 /area/f13/den)
 "wMb" = (
 /obj/structure/rack,
@@ -39226,12 +39292,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -39575,10 +39638,12 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -40208,15 +40273,11 @@
 	},
 /area/f13/sewer)
 "xsf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -40294,19 +40355,8 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
-	},
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40517,12 +40567,13 @@
 	},
 /area/f13/bunker)
 "xzj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "xzp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41136,10 +41187,8 @@
 	},
 /area/f13/bunker)
 "xTi" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41184,9 +41233,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xVD" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xVK" = (
 /obj/structure/cable{
@@ -41394,9 +41445,9 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -41673,20 +41724,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29;
-	id = "dennorthshutters"
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "ylv" = (
@@ -41716,13 +41760,12 @@
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
 "ylL" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -66840,8 +66883,8 @@ wFD
 wFD
 wFD
 wFD
-dTr
-fxi
+wPZ
+iVF
 wFD
 mjG
 dXE
@@ -67088,19 +67131,19 @@ wFD
 lYx
 wFD
 wFD
-dTr
-kTJ
-kTJ
-kTJ
-kTJ
-kTJ
-kTJ
-kTJ
-kTJ
-kTJ
-fxi
-oBq
-kTJ
+wPZ
+bPA
+bPA
+bPA
+bPA
+bPA
+bPA
+bPA
+bPA
+bPA
+iVF
+dLC
+bPA
 dXE
 dXE
 dXE
@@ -67349,13 +67392,13 @@ kUN
 kUN
 kUN
 kUN
-fzY
+nEP
 dAO
 dAO
 dAO
 dAO
-kTJ
-xzj
+bPA
+uso
 wFD
 mjG
 dXE
@@ -67599,20 +67642,20 @@ hQE
 uPr
 hQE
 gMZ
-wif
-dLC
-wif
-wif
+jIs
+vlM
+jIs
+jIs
 auj
 auj
-auj
-dgg
-bup
-yck
-wuU
+bEV
+dCp
+dUO
+rLJ
+uUB
 dAO
 mjG
-fxi
+iVF
 wFD
 mjG
 fQL
@@ -67856,20 +67899,20 @@ hQE
 uPr
 kUN
 gkm
-tsX
-yck
-yck
-yck
+aqh
+sMl
+sMl
+sMl
 auj
 gkm
-yck
-dgg
-gAy
-yck
-dGU
+sMl
+dCp
+rSO
+sMl
+eiz
 dzP
-kTJ
-oBq
+bPA
+dLC
 wFD
 wFD
 wFD
@@ -68112,23 +68155,23 @@ uPr
 uPr
 uPr
 kUN
-aqh
-dpl
-tst
-tst
-tst
-vPv
-auj
-auj
+cuS
+eTS
+flP
+flP
+flP
 tqC
-dPc
-yck
-vBZ
+auj
+auj
+dNa
+bNI
+sMl
+jBt
 dAO
-kTJ
-kTJ
-kTJ
-kTJ
+bPA
+bPA
+bPA
+bPA
 wFD
 wFD
 wFD
@@ -68369,24 +68412,24 @@ hQE
 hQE
 hQE
 kUN
-eGQ
-xVD
+gow
+eMH
 bzg
 bzg
-jaG
-hFt
+flT
+qEH
 auj
-yck
-yck
-lsh
-auj
-sOm
+sMl
+sMl
+qtc
+tac
+gRa
 wYo
 wYo
 ddv
 ddv
 mjG
-uso
+lQm
 mjG
 mjG
 mjG
@@ -68626,24 +68669,24 @@ hQE
 hQE
 hQE
 kUN
-eGQ
+gow
 bzg
 bzg
-aXd
+bhO
 bzg
-geR
+fyC
 auj
 auj
-nUx
-nGD
+opa
+jaG
 bTE
-nGD
-nGD
-nGD
-nGD
+jaG
+jaG
+jaG
+jaG
 ddv
 ddv
-cbG
+uLP
 ddv
 ddv
 ddv
@@ -68883,21 +68926,21 @@ wCB
 hQE
 hQE
 kUN
-eGQ
+gow
 bzg
 bzg
-jaG
+flT
 bzg
-eMH
-eKX
-yck
+gWk
+jmR
+sMl
 auj
-nZC
-bve
-wPZ
-qFM
-fzj
-nGD
+dPc
+wvj
+qGl
+ohx
+cTL
+jaG
 ddv
 ddv
 jqn
@@ -69140,21 +69183,21 @@ hQE
 hQE
 hQE
 kUN
+gow
 eGQ
-nEP
 bzg
 bzg
-kjh
-geR
-auj
-auj
-yck
-nZC
-fGK
 nHM
-qFM
-fzj
-nGD
+fyC
+auj
+auj
+sMl
+dPc
+dTr
+bKb
+ohx
+cTL
+jaG
 ddv
 ddv
 jqn
@@ -69397,21 +69440,21 @@ hQE
 hQE
 hQE
 kUN
-eGQ
-jaG
+gow
+flT
 bzg
 bzg
-vQn
-hFt
+fOr
+qEH
 auj
-yck
-yck
-gWk
-bve
-qFM
-ffZ
-nyG
-nGD
+sMl
+sMl
+ica
+wvj
+ohx
+aJI
+rSU
+jaG
 ddv
 ddv
 jqn
@@ -69651,24 +69694,24 @@ afb
 hQE
 hQE
 hQE
-qTe
-qTe
+fjJ
+fjJ
 kUN
-fju
-fVm
-fVm
-fVm
-fVm
-bHA
-auj
-tsX
-yck
-nZC
-rSO
-nHM
-ffZ
+bPB
 fJp
+fJp
+fJp
+fJp
+pCO
+auj
+aqh
+sMl
+dPc
+eKX
+bKb
+aJI
 nGD
+jaG
 ddv
 ddv
 jqn
@@ -69910,7 +69953,7 @@ hOB
 eBU
 tiS
 auj
-fzD
+ciU
 auj
 auj
 auj
@@ -69918,14 +69961,14 @@ auj
 auj
 auj
 tac
-yck
-auj
-nZC
-bve
-uLP
-ffZ
-fjJ
-nGD
+sMl
+rQv
+dPc
+wvj
+lWO
+aJI
+gza
+jaG
 ddv
 ddv
 jqn
@@ -70157,7 +70200,7 @@ fIf
 bQP
 fIf
 lBm
-fqB
+mnK
 fIf
 fIf
 fIf
@@ -70165,31 +70208,31 @@ fIf
 wRa
 auj
 auj
-yck
-yck
+sMl
+sMl
 auj
 uOX
 uOX
 uOX
 uOX
-wpc
-yck
-yck
+dgg
+sMl
+oBq
 wYo
 wYo
 wYo
-nGD
-nGD
-nGD
+jaG
+jaG
+jaG
 yiv
-nGD
+jaG
 ddv
 ddv
 jqn
 jqn
 jqn
 jqn
-cbG
+uLP
 mjG
 wFD
 wFD
@@ -70421,25 +70464,25 @@ eFv
 eFv
 ekK
 tac
-yck
-yck
+sMl
+sMl
 auj
-tsX
-yck
-auj
-auj
-yck
+aqh
+sMl
 auj
 auj
-tsX
+sMl
+auj
+auj
+aqh
 wYo
 dpu
-fPt
-nGD
-lxs
-jHj
-nEK
-nGD
+vsF
+jaG
+caw
+cdh
+daL
+jaG
 ddv
 ddv
 jqn
@@ -70642,61 +70685,61 @@ wFD
 wFD
 mjG
 abB
-iUU
-gFp
-iUU
-iUU
-eZw
-tlZ
-fEj
-dok
-gow
-fEj
-eZw
-fEj
-eZw
+gDU
 rsi
-dgO
-qfj
-iUU
-eZw
-iUU
-tlZ
+gDU
+gDU
+bPD
+fzj
 fEj
-gow
-iUU
-dIm
+fju
+ylL
 fEj
-flT
+bPD
 fEj
-iUU
-dIm
-qEH
-bNV
+bPD
+vfF
+geR
+gvC
+gDU
+bPD
+gDU
+fzj
+fEj
+ylL
+gDU
+gqj
+fEj
+ehL
+fEj
+gDU
+gqj
+hlO
+dEL
 fEj
 fEj
-bdf
+dpl
 fEj
 mZU
 gMZ
 auj
 auj
-fyC
-yck
-yck
-tac
+rLJ
+sMl
+sMl
 auj
 auj
-gkm
-tsX
+auj
+aqh
+bHA
 wYo
-mCP
-kKb
-nGD
-mCP
-fxX
 nJC
-nGD
+bNV
+jaG
+nJC
+wrg
+cCO
+jaG
 ddv
 ddv
 jqn
@@ -70899,40 +70942,40 @@ wFD
 wWB
 mjG
 abB
-opa
-rSU
-ica
-opa
+akT
+voL
+fzY
+akT
 hRI
-jxS
-opa
+blG
+akT
 hRI
-opa
-vbx
-flP
-hRI
-hRI
-opa
+akT
+ndz
+cbQ
 hRI
 hRI
-kQt
-flP
-opa
-esc
-opa
-esc
-qIj
+akT
 hRI
-opa
-bvs
-esc
+hRI
+dli
+cbQ
+akT
+cJI
+akT
+cJI
+dsx
+hRI
+akT
+bwW
+cJI
 uVE
-flP
-esc
-esc
-rQv
+cbQ
+cJI
+cJI
+eup
 hRI
-rGe
+npc
 hRI
 vWZ
 fEW
@@ -70941,19 +70984,19 @@ auj
 auj
 auj
 auj
-yck
+sMl
 auj
-yck
-yck
-nUx
+sMl
+sMl
+saE
 wYo
-hxB
-fzj
-wvj
-fjJ
-fJp
-fJp
+wjM
+cTL
+xtg
+gza
 nGD
+nGD
+jaG
 ddv
 ddv
 jqn
@@ -71185,32 +71228,32 @@ kUN
 kUN
 kUN
 hRI
-gwf
 esc
-eVt
+cJI
+wLY
 uVE
 gZB
 hRI
-fpT
+xzj
 uOX
 auj
 auj
 iDK
-uUB
-cYs
-uUB
-cYs
+ewe
+hJy
+ewe
+hJy
 auj
-yck
-tsX
+sMl
+aqh
 kQO
-xsf
-dZO
+wam
+fxi
 yiv
-fzj
-gIt
-crx
-nGD
+cTL
+dpW
+qfj
+jaG
 ddv
 ddv
 ddv
@@ -71229,7 +71272,7 @@ mjG
 mjG
 mjG
 mjG
-dCp
+tco
 xse
 mjG
 mjG
@@ -71414,41 +71457,41 @@ wFD
 mjG
 aou
 kUN
-sfM
-aqW
+qia
+lAv
 cRY
-bVO
+lsh
 cRY
-aqW
+lAv
 cRY
 kUN
-gDU
-pSU
+tMr
+epg
 cRY
-ewe
-dZO
+nHE
+fxi
 cRY
-ewe
+nHE
 cRY
-pSU
-gDU
+epg
+tMr
 kUN
-aqW
+lAv
 cRY
-bVO
+lsh
 cRY
 cRY
-bNI
-sfM
-kUN
-hRI
-dUO
-hRI
 jEr
-esc
+qia
+kUN
+hRI
+kIf
+hRI
+kaQ
+cJI
 xwm
 hRI
-lwv
+aqW
 gMZ
 iDK
 auj
@@ -71456,18 +71499,18 @@ auj
 blx
 diR
 diR
-wgS
-wgS
-gyu
-gyu
+fmW
+fmW
+eCs
+eCs
 kUN
-nGD
+jaG
 bTE
-nGD
+jaG
 yiv
-nGD
-bPD
-bPD
+jaG
+cQc
+cQc
 ddv
 ddv
 ddv
@@ -71671,7 +71714,7 @@ wFD
 mjG
 bzl
 kUN
-sfM
+qia
 cRY
 cRY
 kUN
@@ -71679,7 +71722,7 @@ cRY
 fPo
 cRY
 kUN
-ndz
+mCP
 cRY
 cRY
 kUN
@@ -71688,22 +71731,22 @@ bIT
 kUN
 cRY
 cRY
-ndz
+mCP
 kUN
 cRY
 cRY
-fnc
+bdf
 wYo
 cRY
 fPo
-sfM
+qia
 kUN
-esc
+cJI
 hRI
-esc
-vsF
+cJI
+tst
 rjD
-gwf
+esc
 hRI
 vWZ
 fEW
@@ -71713,8 +71756,8 @@ iDK
 blx
 gKU
 aVZ
-fmW
-fmW
+dyB
+dyB
 gCa
 fjS
 wYo
@@ -71723,7 +71766,7 @@ ekQ
 dLn
 efa
 bFe
-bPD
+cQc
 eLE
 eLE
 eLE
@@ -71928,9 +71971,9 @@ wFD
 mjG
 bzl
 kUN
-ylp
+kJu
 nCx
-fzj
+cTL
 kUN
 cRY
 cRY
@@ -71941,8 +71984,8 @@ fPo
 cRY
 kUN
 cRY
-dZO
-rIU
+fxi
+dGU
 cRY
 fPo
 cRY
@@ -71953,13 +71996,13 @@ kUN
 wYo
 cRY
 cRY
-sfM
+qia
 kUN
 hRI
-esc
-esc
-daE
-ciU
+cJI
+cJI
+cIZ
+nzO
 rjD
 hRI
 mZU
@@ -71980,7 +72023,7 @@ tBY
 xbj
 efa
 efa
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -72185,28 +72228,28 @@ wWB
 mjG
 agK
 kUN
-xtg
-fzj
-fzj
+dZO
+cTL
+cTL
 kUN
 fXU
 cRY
-tco
-eay
-cAU
-cAU
-cAU
-gxS
-dZO
-dZO
+gFp
+gMt
+fpD
+fpD
+fpD
+cMf
+fxi
+fxi
 cKb
-cAU
-cAU
-cAU
+fpD
+fpD
+fpD
 kUN
 cRY
 cRY
-hJy
+jbM
 wYo
 cRY
 cRY
@@ -72215,19 +72258,19 @@ kUN
 rjD
 uVE
 hRI
-esc
-hqt
-rQv
+cJI
+wms
+eup
 hRI
-hlO
+czr
 iDK
 auj
 iDK
 auj
 kDG
-cJI
+tlZ
 okb
-dyB
+bAz
 gCa
 gCa
 gCa
@@ -72237,7 +72280,7 @@ jyQ
 flC
 efa
 aLf
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -72441,39 +72484,39 @@ bbB
 bbB
 mjG
 aEg
-qtc
-dTG
-dTG
-dTG
+vQn
+uII
+uII
+uII
 dtr
-dZO
-dZO
-nye
+fxi
+fxi
+wpc
+iUU
+cRY
+cRY
+cRY
+lAv
+fxi
+cRY
 lAv
 cRY
 cRY
 cRY
-aqW
-dZO
-cRY
-aqW
-cRY
-cRY
-cRY
-aqW
+lAv
 cRY
 cRY
 kUN
 wYo
 fXU
 fPo
-tco
+gFp
 kUN
 hRI
-gwf
 esc
-esc
-esc
+cJI
+cJI
+cJI
 oYU
 hRI
 qFJ
@@ -72481,7 +72524,7 @@ fUQ
 iDK
 uDa
 iDK
-pBk
+bHI
 cjg
 auj
 hOB
@@ -72494,7 +72537,7 @@ hlg
 bTE
 efa
 efa
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -72698,39 +72741,39 @@ bbB
 bbB
 mjG
 mjG
-kZh
+tsX
 cRY
 cRY
 cRY
-aqW
-dZO
+lAv
+fxi
 cRY
 cRY
-dZO
+fxi
 cRY
 cRY
 cRY
 cRY
-tda
-bhO
-bhO
-bhO
-tda
-bhO
-bhO
-tda
+ehc
+gyu
+gyu
+gyu
+ehc
+gyu
+gyu
+ehc
 cRY
 kUN
 wYo
 nCx
-fis
+nFt
 ooI
 kUN
-gwf
+esc
 rjD
 hRI
 uVE
-esc
+cJI
 uVE
 hRI
 bLc
@@ -72738,7 +72781,7 @@ iDK
 uDa
 tUT
 gmI
-pCO
+rzy
 wIN
 dTK
 bMt
@@ -72750,8 +72793,8 @@ wLR
 kLD
 txw
 efa
-efa
-bPD
+faq
+cQc
 eLE
 yhT
 yhT
@@ -72955,32 +72998,32 @@ wFD
 wWB
 mjG
 bzl
-bhO
-bhO
-bhO
-bhO
-owJ
-bhO
-tda
-bhO
+gyu
+gyu
+gyu
+gyu
+fyh
+gyu
+ehc
+gyu
 wzt
 wzt
 wzt
-bhO
-bhO
-bhO
-egc
+gyu
+gyu
+gyu
+dTG
 exf
 eiS
-egc
+dTG
 exf
-egc
-bhO
+dTG
+gyu
 cRY
-aqQ
+gxS
 wYo
-cCO
-fzj
+aqQ
+cTL
 lVK
 kUN
 hRI
@@ -72993,10 +73036,10 @@ hRI
 mZU
 auj
 gJA
-eFq
+fjU
 fjA
-pCO
-lFt
+rzy
+fhe
 dyu
 bMt
 bIC
@@ -73008,7 +73051,7 @@ ekQ
 dke
 efa
 efa
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -73213,26 +73256,26 @@ wWB
 mjG
 bzl
 cRY
-iVF
+dok
 cRY
 cRY
 cRY
 cRY
 cRY
-iVF
+dok
 cRY
 cRY
 cRY
-iVF
+dok
 cRY
 wzt
-egc
+dTG
 iFg
 okH
 maO
 rvK
-egc
-bhO
+dTG
+gyu
 cRY
 cRY
 kUN
@@ -73240,11 +73283,11 @@ vct
 vct
 vct
 kUN
-vVu
-vVu
-vVu
-vVu
-vVu
+qjU
+qjU
+qjU
+qjU
+qjU
 fsN
 gNZ
 auj
@@ -73252,9 +73295,9 @@ fUQ
 lCp
 tUT
 iDK
-pCO
+rzy
 cjg
-wjM
+gkY
 dxH
 bIC
 gCa
@@ -73265,7 +73308,7 @@ wQp
 xbj
 efa
 efa
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -73474,7 +73517,7 @@ kUN
 kUN
 kUN
 kUN
-gxS
+cMf
 kUN
 kUN
 kUN
@@ -73482,21 +73525,21 @@ kUN
 kUN
 pJN
 cRY
-bhO
+gyu
 aPF
 kbT
 uVE
 eyK
 ghs
-bRm
-bhO
-bhO
-bhO
-eiz
+tGq
+gyu
+gyu
+gyu
+fwZ
 cRY
 cRY
 cRY
-ylL
+dgO
 xdj
 xdj
 xdj
@@ -73509,7 +73552,7 @@ jLx
 cAC
 gVL
 tKj
-pCO
+rzy
 wIN
 iDK
 hOB
@@ -73522,7 +73565,7 @@ bIh
 pHQ
 efa
 crb
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -73739,16 +73782,16 @@ kUN
 kUN
 kUN
 cRY
-mnK
-egc
+nEK
+dTG
 bUh
-gqj
-ixi
+cAU
+fQB
 bhu
-egc
-tda
-bhO
-bhO
+dTG
+ehc
+gyu
+gyu
 fUv
 cRY
 cRY
@@ -73774,12 +73817,12 @@ bmJ
 gCa
 gCa
 dAO
-nGD
-nGD
-nGD
+jaG
+jaG
+jaG
 efa
 efa
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -73985,30 +74028,30 @@ mjG
 vgV
 kUN
 kUN
-pPI
-tCQ
+qIj
+nbd
 gCa
 fjS
 kUN
 gCa
-uhB
+jFq
 gCa
 gCa
-bVO
+lsh
 cRY
 wzt
-egc
-ajO
+dTG
+kKb
 uVE
 eyK
-kJu
-egc
-bhO
-bhO
-bhO
+mOS
+dTG
+gyu
+gyu
+gyu
 fUv
 cRY
-eOP
+ddI
 cRY
 cRY
 xdj
@@ -74019,11 +74062,11 @@ flG
 fuL
 eiA
 iDK
-cIZ
+gHU
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 aVZ
 gCa
 gCa
@@ -74034,9 +74077,9 @@ wYo
 ibY
 gVp
 fVQ
-nGD
+jaG
 cbu
-bPD
+cQc
 eLE
 yhT
 yhT
@@ -74242,25 +74285,25 @@ mjG
 vgV
 kUN
 kUN
-tzz
+ffZ
 cUt
 dyH
 dLs
 kUN
-fwZ
+eJq
 fRv
-sMl
+rIU
 gCa
-sIa
+uFe
 cRY
 wzt
-rzy
-saE
-vjM
-tMr
-vlM
-egc
-bhO
+pPI
+mYc
+tus
+dUk
+nye
+dTG
+gyu
 cRY
 cRY
 kUN
@@ -74279,11 +74322,11 @@ iDK
 iDK
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 aVZ
 gCa
-ava
+nZC
 npf
 xpf
 gCa
@@ -74292,7 +74335,7 @@ exn
 bFe
 uuD
 efa
-epg
+hri
 hQE
 eLE
 yhT
@@ -74499,25 +74542,25 @@ aLB
 vgV
 kUN
 kUN
-ocq
+eVt
 cWc
 dyH
 fjS
 kUN
-fUu
+eWL
 fRv
-sMl
-lmD
+rIU
+mNi
 kUN
 fXU
 cBZ
-egc
+dTG
 exf
-rzy
-egc
+pPI
+dTG
 exf
 aPF
-bhO
+gyu
 cRY
 pJN
 kUN
@@ -74525,7 +74568,7 @@ kUN
 kUN
 kUN
 kUN
-nHE
+eZw
 fEj
 fEj
 fEj
@@ -74536,12 +74579,12 @@ fjh
 gmI
 iDK
 auj
-pCO
+rzy
 gBD
 aVZ
 gCa
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -74549,7 +74592,7 @@ gAy
 efa
 efa
 efa
-mOS
+dOg
 hQE
 eLE
 yhT
@@ -74757,24 +74800,24 @@ vgV
 kUN
 kUN
 fjS
-eCs
+xVD
 gCa
-npc
+bup
 kUN
-vkI
-gRa
-fpD
+uvj
+hxB
+woj
 gCa
 kUN
 cRY
 bwq
 wzt
-bhO
-bhO
-tda
-bhO
-bhO
-tda
+gyu
+gyu
+ehc
+gyu
+gyu
+ehc
 cRY
 kUN
 kUN
@@ -74793,8 +74836,8 @@ fjh
 hOB
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 gQW
 gCa
 fjS
@@ -74802,11 +74845,11 @@ gCa
 exN
 gCa
 wKN
-uvI
+thm
 efa
 ucR
 efa
-uII
+pSU
 hQE
 eLE
 yhT
@@ -75018,16 +75061,16 @@ kUN
 ohV
 kUN
 kUN
-fwZ
+eJq
 fRv
-sMl
+rIU
 gCa
 kUN
 cRY
 cRY
 cRY
-dZO
-nye
+fxi
+wpc
 cRY
 cRY
 cRY
@@ -75036,16 +75079,16 @@ cRY
 kUN
 kUN
 ddx
-qjU
-mSP
+fzD
+vkI
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-bxH
-nsf
+gwf
+hqt
 fjh
 iDK
 tZP
@@ -75274,11 +75317,11 @@ gCa
 gCa
 gCa
 eiA
-cQc
-fUu
+bVO
+eWL
 cXP
-sMl
-lmD
+rIU
+mNi
 cKb
 fXU
 cRY
@@ -75286,15 +75329,15 @@ dWg
 cRY
 cRY
 cRY
-iLY
+dEl
 cRY
 cRY
-cbQ
-rIU
+eOP
+dGU
 kUN
-gvC
-vkj
-lQm
+crx
+cbG
+fxX
 kUN
 kUN
 hRI
@@ -75311,14 +75354,14 @@ iDK
 eiA
 gCa
 gCa
-ava
+nZC
 npf
 xpf
 gCa
 ibo
-bKb
+vra
 xac
-fjU
+tCl
 efa
 fKK
 hQE
@@ -75545,20 +75588,20 @@ fPo
 cRY
 cRY
 cRY
-dZO
+fxi
 cRY
 kUN
 kUN
-wms
-jbM
-bwW
+pBk
+ixi
+jxS
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-kcf
+tbE
 iDK
 iDK
 iDK
@@ -75567,9 +75610,9 @@ auj
 gmI
 eiA
 fjS
-fmW
+dyB
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -75784,7 +75827,7 @@ aLB
 vgV
 kUN
 kUN
-dEL
+nyG
 fjS
 gCa
 eiA
@@ -75792,7 +75835,7 @@ gCa
 gCa
 fjS
 gCa
-dHw
+dVW
 kUN
 cRY
 cRY
@@ -75802,11 +75845,11 @@ cRY
 cRY
 cRY
 cRY
-nye
+wpc
 cRY
 kUN
 kUN
-lWO
+eFq
 gJz
 gJz
 kUN
@@ -76059,20 +76102,20 @@ cRY
 cRY
 dWg
 cRY
-dZO
-cbQ
+fxi
+eOP
 kUN
 kUN
-woj
-nFt
-bAz
+qXj
+eLg
+lUs
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-tXd
+itn
 gmI
 pVU
 tac
@@ -76303,14 +76346,14 @@ gCa
 gCa
 eiA
 gCa
-rLJ
+qjN
 gCa
 gCa
-dIq
+lFt
 kUN
 cRY
 cRY
-bPA
+uhB
 cRY
 fPo
 cRY
@@ -76320,9 +76363,9 @@ cRY
 kUN
 kUN
 kUN
-tXl
-lQm
-tbE
+iLY
+fxX
+ava
 kUN
 kUN
 hRI
@@ -76555,31 +76598,31 @@ mjG
 vgV
 kUN
 kUN
-jBt
-jBt
-jBt
+ajO
+ajO
+ajO
 kUN
 kUN
 kUN
-bVO
+lsh
 kUN
 kUN
 kUN
 kUN
 kUN
 kUN
-gza
+lwv
 nfB
 nfB
 kUN
 kUN
 kUN
 kUN
-dFv
-ddI
-lQm
-lQm
-aQw
+nUx
+ezs
+fxX
+fxX
+vPv
 kUN
 kUN
 hRI
@@ -76812,31 +76855,31 @@ mjG
 vgV
 kUN
 kUN
-qTe
-qTe
-qTe
+fjJ
+fjJ
+fjJ
 kUN
 dcd
 emK
-dQG
-dQG
-gBM
-eup
+egc
+egc
+aQw
+oVS
 uqb
-dUk
+cYs
 kUN
-fQB
+vbx
 anK
 qMr
-bMI
+kZh
 qMr
-iPX
+tda
 kUN
-tus
-lQm
-cMf
-lQm
-cuS
+ylp
+fxX
+iPX
+fxX
+dhF
 kUN
 kUN
 hRI
@@ -77073,27 +77116,27 @@ kUN
 kUN
 kUN
 kUN
-eLq
-dQG
-dNa
-dQG
+lmD
+egc
+vjM
+egc
 uqb
 aEe
 uqb
-eTS
+qTe
 kUN
-dEl
+tCQ
 anK
 anK
-bMI
+kZh
 anK
-czr
+rAd
 kUN
-hOx
-lQm
-lQm
-lQm
-bEV
+sfM
+fxX
+fxX
+fxX
+fLy
 kUN
 kUN
 hRI
@@ -77330,27 +77373,27 @@ dDz
 ccg
 sVT
 kUN
-aLA
-dQG
-dQG
-cqu
-bdL
+fis
+egc
+egc
+dIq
+wZU
 uqb
 uqb
-wrg
+eay
 kUN
-gHU
+vVu
 anK
 anK
-bMI
+kZh
 anK
 anK
-dhF
-lQm
-tGq
-lQm
-lQm
-voL
+daE
+fxX
+bxH
+fxX
+fxX
+tXl
 kUN
 kUN
 hRI
@@ -77584,35 +77627,35 @@ vgV
 kUN
 cQp
 acI
-iDd
+fqB
 acI
 kUN
-eLg
-dQG
-dQG
-cqu
-fOr
+bdL
+egc
+egc
+dIq
+fws
 fqF
 uqb
-fLy
+bqI
 kUN
-xTi
+fPt
 anK
 anK
-fyh
+fUu
 anK
 anK
 kUN
 kUN
 kUN
 kUN
-bVO
+lsh
 kUN
 kUN
 kUN
 cSY
-dpW
-qDc
+vQw
+aXd
 xdj
 dXE
 dXE
@@ -77844,27 +77887,27 @@ lLo
 fQz
 cSN
 ltu
-gMt
-hri
-fqF
-dHg
-eJq
+kcf
 dQG
+fqF
+qDc
+cqu
+egc
 uqb
-liN
+dHg
 kUN
-bMI
-bMI
-bMI
+kZh
+kZh
+kZh
 kUN
 anK
-pKf
+tXd
 kUN
-bqI
-dVW
+fVm
+dnc
 rqX
 rqX
-cxY
+qFM
 kUN
 kUN
 cSY
@@ -78099,29 +78142,29 @@ kUN
 gyB
 gyB
 gyB
-ube
+mZs
 kUN
-cTL
+iDd
 uqb
-gMt
+kcf
 uqb
-dQG
-gMt
+egc
+kcf
 uqb
-wam
+bUD
 kUN
-bPB
+pKf
 anK
 anK
 qMr
 anK
-fws
+kQt
 kUN
-kIf
+wuU
 rqX
-kIf
+wuU
 rqX
-eWL
+xTi
 kUN
 kUN
 cSY
@@ -78358,21 +78401,21 @@ acI
 uBk
 bXn
 kUN
-eJq
-eJq
-nbd
-eJq
-wLY
-dQG
+cqu
+cqu
+vkj
+cqu
+liN
+egc
 fqF
 uqb
-caw
+fpT
 anK
 anK
 anK
 anK
 anK
-mNi
+nsf
 kUN
 rqX
 rqX
@@ -78612,8 +78655,8 @@ vgV
 kUN
 gNv
 acI
-daL
-vfF
+vBZ
+rdP
 kUN
 kUN
 kUN
@@ -78629,11 +78672,11 @@ anK
 anK
 anK
 anK
-qXj
+wif
 kUN
-rAd
+gBM
 rqX
-kIf
+wuU
 rqX
 cLd
 kUN
@@ -78868,8 +78911,8 @@ mjG
 vgV
 kUN
 bXn
-exg
-itn
+uvI
+dFv
 lyd
 kUN
 kUN
@@ -78881,18 +78924,18 @@ kUN
 kUN
 kUN
 kUN
-jIs
 wpa
+eLq
 sTs
-lUs
+dIm
 anK
 qMr
 ltu
 rqX
-faq
-bMH
-tCl
-ezs
+xsf
+sOm
+tzz
+ube
 kUN
 kUN
 cSY
@@ -79641,10 +79684,10 @@ hQE
 hQE
 aoj
 aoj
-vra
+kjh
 aoj
 aoj
-jFq
+owJ
 vcx
 aoj
 aoj
@@ -79899,7 +79942,7 @@ hQE
 aoj
 aoj
 aoj
-ehc
+yck
 emV
 aoj
 aoj
@@ -80411,10 +80454,10 @@ fQL
 hQE
 hQE
 dXE
-uvj
+mSP
+sIa
+fnc
 pjR
-dsx
-dli
 dXE
 aoj
 vcx
@@ -80668,17 +80711,17 @@ fQL
 hQE
 hQE
 dXE
-thm
-fhe
-fhe
-fhe
+qxm
+dHw
+dHw
+dHw
 dXE
 aoj
 aoj
 aoj
 aoj
 aoj
-mYc
+ckD
 hKN
 cPI
 hQE
@@ -80925,9 +80968,9 @@ fQL
 hQE
 hQE
 dXE
-oVS
-fhe
-fhe
+ocq
+dHw
+dHw
 rSB
 dXE
 aoj
@@ -80937,7 +80980,7 @@ aoj
 aoj
 uPr
 cPI
-nzO
+kTJ
 hQE
 dXE
 dXE
@@ -81184,7 +81227,7 @@ hQE
 dXE
 dXE
 dXE
-qjN
+hFt
 dXE
 dXE
 hQE
@@ -81202,7 +81245,7 @@ hQE
 hQE
 hQE
 hQE
-ckD
+rGe
 hQE
 hQE
 hQE
@@ -81438,10 +81481,10 @@ mjG
 fQL
 hQE
 hQE
-uyC
-bHI
+jHj
+bMH
 sVP
-mZs
+cxY
 buN
 aoj
 aoj
@@ -81451,7 +81494,7 @@ aoj
 aoj
 aoj
 buN
-mYc
+ckD
 aoj
 aoj
 aoj
@@ -81466,9 +81509,9 @@ dii
 dii
 dii
 dii
-wZU
+aLA
 dii
-wZU
+aLA
 wFD
 mNE
 wFD
@@ -81695,15 +81738,15 @@ mjG
 fQL
 hQE
 hQE
-uyC
+jHj
 uuq
-mZs
-mZs
+cxY
+cxY
 hQE
 hQE
 hQE
 hQE
-ckD
+rGe
 hQE
 aoj
 dXE
@@ -81723,9 +81766,9 @@ dii
 dii
 dii
 dii
-wZU
+aLA
 dii
-wZU
+aLA
 wFD
 mNE
 wFD
@@ -81952,15 +81995,15 @@ mjG
 fQL
 hQE
 hQE
-mZs
-mZs
-akT
-mZs
+cxY
+cxY
+exg
+cxY
 hQE
 hzR
-fhe
+dHw
 flj
-fhe
+dHw
 hQE
 aoj
 dXE
@@ -81973,7 +82016,7 @@ hQE
 hQE
 hQE
 hQE
-ckD
+rGe
 hQE
 buN
 hQE
@@ -82209,15 +82252,15 @@ mjG
 fQL
 hQE
 hQE
-mZs
-mZs
-mZs
-mZs
+cxY
+cxY
+cxY
+cxY
 hQE
-fhe
+dHw
 flj
-fhe
-aJI
+dHw
+bMI
 hQE
 aoj
 dXE
@@ -82231,7 +82274,7 @@ aoj
 aoj
 aoj
 aoj
-ckD
+rGe
 aoj
 hQE
 cSY
@@ -82466,15 +82509,15 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 uCP
-mZs
-mZs
+cxY
+cxY
 hQE
 flj
-fhe
-fhe
-gkY
+dHw
+dHw
+bve
 hQE
 aoj
 dXE
@@ -82723,22 +82766,22 @@ mjG
 fQL
 hQE
 hQE
-mZs
-mZs
-mZs
-mZs
+cxY
+cxY
+cxY
+cxY
 hQE
 cLS
-fhe
-fhe
-fhe
+dHw
+dHw
+dHw
 hQE
 aoj
 aoj
 aoj
 aoj
 aoj
-ckD
+rGe
 aoj
 dXE
 dXE
@@ -82980,15 +83023,15 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 jPC
-qia
+hOx
 jPC
 hQE
 hQE
 hQE
 hQE
-ckD
+rGe
 hQE
 hQE
 hQE
@@ -83237,7 +83280,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 jPC
 jzO
 dFt
@@ -83494,7 +83537,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 jPC
 lzb
 uqE
@@ -83751,7 +83794,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 jPC
 wDa
 gSS
@@ -83759,7 +83802,7 @@ hQE
 aoj
 hQE
 hQE
-ckD
+rGe
 hQE
 hQE
 hQE
@@ -84008,7 +84051,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 lQz
 uqE
 ncJ
@@ -84265,7 +84308,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 rCl
 fxD
 gSS
@@ -84522,7 +84565,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 ngX
 dXE
 dXE
@@ -84779,7 +84822,7 @@ mjG
 fQL
 hQE
 hQE
-mZs
+cxY
 lNw
 jPC
 jPC
@@ -85036,10 +85079,10 @@ mjG
 fQL
 hQE
 hQE
-mZs
-cdh
-mZs
-dnc
+cxY
+lxs
+cxY
+gIt
 hQE
 aoj
 hQE
@@ -85293,9 +85336,9 @@ mjG
 fQL
 hQE
 hQE
-mZs
-mZs
-mZs
+cxY
+cxY
+cxY
 nBV
 hQE
 aoj
@@ -85547,15 +85590,15 @@ mjG
 wFD
 wFD
 dtk
-dOg
+bRm
 nEz
 uCP
 bSl
-mZs
-mZs
-mZs
+cxY
+cxY
+cxY
+rGe
 ckD
-mYc
 hQE
 dXE
 aoj
@@ -85812,7 +85855,7 @@ nEz
 hQE
 hQE
 hQE
-mYc
+ckD
 hQE
 dXE
 aoj
@@ -86064,8 +86107,8 @@ mjG
 fQL
 hQE
 hQE
-mZs
-mZs
+cxY
+cxY
 hQE
 dXE
 dXE
@@ -86322,7 +86365,7 @@ fQL
 hQE
 hQE
 gQR
-mZs
+cxY
 hQE
 dXE
 dXE
@@ -86578,8 +86621,8 @@ bbB
 fQL
 hQE
 hQE
-mZs
-mZs
+cxY
+cxY
 hQE
 dXE
 dXE
@@ -86835,8 +86878,8 @@ bbB
 fQL
 hQE
 hQE
-mZs
-mZs
+cxY
+cxY
 hQE
 dXE
 dXE
@@ -87092,8 +87135,8 @@ bbB
 fQL
 hQE
 hQE
-mZs
-mZs
+cxY
+cxY
 hQE
 dXE
 dXE
@@ -87349,7 +87392,7 @@ mjG
 fQL
 hQE
 hQE
-ckD
+rGe
 hQE
 hQE
 dXE
@@ -88635,7 +88678,7 @@ fQL
 hQE
 hQE
 hQE
-ckD
+rGe
 hQE
 hQE
 hQE
@@ -88663,8 +88706,8 @@ dXE
 dXE
 dXE
 dXE
-qGl
-kaQ
+uyC
+bvs
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -302,12 +302,13 @@
 /turf/open/water,
 /area/f13/tunnel)
 "ajO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "ajR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -333,6 +334,18 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/operations)
+"akT" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "alv" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -481,12 +494,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/structure/fence{
+	dir = 8
 	},
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -513,6 +522,41 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"aqW" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/datura,
+/obj/item/seeds/datura,
+/obj/item/seeds/yucca,
+/obj/item/seeds/yucca,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/buffalogourd,
+/obj/item/seeds/grass,
+/obj/item/seeds/grass,
+/obj/item/seeds/tato,
+/obj/item/seeds/tato,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/coyotetobacco,
+/obj/item/seeds/coyotetobacco,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice/d20,
@@ -959,12 +1003,8 @@
 	},
 /area/f13/tunnel)
 "aEe" = (
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1145,13 +1185,11 @@
 	},
 /area/f13/tunnel)
 "aJI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/den)
 "aKc" = (
 /obj/structure/cable{
@@ -1217,11 +1255,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"aLA" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "aLB" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13{
@@ -1314,8 +1347,13 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "aPF" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/melee/onehanded/knife/switchblade,
+/obj/item/gun/ballistic/automatic/smg/tommygun,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
+/obj/item/ammo_box/magazine/tommygunm45/stick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "aPG" = (
@@ -1342,19 +1380,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "aQw" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "aQU" = (
@@ -1547,13 +1575,8 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "aXd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
@@ -1810,10 +1833,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "bdf" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
 	},
-/turf/closed/wall/f13/wood/interior,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
@@ -1847,11 +1870,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bdL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/pinup_bed,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bdY" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1982,8 +2002,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2113,10 +2136,14 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2311,15 +2338,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bqI" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/table/wood/junk,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "bqO" = (
@@ -2489,6 +2511,14 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"bup" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = 32
+	},
+/obj/item/stack/f13Cash/caps/onezerozerozero,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2510,8 +2540,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "bve" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -2522,8 +2552,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "bvs" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "bvG" = (
 /obj/structure/spider/stickyweb,
@@ -2579,15 +2613,6 @@
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bwW" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
-/area/f13/den)
 "bxf" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/barber{
@@ -2626,17 +2651,10 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "bxT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2720,8 +2738,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "bAz" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_t,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
@@ -2915,12 +2941,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -2990,14 +3015,24 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"bHI" = (
-/obj/structure/fence{
-	dir = 8
-	},
+"bHA" = (
 /obj/structure/handrail/g_central{
-	pixel_y = -16
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
+"bHI" = (
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
@@ -3050,15 +3085,12 @@
 	},
 /area/f13/brotherhood/operating)
 "bIT" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "bIX" = (
 /obj/effect/decal/cleanable/dirt{
@@ -3180,13 +3212,14 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMI" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
@@ -3217,11 +3250,9 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices2nd)
 "bNI" = (
-/obj/structure/pondlily_small{
-	pixel_x = 34;
-	pixel_y = 26
-	},
-/turf/open/water,
+/obj/structure/sign/poster/contraband/power,
+/obj/structure/simple_door/wood,
+/turf/open/space/basic,
 /area/f13/den)
 "bNJ" = (
 /obj/structure/bed/mattress/pregame,
@@ -3234,12 +3265,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "bOp" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -3303,38 +3329,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"bPA" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
-"bPB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
-"bPD" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3389,12 +3383,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bRm" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "bRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3601,10 +3589,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/offices1st)
 "bVO" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "bVT" = (
 /obj/structure/chair/f13foldupchair{
@@ -3632,16 +3618,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"bXn" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "bXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -3738,11 +3714,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "caw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "caG" = (
 /obj/structure/flora/junglebush/c,
@@ -3787,6 +3768,14 @@
 	req_access_txt = "87"
 	},
 /turf/open/floor/wood/f13/oak,
+/area/f13/den)
+"cbG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
@@ -3839,11 +3828,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "ccg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/structure/pondlily_small{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "ccq" = (
 /obj/item/clothing/head/helmet/knight/f13/metal/reinforced,
@@ -3905,17 +3894,9 @@
 	},
 /area/f13/tunnel)
 "cdh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/chem_master/condimaster{
-	density = 0
-	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "cdu" = (
 /obj/structure/cable{
@@ -4152,12 +4133,9 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "ckH" = (
 /obj/structure/cable{
@@ -4342,14 +4320,9 @@
 	},
 /area/f13/caves)
 "cqu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "cqC" = (
@@ -4382,15 +4355,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "crx" = (
-/obj/structure/table{
-	pixel_x = 6
-	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/wood/f13/oak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "crL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -4496,7 +4462,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "cuS" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "cvd" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4595,6 +4565,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"cxY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cyb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -4649,14 +4625,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
-"czr" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4765,9 +4733,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4888,13 +4861,9 @@
 	},
 /area/f13/building)
 "cCO" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
@@ -5070,21 +5039,9 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
-"cIZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"cJI" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
@@ -5189,6 +5146,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
+"cMf" = (
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "cMJ" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
@@ -5239,11 +5200,19 @@
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
 "cQc" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
@@ -5251,10 +5220,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "cQp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -5364,7 +5336,18 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "cTL" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "cTR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5530,8 +5513,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cXP" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/f13/wood/interior,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "cYb" = (
 /turf/open/floor/f13/wood{
@@ -5561,25 +5546,9 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "cYs" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5639,22 +5608,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/brotherhood/mining)
 "daE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/junglebush,
+/turf/open/water,
+/area/f13/den)
+"daL" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
 	pixel_x = -20
 	},
-/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
 /turf/open/water,
-/area/f13/den)
-"daL" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
 /area/f13/den)
 "dba" = (
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -5741,9 +5706,8 @@
 	},
 /area/f13/den)
 "ddI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "deM" = (
 /obj/structure/table/wood/settler,
@@ -5768,9 +5732,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dgg" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5808,12 +5776,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
-"dgO" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5841,10 +5803,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "dhF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood,
-/turf/open/floor/carpet/red,
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5996,9 +5956,14 @@
 	},
 /area/f13/bunker)
 "dli" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "dlk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -6097,14 +6062,22 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
 "dnc" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "S6"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/fence/corner{
+	dir = 8
 	},
-/area/f13/sewer)
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -6148,18 +6121,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dok" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 56;
+	pixel_y = 35
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/red,
+/turf/open/water,
 /area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -6192,18 +6159,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dpl" = (
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "dpu" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_y = -1;
+/obj/machinery/light/fo13colored/Red,
+/obj/structure/sign/poster/contraband/pinup_topless{
 	pixel_x = -31
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6217,21 +6188,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "dqh" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/wiki/cit/chem_recipies,
@@ -6304,8 +6274,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "dsx" = (
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/structure/pondlily_small,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
+/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6651,19 +6623,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dCp" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dCK" = (
 /turf/open/floor/wood,
@@ -6711,13 +6675,9 @@
 	},
 /area/f13/building)
 "dEl" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6730,12 +6690,12 @@
 	},
 /area/f13/sewer)
 "dEL" = (
-/obj/machinery/light,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dES" = (
@@ -6770,6 +6730,12 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"dFv" = (
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "dGP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6794,15 +6760,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"dGU" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/suit/f13/sexymaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
@@ -6836,8 +6793,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "dIm" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "dIo" = (
 /obj/structure/cable{
@@ -6846,14 +6807,10 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
 "dIq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/departments/medbay{
-	pixel_x = 33
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "dII" = (
@@ -6964,9 +6921,19 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "dLC" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
+/area/f13/den)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -7005,9 +6972,12 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "dNa" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
@@ -7065,19 +7035,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/machinery/button/door{
-	name = "North Den Gate";
-	pixel_y = 29;
-	pixel_x = 1;
-	id = "dennorthgate"
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -7115,13 +7083,41 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "dPc" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "dPo" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7264,11 +7260,12 @@
 /turf/open/water,
 /area/f13/bunker)
 "dTr" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/machinery/light/floor,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
@@ -7314,9 +7311,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "dUk" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/enforcer,
-/turf/open/floor/carpet/green,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "dUn" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -7336,14 +7334,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dUO" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = 15
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
+/obj/machinery/microwave{
+	pixel_x = -6
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/table{
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "dUX" = (
 /obj/machinery/light/floor,
@@ -7430,10 +7431,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -7555,11 +7558,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
 "dZO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/machinery/button/door{
+	name = "North Den Gate";
+	pixel_y = 29;
+	pixel_x = 1;
+	id = "dennorthgate"
 	},
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -7600,10 +7608,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "eay" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "eaB" = (
@@ -7824,9 +7834,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "egc" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
@@ -7854,6 +7862,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"ehc" = (
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/junglebush,
@@ -7889,12 +7907,16 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
 "ehL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "ehQ" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7904,13 +7926,12 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "eiA" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -8032,9 +8053,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "ekK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
 	},
 /area/f13/den)
 "ekQ" = (
@@ -8167,11 +8190,6 @@
 /obj/item/card/id/dogtag/enclave/noncombatant,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
-"epg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "epz" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 16;
@@ -8257,8 +8275,12 @@
 	},
 /area/f13/brotherhood/leisure)
 "esc" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/structure/chair/wood,
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "esg" = (
 /obj/item/flag/bos,
@@ -8354,9 +8376,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "eup" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
 /area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
@@ -8407,6 +8428,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"ewe" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "ewF" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/spacevine{
@@ -8423,6 +8449,22 @@
 "exf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/grass,
+/area/f13/den)
+"exg" = (
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8472,13 +8514,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
-"exN" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "exP" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
@@ -8518,14 +8553,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
 	},
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "eAa" = (
@@ -8575,13 +8609,15 @@
 	},
 /area/f13/building)
 "eBU" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
 	},
+/turf/open/floor/plasteel/stairs,
 /area/f13/den)
 "eBZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8601,10 +8637,17 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "eCF" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot_white,
@@ -8726,10 +8769,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "eFq" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/falsewall/rust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
@@ -8778,9 +8819,10 @@
 	},
 /area/f13/building)
 "eGQ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "eGX" = (
 /obj/structure/table/wood/settler,
@@ -8795,6 +8837,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "eHr" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -8898,8 +8943,8 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/f13/dendoctor,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "eJW" = (
@@ -8940,8 +8985,14 @@
 	},
 /area/f13/brotherhood/archives)
 "eKX" = (
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
@@ -8957,18 +9008,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "eLg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/den)
-"eLq" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/water,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
+"eLq" = (
+/obj/structure/closet/cabinet{
+	pixel_x = 2;
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -9021,13 +9072,8 @@
 	},
 /area/f13/sewer)
 "eMH" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = -64;
-	pixel_y = -37
-	},
-/turf/open/water,
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "eMK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9115,9 +9161,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eOP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9288,6 +9339,10 @@
 	dir = 5
 	},
 /area/f13/brotherhood/mining)
+"eTS" = (
+/obj/structure/pondlily_small,
+/turf/open/water,
+/area/f13/den)
 "eUi" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9337,14 +9392,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"eVt" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
-	},
-/area/f13/den)
 "eVu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9375,13 +9422,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"eWL" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "eWN" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -9482,13 +9522,25 @@
 	},
 /area/f13/bunker)
 "eZw" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	density = 0;
+	pixel_y = -34
+	},
+/obj/machinery/vending/dinnerware{
+	pixel_x = -29;
+	density = 0
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "faq" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9549,13 +9601,12 @@
 /area/f13/sewer)
 "fdw" = (
 /obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/caves)
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
+/area/f13/den)
 "fdG" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
@@ -9615,12 +9666,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/item/fishyegg/shrimp,
+/turf/open/water,
 /area/f13/den)
 "fgo" = (
 /obj/structure/sign/warning,
@@ -9681,13 +9732,17 @@
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
 "fhe" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/fence/corner{
+	dir = 6
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
@@ -9703,9 +9758,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "fis" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9724,12 +9781,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fju" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
 /area/f13/den)
 "fjv" = (
 /obj/structure/simple_door/house{
@@ -9754,11 +9811,8 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fjJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/f13/sewer)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/den)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9822,15 +9876,18 @@
 /turf/open/water,
 /area/f13/den)
 "flP" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/caves)
+"flT" = (
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/den)
-"flT" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/caves)
 "flW" = (
 /obj/structure/wreck/trash/engine,
 /obj/structure/spider/stickyweb,
@@ -9876,29 +9933,15 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "fnc" = (
-/obj/structure/table,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/adv{
-	pixel_x = -8
+/obj/structure/table{
+	pixel_x = 6
 	},
-/obj/item/scalpel,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
 	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/electropack/shockcollar{
-	name = "Prisoner Control Device"
-	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/wood/wood_large,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -9995,10 +10038,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -10021,17 +10062,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"fpT" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -10053,41 +10083,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqB" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
+/obj/structure/fence{
+	dir = 8
 	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/handrail/g_central{
+	pixel_y = -16
 	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "fqF" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10286,13 +10288,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "fww" = (
 /obj/structure/flora/rock/jungle{
@@ -10312,23 +10314,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fwZ" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
-"fxi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "fxu" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -10343,6 +10331,11 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fxX" = (
+/obj/structure/pondlily_small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/remains/human,
@@ -10355,7 +10348,14 @@
 	},
 /area/f13/building)
 "fyh" = (
-/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fym" = (
@@ -10387,6 +10387,11 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"fyC" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
+/area/f13/den)
 "fyG" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
 /turf/open/floor/carpet/vault,
@@ -10414,23 +10419,15 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
 "fzj" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
-"fzD" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
+"fzD" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -10448,15 +10445,12 @@
 	},
 /area/f13/den)
 "fzY" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/water,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10635,7 +10629,7 @@
 /area/f13/tunnel)
 "fGK" = (
 /obj/structure/chair/wood{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -10740,12 +10734,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fJp" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/fishyegg/shrimp,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10905,9 +10898,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fOr" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -10946,9 +10942,8 @@
 	},
 /area/f13/bunker)
 "fPo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fPt" = (
 /obj/structure/barricade/bars{
@@ -11001,11 +10996,9 @@
 /turf/open/floor/wood/wood_large,
 /area/f13/den)
 "fQB" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
@@ -11018,12 +11011,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fRK" = (
 /turf/open/floor/plating/tunnel{
@@ -11161,11 +11151,11 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -11203,11 +11193,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
 "fVm" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "fVA" = (
@@ -11273,7 +11264,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "fXU" = (
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
@@ -11659,15 +11652,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "gkx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11694,8 +11682,11 @@
 	},
 /area/f13/brotherhood/rnd)
 "gkY" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "glc" = (
 /obj/effect/turf_decal/bot,
@@ -11792,9 +11783,8 @@
 	},
 /area/f13/bunker)
 "gow" = (
-/obj/structure/simple_door/metal/fence,
-/obj/structure/decoration/rag,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
@@ -11841,11 +11831,11 @@
 	},
 /area/f13/bunker)
 "gqj" = (
-/obj/structure/chair/stool/bar{
-	desc = "The place you sit when all hope is lost.";
-	name = "casino stool"
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "gqt" = (
 /obj/structure/rack,
@@ -12016,8 +12006,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gvC" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "gvL" = (
 /obj/machinery/light/sign{
@@ -12027,11 +12022,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "gwf" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 0
-	},
-/turf/open/water,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -12069,12 +12061,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "gxS" = (
-/obj/structure/flora/rock/pile/largejungle{
-	layer = 3.2;
-	pixel_x = 56;
-	pixel_y = 35
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/water,
+/obj/structure/sign/departments/medbay{
+	pixel_x = 33
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "gxY" = (
 /turf/open/floor/carpet/royalblue,
@@ -12094,12 +12089,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
 "gyu" = (
-/obj/structure/closet/cabinet{
-	pixel_x = 2;
-	pixel_y = 32;
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
 	},
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "gyB" = (
 /obj/structure/barricade/bars,
@@ -12123,9 +12115,13 @@
 	},
 /area/f13/bunker)
 "gza" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
+/area/f13/den)
 "gzg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -12202,15 +12198,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "gBM" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/flora/ausbushes/reedbush,
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gCa" = (
 /turf/open/floor/carpet/green,
@@ -12303,11 +12294,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"gDU" = (
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "gEn" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -12347,6 +12333,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"gFp" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "gFC" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -12444,16 +12436,9 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "gHU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "gHY" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -12480,6 +12465,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"gIt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "gIQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -12617,9 +12612,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "gNv" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/item/fishyegg/shrimp,
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = -64;
+	pixel_y = -37
+	},
 /turf/open/water,
 /area/f13/den)
 "gNC" = (
@@ -12726,14 +12724,17 @@
 	},
 /area/f13/caves)
 "gQW" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "gRa" = (
-/obj/structure/pondlily_small,
-/turf/open/water,
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12902,8 +12903,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/red,
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -13507,6 +13510,22 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"hqt" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
+"hri" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "hrM" = (
 /obj/structure/table,
 /obj/machinery/light/small,
@@ -13681,8 +13700,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "hxF" = (
 /obj/machinery/light{
@@ -13815,8 +13836,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "hFt" = (
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "hFL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13938,10 +13959,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/water,
 /area/f13/tunnel)
-"hJy" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
 "hJD" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -14132,14 +14149,17 @@
 	},
 /area/f13/bunker)
 "hOx" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
+/obj/structure/fence/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14598,13 +14618,16 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "ica" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
 	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15065,10 +15088,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "itn" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/f13/dendoctor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "itB" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -15237,21 +15260,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ixi" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/water,
 /area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
@@ -15395,10 +15406,10 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "iDd" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "iDh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -15610,10 +15621,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "iLY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15765,12 +15776,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/water,
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -15930,10 +15938,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
@@ -15962,10 +15968,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "iVF" = (
-/obj/structure/rack,
-/obj/item/locked_box/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -16152,8 +16159,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "jaU" = (
 /obj/structure/table,
@@ -16178,14 +16185,6 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jbM" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/pondlily_small,
-/turf/open/water,
-/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -16696,10 +16695,10 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "juA" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "juI" = (
 /obj/structure/kitchenspike,
@@ -16787,6 +16786,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jxS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/chem_master/condimaster{
+	density = 0
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "jxW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Canteen"
@@ -16898,16 +16910,6 @@
 "jBq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"jBt" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/melee/onehanded/knife/switchblade,
-/obj/item/gun/ballistic/automatic/smg/tommygun,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/obj/item/ammo_box/magazine/tommygunm45/stick,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "jBu" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16969,11 +16971,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/area/f13/sewer)
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17013,14 +17018,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "jFq" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "jFC" = (
 /obj/machinery/door/poddoor{
 	id = "pain"
@@ -17068,10 +17070,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge,
-/turf/open/floor/carpet/red,
-/area/f13/den)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "jHI" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -17093,12 +17097,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jIs" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "jIw" = (
 /obj/effect/decal/cleanable/glass,
 /turf/closed/indestructible/vaultdoor,
@@ -17684,12 +17682,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "kaQ" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "kbf" = (
 /obj/machinery/autolathe,
@@ -17769,8 +17767,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "kcf" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18015,12 +18019,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"kjh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18814,6 +18812,17 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"kIf" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18846,12 +18855,8 @@
 /area/f13/bunker)
 "kJu" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
+/obj/structure/closet/fridge,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "kJB" = (
 /obj/item/mop,
@@ -18884,8 +18889,11 @@
 	},
 /area/f13/bunker)
 "kKb" = (
-/obj/structure/sign/poster/contraband/rebels_unite,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "kKs" = (
 /obj/structure/simple_door/house{
@@ -19014,15 +19022,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "kQt" = (
-/obj/structure/table{
-	pixel_x = 6
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1;
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
 /area/f13/den)
 "kQy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19118,14 +19123,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/flora/grass/jungle,
+/turf/open/water,
 /area/f13/den)
 "kTO" = (
 /obj/machinery/light/broken{
@@ -19432,18 +19431,12 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/obj/structure/flora/junglebush,
+/turf/open/water,
 /area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
@@ -19729,14 +19722,11 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "liS" = (
@@ -19884,11 +19874,14 @@
 	},
 /area/f13/bunker)
 "lmD" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "lmG" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -20053,12 +20046,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lsh" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 32
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/stack/f13Cash/caps/onezerozerozero,
-/turf/open/floor/carpet/green,
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -20187,13 +20182,14 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "lwv" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "lwU" = (
@@ -20203,15 +20199,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"lxs" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
 "lxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -20496,10 +20483,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "lFt" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "lFR" = (
@@ -20840,12 +20827,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"lQm" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
 "lQs" = (
 /obj/structure/fans/tiny{
 	pixel_y = -33
@@ -20946,8 +20927,29 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/structure/table,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze/adv{
+	pixel_x = -8
+	},
+/obj/item/scalpel,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/electropack/shockcollar{
+	name = "Prisoner Control Device"
+	},
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21532,22 +21534,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/structure/table/wood/poker,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/cards/singlecard{
-	pixel_x = 3
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
 	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = 1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -1
-	},
-/obj/item/toy/cards/singlecard{
-	pixel_x = -3
-	},
-/obj/item/toy/cards/singlecard,
-/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "mnU" = (
@@ -21890,17 +21882,6 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"mCP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -22149,12 +22130,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mNi" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/water,
 /area/f13/den)
 "mNt" = (
 /obj/structure/rack,
@@ -22196,39 +22178,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mOS" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/datura,
-/obj/item/seeds/datura,
-/obj/item/seeds/yucca,
-/obj/item/seeds/yucca,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/buffalogourd,
-/obj/item/seeds/grass,
-/obj/item/seeds/grass,
-/obj/item/seeds/tato,
-/obj/item/seeds/tato,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/coyotetobacco,
-/obj/item/seeds/coyotetobacco,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "mPe" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -22351,10 +22304,21 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "mSP" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/jade,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/pinup_ride{
+	pixel_y = -1;
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -22562,11 +22526,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_south"
 	},
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "mZG" = (
 /obj/item/pickaxe/drill,
@@ -22649,10 +22613,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22750,6 +22713,11 @@
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"ndz" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "nee" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23070,19 +23038,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "npc" = (
-/obj/machinery/light/floor,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "npf" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "npi" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -23180,6 +23147,18 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"nsf" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "nsr" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
@@ -23408,16 +23387,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
 "nye" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "nyq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt{
@@ -23435,12 +23408,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/machinery/processor{
-	pixel_x = -1;
-	pixel_y = -31;
-	density = 0
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "nyX" = (
 /obj/structure/chair/wood/normal{
@@ -23476,6 +23447,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"nzO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -23617,16 +23597,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
-"nEK" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/melee/onehanded/knife/switchblade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "nEP" = (
-/obj/structure/chair/stool/bar/brass,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 33;
+	pixel_x = 1
+	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "nFc" = (
@@ -23663,13 +23652,8 @@
 	},
 /area/f13/building)
 "nFt" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/carpet/red,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -23764,23 +23748,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHE" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
-"nHM" = (
 /obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
+"nHM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "nHY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/drone,
@@ -23833,17 +23814,11 @@
 	},
 /area/f13/brotherhood/operating)
 "nJC" = (
-/obj/structure/fence/corner{
-	dir = 6
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -24167,8 +24142,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "nUx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "nUA" = (
@@ -24352,11 +24329,15 @@
 	},
 /area/f13/brotherhood/mining)
 "nZC" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
+/obj/machinery/button/door{
+	name = "den clinic shutters";
+	pixel_y = -28;
+	id = "denmedshutters"
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "nZW" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -24428,16 +24409,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ocq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/fo13colored/Red,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -31
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "ocy" = (
 /obj/structure/barricade/wooden,
@@ -24658,8 +24635,16 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "ohx" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "ohV" = (
@@ -24937,9 +24922,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "opa" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood/wood_large,
+/obj/structure/table/wood/settler,
+/obj/structure/fence/pole_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "opk" = (
 /obj/structure/spider/stickyweb,
@@ -25141,8 +25126,18 @@
 	},
 /area/f13/building)
 "owJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
 /obj/structure/chair/stool/retro/black,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
@@ -25288,8 +25283,8 @@
 	},
 /area/f13/building)
 "oBq" = (
+/obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush,
 /turf/open/water,
 /area/f13/den)
 "oBy" = (
@@ -25802,17 +25797,11 @@
 	},
 /area/f13/bunker)
 "oVS" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 15
+/obj/structure/chair/stool/bar{
+	desc = "The place you sit when all hope is lost.";
+	name = "casino stool"
 	},
-/obj/machinery/microwave{
-	pixel_x = -6
-	},
-/obj/structure/table{
-	pixel_x = 14
-	},
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -26214,10 +26203,11 @@
 	},
 /area/f13/bunker)
 "pjR" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
-/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "pkj" = (
 /obj/machinery/button/door{
@@ -26687,13 +26677,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBk" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "pBU" = (
 /obj/structure/flora/rock/jungle{
@@ -26733,11 +26725,9 @@
 	},
 /area/f13/tunnel)
 "pCO" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
-	},
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/light/floor,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
@@ -26912,10 +26902,6 @@
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
 /area/f13/building)
-"pJN" = (
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "pJT" = (
 /obj/structure/billboard/cola/pristine,
 /obj/effect/decal/cleanable/dirt,
@@ -26930,9 +26916,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pKf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/den)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/water,
+/area/f13/sewer)
 "pKC" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -27109,16 +27096,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "pPI" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/structure/fence/pole_t,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/water,
 /area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
@@ -27253,16 +27236,23 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "pSU" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/cards/singlecard{
+	pixel_x = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/item/toy/cards/singlecard{
+	pixel_x = 1
 	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -1
+	},
+/obj/item/toy/cards/singlecard{
+	pixel_x = -3
+	},
+/obj/item/toy/cards/singlecard,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "pTC" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -27664,10 +27654,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "qfj" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qfw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27768,10 +27757,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence/pole_t,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/barber{
@@ -27854,12 +27850,14 @@
 /area/f13/bunker)
 "qjN" = (
 /obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+	dir = 1;
+	pixel_y = 23
 	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
@@ -27873,11 +27871,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qjU" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/closed/mineral/random/high_chance,
-/area/f13/caves)
+/obj/structure/chair/f13foldupchair,
+/obj/effect/landmark/start/f13/mobboss,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -28164,16 +28161,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtc" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "qtf" = (
 /obj/structure/rack,
@@ -28280,10 +28268,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qxm" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -28472,13 +28456,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qDc" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/effect/light_emitter,
+/obj/structure/flora/tree/jungle/small,
 /turf/open/water,
 /area/f13/den)
 "qDw" = (
@@ -28511,13 +28493,11 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qEH" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
 	},
 /turf/open/water,
-/area/f13/den)
+/area/f13/caves)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/structure/spider/stickyweb,
@@ -28595,9 +28575,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "qFM" = (
-/obj/machinery/light/floor,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
+/obj/structure/flora/rock/pile/largejungle{
+	layer = 3.2;
+	pixel_x = 0
+	},
+/turf/open/water,
 /area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
@@ -28617,12 +28599,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGl" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
-/turf/open/water,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -28662,10 +28645,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qIj" = (
-/obj/structure/pondlily_small{
-	pixel_x = 2;
-	pixel_y = -2
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
+/obj/item/fishyegg/shrimp,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/den)
 "qIw" = (
@@ -28804,13 +28789,10 @@
 	},
 /area/f13/brotherhood/offices1st)
 "qMr" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/caves)
+/area/f13/den)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -29033,8 +29015,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/den)
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "qTm" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/tunnel,
@@ -29153,9 +29136,10 @@
 	},
 /area/f13/brotherhood/rnd)
 "qXj" = (
-/obj/structure/sign/poster/contraband/bountyhunters,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29811,8 +29795,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rsi" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/carpet/red,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
@@ -30208,13 +30197,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "rzy" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
@@ -30233,16 +30220,24 @@
 	},
 /area/f13/den)
 "rAd" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_t,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "rAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -30535,9 +30530,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/mobboss,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
+	},
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "rGi" = (
 /obj/structure/bed/wooden,
@@ -30595,13 +30592,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
-"rIU" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "rJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
@@ -30760,12 +30750,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "rLJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/falsewall/rust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/sign/poster/official/anniversary_vintage_reprint,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "rLN" = (
 /turf/open/floor/plating/ashplanet/wateryrock,
@@ -30938,13 +30924,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "rQv" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gib2-old"
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood/wood_large,
-/area/f13/den)
+/area/f13/caves)
 "rQO" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -30995,31 +30979,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "rSO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gib2-old"
 	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 33;
-	pixel_x = 1
-	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/wood_large,
 /area/f13/den)
 "rSU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water,
 /area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
@@ -31270,11 +31243,14 @@
 	},
 /area/f13/tunnel)
 "saE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
 	},
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/caves)
 "saS" = (
 /obj/item/mine/shrapnel,
 /turf/open/water,
@@ -31402,14 +31378,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
 "sfM" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
-	},
-/turf/open/water,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/enforcer,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32251,11 +32222,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"sIa" = (
-/obj/structure/sign/poster/contraband/power,
-/obj/structure/simple_door/wood,
-/turf/open/space/basic,
-/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -32419,10 +32385,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sOm" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/caves)
 "sOq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32595,10 +32557,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "sTs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "sTW" = (
 /obj/structure/simple_door/metal/barred,
@@ -32830,14 +32792,15 @@
 	},
 /area/f13/sewer)
 "tbE" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
@@ -32851,12 +32814,15 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -32864,15 +32830,8 @@
 /area/f13/building)
 "tda" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/boozeomat/syndicate_access{
-	density = 0;
-	pixel_y = -34
-	},
-/obj/machinery/vending/dinnerware{
-	pixel_x = -29;
-	density = 0
-	},
-/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "tdv" = (
@@ -32978,6 +32937,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"thm" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -33111,23 +33074,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tlZ" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29;
-	id = "dennorthshutters"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "tmc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo,
@@ -33351,15 +33297,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tst" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/carpet/green,
 /area/f13/den)
 "tsK" = (
 /obj/structure/chair/f13chair1{
@@ -33372,15 +33314,11 @@
 	},
 /area/f13/bunker)
 "tsX" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "neutralrustyfull"
 	},
-/area/f13/den)
+/area/f13/caves)
 "tte" = (
 /obj/machinery/workbench/advanced,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -33407,13 +33345,14 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "tus" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "S6"
 	},
-/obj/structure/flora/junglebush,
-/turf/open/water,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "tuB" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -33589,11 +33528,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "tzz" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33679,22 +33616,21 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/caves)
-"tCQ" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters";
-	pixel_y = -28;
-	id = denmedshutters
-	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/den)
+"tCQ" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -33837,6 +33773,23 @@
 	name = "vault floor"
 	},
 /area/f13/enclave)
+"tGq" = (
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29;
+	id = "dennorthshutters"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34071,11 +34024,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "tMr" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/pondlily_small{
+	pixel_x = 34;
+	pixel_y = 26
 	},
-/turf/open/floor/carpet/green,
+/turf/open/water,
 /area/f13/den)
 "tMD" = (
 /turf/closed/indestructible/rock,
@@ -34350,17 +34303,17 @@
 	},
 /area/f13/bunker)
 "tXd" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/obj/structure/pondlily_small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -34511,6 +34464,14 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"ube" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/bars,
+/obj/structure/window/fulltile/ruins{
+	max_integrity = 700
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "ubh" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -34607,13 +34568,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "uhB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
@@ -34893,6 +34849,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"uqb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -35008,17 +34972,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "uso" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/machinery/processor{
+	pixel_x = -1;
+	pixel_y = -31;
+	density = 0
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -35112,6 +35071,15 @@
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
+"uvj" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/suit/f13/sexymaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -35123,12 +35091,8 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
@@ -35168,12 +35132,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "uyC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/rebels_unite,
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35435,9 +35396,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "uII" = (
-/obj/structure/barricade/bars,
-/turf/open/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/den)
 "uJq" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/waste{
@@ -35515,14 +35478,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
 "uLP" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
+/obj/effect/decal/remains{
+	icon_state = "remains"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -35773,8 +35733,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "uUB" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -36004,11 +35964,9 @@
 	},
 /area/f13/brotherhood/offices1st)
 "vbx" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "vbU" = (
@@ -36199,7 +36157,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/machinery/light/floor,
+/obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -36275,13 +36233,14 @@
 	},
 /area/f13/brotherhood/dorms)
 "vjM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood/anchored,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 1
 	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36290,6 +36249,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"vjW" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -36310,6 +36273,13 @@
 	dir = 1
 	},
 /area/f13/brotherhood/mining)
+"vkj" = (
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/den)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -36325,27 +36295,19 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"vkI" = (
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
 "vlM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
 /area/f13/den)
 "vlT" = (
 /obj/machinery/light/small{
@@ -36426,6 +36388,17 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
+"voL" = (
+/obj/structure/table{
+	pixel_x = 6
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "voT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36497,10 +36470,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "vra" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -36546,9 +36520,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vsF" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/falsewall/rust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/den)
 "vsI" = (
@@ -37323,11 +37299,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vPv" = (
-/obj/structure/simple_door/house{
-	icon_state = "glassclosing"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/caves)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37353,11 +37331,16 @@
 	},
 /area/f13/brotherhood/armory)
 "vQn" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "vQs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37373,16 +37356,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "vQw" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/sign/poster/contraband/pinup_pink,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -37518,9 +37493,7 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "vVu" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "vVx" = (
@@ -37577,12 +37550,18 @@
 /turf/open/floor/plasteel,
 /area/f13/bunker)
 "vWZ" = (
-/obj/structure/chair/wood,
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "denmedshutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "vXF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -37665,14 +37644,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wam" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/water,
-/area/f13/den)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -37855,6 +37826,18 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"wgS" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "whA" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -37876,10 +37859,8 @@
 	},
 /area/f13/brotherhood/mining)
 "wif" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
@@ -37923,16 +37904,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/obj/structure/table/wood/settler,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/item/lipstick/purple,
-/obj/item/lipstick,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -38000,10 +37973,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "wms" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
@@ -38028,14 +38004,14 @@
 	},
 /area/f13/brotherhood/mining)
 "woj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/turf/open/water,
 /area/f13/den)
 "wom" = (
 /obj/structure/bed/old,
@@ -38052,15 +38028,24 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/structure/rack/shelf_metal,
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "wpc" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/junglebush,
-/turf/open/water,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -38122,10 +38107,10 @@
 	},
 /area/f13/brotherhood/armory)
 "wrg" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/junglebush,
 /turf/open/water,
-/area/f13/caves)
+/area/f13/den)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -38192,9 +38177,14 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "wuU" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/caves)
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "wvi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -38202,16 +38192,15 @@
 	},
 /area/f13/clinic)
 "wvj" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/table/wood/settler,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2
 	},
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
-/turf/open/floor/wood/f13/stage_b,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wvk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -38389,12 +38378,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "wzt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/ruins{
-	max_integrity = 700
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38626,8 +38613,12 @@
 	},
 /area/f13/den)
 "wGF" = (
-/obj/structure/falsewall/rust,
-/turf/open/floor/wood/f13/oak,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wGG" = (
 /obj/structure/wreck/trash/engine{
@@ -38742,14 +38733,6 @@
 "wKL" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
-"wKN" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -38800,16 +38783,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "wLY" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_y = 32
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/den)
 "wMb" = (
 /obj/structure/rack,
@@ -38920,8 +38897,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/corner,
 /area/f13/brotherhood/mining)
 "wPZ" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood/f13/oak,
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "wQb" = (
 /obj/structure/rack,
@@ -38979,11 +38956,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wRa" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "wRf" = (
 /obj/structure/barricade/wooden,
@@ -39220,7 +39201,9 @@
 /area/f13/brotherhood/offices2nd)
 "wYl" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet/green,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
@@ -39267,14 +39250,8 @@
 	},
 /area/f13/brotherhood/offices2nd)
 "wZU" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/sign/poster/contraband/bountyhunters,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "xac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39832,6 +39809,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"xpf" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/glass,
@@ -39898,12 +39881,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"xsf" = (
-/obj/machinery/door/window/brigdoor/eastleft,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "xsn" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6;
@@ -39980,9 +39957,8 @@
 	},
 /area/f13/sewer)
 "xtg" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
@@ -40804,6 +40780,19 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"xTi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
+/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -40846,6 +40835,15 @@
 "xVz" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xVD" = (
+/obj/structure/table/wood/settler,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/item/lipstick/purple,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/den)
 "xVK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41052,15 +41050,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "yck" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
+/area/f13/den)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -41337,11 +41331,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
-/area/f13/sewer)
+/turf/open/water,
+/area/f13/den)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -41368,6 +41364,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
+"ylL" = (
+/obj/machinery/light,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -66484,8 +66487,8 @@ wFD
 wFD
 wFD
 wFD
-eOP
-fjJ
+gHU
+bEV
 wFD
 mjG
 dXE
@@ -66732,19 +66735,19 @@ wFD
 lYx
 wFD
 wFD
-eOP
-jEr
-jEr
-jEr
-jEr
-jEr
-jEr
-jEr
-jEr
-jEr
-fjJ
-cQp
-jEr
+gHU
+nHM
+nHM
+nHM
+nHM
+nHM
+nHM
+nHM
+nHM
+nHM
+bEV
+pKf
+nHM
 dXE
 dXE
 dXE
@@ -66993,13 +66996,13 @@ kUN
 kUN
 kUN
 kUN
-rLJ
+vsF
 dAO
 dAO
 dAO
 dAO
-jEr
-ehL
+nHM
+eiz
 wFD
 mjG
 dXE
@@ -67243,20 +67246,20 @@ hQE
 uPr
 hQE
 gMZ
-dqh
-fws
-dqh
-dqh
+dCp
+lmD
+dCp
+dCp
 auj
 auj
 auj
-rSU
-dhF
-sMl
+vra
 tda
-eLg
+sMl
+eZw
+lFt
 mjG
-fjJ
+bEV
 wFD
 mjG
 fQL
@@ -67499,21 +67502,21 @@ hQE
 hQE
 uPr
 kUN
-sTs
-fPo
+gkm
+qfj
 sMl
 sMl
 sMl
 auj
-sTs
+gkm
 sMl
-rSU
+vra
 gAy
 sMl
-jHj
+kJu
 dzP
-jEr
-cQp
+nHM
+pKf
 wFD
 wFD
 wFD
@@ -67756,23 +67759,23 @@ uPr
 uPr
 uPr
 kUN
-ixi
-bPA
-fwZ
-fwZ
-fwZ
-bxH
+dnc
+dOg
+bMI
+bMI
+bMI
+hOx
 auj
 auj
-caw
-cdh
+fJp
+jxS
 sMl
-kQt
+voL
 dAO
-jEr
-jEr
-jEr
-jEr
+nHM
+nHM
+nHM
+nHM
 wFD
 wFD
 wFD
@@ -68013,24 +68016,24 @@ hQE
 hQE
 hQE
 kUN
-kTJ
-jaG
+aqh
+aXd
 bzg
 bzg
 bzg
-bHI
+fqB
 auj
 sMl
 sMl
-rzy
+npc
 auj
-nFt
+mnK
 wYo
 wYo
 ddv
 ddv
 mjG
-ylp
+dFv
 mjG
 mjG
 mjG
@@ -68270,24 +68273,24 @@ hQE
 hQE
 hQE
 kUN
-kTJ
+aqh
 bzg
 bzg
-cJI
+uUB
 bzg
-wvj
+akT
 auj
 auj
-epg
-cuS
+cCO
+qtc
 bTE
-cuS
-cuS
-cuS
-cuS
+qtc
+qtc
+qtc
+qtc
 ddv
 ddv
-lQm
+gFp
 ddv
 ddv
 ddv
@@ -68527,21 +68530,21 @@ wCB
 hQE
 hQE
 kUN
-kTJ
+aqh
 bzg
 bzg
-bve
+iUU
 bzg
-gow
-fpT
+gRa
+eBU
 sMl
 auj
-wPZ
-gkm
-fyh
-fyh
-bvs
-cuS
+jaG
+wvj
+hFt
+hFt
+uhB
+qtc
 ddv
 ddv
 jqn
@@ -68784,21 +68787,21 @@ hQE
 hQE
 hQE
 kUN
-kTJ
-gQW
+aqh
+iVF
 bzg
 bzg
-pjR
-wvj
+uII
+akT
 auj
 auj
 sMl
-wPZ
-rAd
-dNa
-fyh
-cTL
-cuS
+jaG
+bAz
+opa
+hFt
+fzj
+qtc
 ddv
 ddv
 jqn
@@ -69041,21 +69044,21 @@ hQE
 hQE
 hQE
 kUN
-kTJ
+aqh
 bzg
 bzg
 bzg
-vkI
-bHI
+wPZ
+fqB
 auj
 sMl
 sMl
-jIs
-gkm
-fyh
+bxH
+wvj
+hFt
 nGD
-cTL
-cuS
+fzj
+qtc
 ddv
 ddv
 jqn
@@ -69295,24 +69298,24 @@ afb
 hQE
 hQE
 hQE
-qTe
-qTe
+fjJ
+fjJ
 kUN
-aqh
-dUO
-dUO
-dUO
-dUO
-nJC
+cTL
+vjM
+vjM
+vjM
+vjM
+fhe
 auj
-fPo
+qfj
 sMl
-wPZ
-pPI
-dNa
+jaG
+qia
+opa
 nGD
-wms
-cuS
+bNV
+qtc
 ddv
 ddv
 jqn
@@ -69564,12 +69567,12 @@ auj
 tac
 sMl
 auj
-wPZ
-gkm
-fyh
+jaG
+wvj
+hFt
 nGD
-nUx
-cuS
+cdh
+qtc
 ddv
 ddv
 jqn
@@ -69801,7 +69804,7 @@ fIf
 bQP
 fIf
 lBm
-eay
+pjR
 fIf
 fIf
 fIf
@@ -69816,24 +69819,24 @@ uOX
 uOX
 uOX
 uOX
-fQB
+kKb
 sMl
 sMl
 wYo
 wYo
 wYo
-cuS
-cuS
-cuS
+qtc
+qtc
+qtc
 yiv
-cuS
+qtc
 ddv
 ddv
 jqn
 jqn
 jqn
 jqn
-lQm
+gFp
 mjG
 wFD
 wFD
@@ -70068,22 +70071,22 @@ tac
 sMl
 sMl
 auj
-fPo
+qfj
 sMl
 auj
 auj
 sMl
 auj
 auj
-fPo
+qfj
 wYo
+mSP
 dpu
-ocq
-cuS
-bMI
-mCP
-cTL
-cuS
+qtc
+jEr
+fyh
+fzj
+qtc
 ddv
 ddv
 jqn
@@ -70286,40 +70289,40 @@ wFD
 wFD
 mjG
 abB
-fju
-qjN
-fju
-fju
-wam
-daE
+gQW
+vlM
+gQW
+gQW
+bvs
+fdw
 fEj
-jbM
-uvI
+dgg
+qDc
 fEj
-wam
+bvs
 fEj
-wam
-lxs
-fhe
-aJI
-fju
-wam
-fju
-daE
+bvs
+bHA
+dli
+qIj
+gQW
+bvs
+gQW
+fdw
 fEj
-uvI
-fju
-fJp
+qDc
+gQW
+ffZ
 fEj
-dPc
+daL
 fEj
-fju
-fJp
-tus
-dEl
+gQW
+ffZ
+kZh
+rSU
 fEj
 fEj
-tco
+kQt
 fEj
 mZU
 gMZ
@@ -70331,16 +70334,16 @@ sMl
 tac
 auj
 auj
-fPo
-fPo
+qfj
+qfj
 wYo
-wjM
-bXn
-cuS
-fzD
-bXn
-mZs
-cuS
+eCs
+eKX
+qtc
+xVD
+eKX
+fUu
+qtc
 ddv
 ddv
 jqn
@@ -70543,42 +70546,42 @@ wFD
 wWB
 mjG
 abB
-kcf
-eup
-tXl
-kcf
+kTJ
+iPX
+fxX
+kTJ
 hRI
-eKX
-kcf
+dhF
+kTJ
 hRI
-kcf
-gNv
-gRa
-hRI
-hRI
-kcf
+kTJ
+gBM
+eTS
 hRI
 hRI
-iDd
-gRa
-kcf
-fis
-kcf
-fis
-eZw
+kTJ
 hRI
-kcf
-xtg
-fis
+hRI
+fyC
+eTS
+kTJ
+fPo
+kTJ
+fPo
+dsx
+hRI
+kTJ
+ixi
+fPo
 uVE
-gRa
-fis
-fis
-wpc
+eTS
+fPo
+fPo
+wrg
 hRI
-oBq
+daE
 hRI
-vWZ
+esc
 fjU
 bMt
 auj
@@ -70589,15 +70592,15 @@ sMl
 auj
 sMl
 sMl
-epg
+cCO
 wYo
-bVO
-cTL
-cXP
-pKf
-wms
-wms
-cuS
+wLY
+fzj
+wjM
+crx
+bNV
+bNV
+qtc
 ddv
 ddv
 jqn
@@ -70829,32 +70832,32 @@ kUN
 kUN
 kUN
 hRI
-esc
-fis
-eMH
+bVO
+fPo
+gNv
 uVE
 gZB
 hRI
-npc
+dTr
 uOX
 auj
 auj
 iDK
-gWk
-gqj
-gWk
-gqj
+thm
+oVS
+thm
+oVS
 auj
 sMl
-fPo
+qfj
 kQO
-cqu
-fxi
-sIa
-cTL
-dGU
-kaQ
-bdf
+fOr
+bIT
+bNI
+fzj
+uvj
+cQp
+dUk
 ddv
 ddv
 ddv
@@ -70873,7 +70876,7 @@ mjG
 mjG
 mjG
 mjG
-dnc
+tus
 xse
 mjG
 mjG
@@ -71058,38 +71061,38 @@ wFD
 mjG
 aou
 kUN
-nEK
-aPF
-aPF
-dZO
-aPF
-aPF
-aPF
+fzD
+fXU
+fXU
+blG
+fXU
+fXU
+fXU
 kUN
-fOr
-aPF
-aPF
-tzz
-fxi
-aPF
-tzz
-aPF
-aPF
-fOr
+faq
+fXU
+fXU
+vfF
+bIT
+fXU
+vfF
+fXU
+fXU
+faq
 kUN
-aPF
-aPF
-dZO
-aPF
-aPF
-cIZ
-nEK
+fXU
+fXU
+blG
+fXU
+fXU
+liN
+fzD
 kUN
 hRI
-qIj
+ccg
 hRI
-ddI
-fis
+fQB
+fPo
 xwm
 hRI
 fEW
@@ -71100,18 +71103,18 @@ auj
 blx
 diR
 diR
-kJu
-kJu
-vPv
-vPv
+ajO
+ajO
+bdf
+bdf
 kUN
-cuS
+qtc
 bTE
-cuS
+qtc
 yiv
-cuS
-dsx
-dsx
+qtc
+aEe
+aEe
 ddv
 ddv
 ddv
@@ -71315,41 +71318,41 @@ wFD
 mjG
 bzl
 kUN
-nEK
-aPF
-aPF
+fzD
+fXU
+fXU
 kUN
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 kUN
-vsF
-aPF
-aPF
+hxB
+fXU
+fXU
 kUN
-aPF
-fxi
+fXU
+bIT
 kUN
-aPF
-aPF
-vsF
+fXU
+fXU
+hxB
 kUN
-aPF
-aPF
-uUB
+fXU
+fXU
+rLJ
 wYo
-aPF
-aPF
-nEK
+fXU
+fXU
+fzD
 kUN
-fis
+fPo
 hRI
-fis
-bdL
+fPo
+gkY
 rjD
-esc
+bVO
 hRI
-vWZ
+esc
 fjU
 bMt
 auj
@@ -71367,7 +71370,7 @@ ekQ
 dLn
 efa
 bFe
-dsx
+aEe
 eLE
 eLE
 eLE
@@ -71572,38 +71575,38 @@ wFD
 mjG
 bzl
 kUN
-tlZ
+tGq
 nCx
-cTL
+fzj
 kUN
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 kUN
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 kUN
-aPF
-fxi
-flP
-aPF
-aPF
-aPF
+fXU
+bIT
+bdL
+fXU
+fXU
+fXU
 kUN
-aPF
-aPF
+fXU
+fXU
 kUN
 wYo
-aPF
-aPF
-nEK
+fXU
+fXU
+fzD
 kUN
 hRI
-fis
-fis
-bNI
-gwf
+fPo
+fPo
+tMr
+qFM
 rjD
 hRI
 mZU
@@ -71618,13 +71621,13 @@ gCa
 bmJ
 gCa
 gCa
-wGF
+eFq
 xXZ
 tBY
 xbj
 gJz
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -71829,47 +71832,47 @@ wWB
 mjG
 agK
 kUN
-dOg
-cTL
-cTL
+dZO
+fzj
+fzj
 kUN
-aPF
-aPF
-aPF
-hFt
+fXU
+fXU
+fXU
+vQw
 fPt
 fPt
 fPt
-gvC
-fxi
-fxi
+tXl
+bIT
+bIT
 cKb
 fPt
 fPt
 fPt
 kUN
-aPF
-aPF
-faq
+fXU
+fXU
+uvI
 wYo
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 kUN
 rjD
 uVE
 hRI
-fis
-gxS
-wpc
+fPo
+dok
+wrg
 hRI
-iPX
+dpl
 iDK
 auj
 iDK
 auj
 kDG
-bPD
+ehL
 okb
 dyB
 gCa
@@ -71881,7 +71884,7 @@ jyQ
 flC
 efa
 aLf
-wuU
+flP
 eLE
 yhT
 yhT
@@ -72085,39 +72088,39 @@ bbB
 bbB
 mjG
 aEg
-kKb
+uyC
 dTG
 dTG
 dTG
 dtr
-fxi
-fxi
-nye
+bIT
+bIT
+wpc
 lAv
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 cRY
-fxi
-aPF
+bIT
+fXU
 cRY
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 cRY
-aPF
-aPF
+fXU
+fXU
 kUN
 wYo
-ffZ
-vfF
-juA
+dNa
+aQw
+mOS
 kUN
 hRI
-esc
-fis
-fis
-fis
+bVO
+fPo
+fPo
+fPo
 oYU
 hRI
 qFJ
@@ -72125,7 +72128,7 @@ gmI
 iDK
 uDa
 iDK
-wzt
+ube
 cjg
 auj
 cbQ
@@ -72138,7 +72141,7 @@ hlg
 bTE
 efa
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -72342,39 +72345,39 @@ bbB
 bbB
 mjG
 mjG
-uLP
-aPF
-aPF
-aPF
+gvC
+fXU
+fXU
+fXU
 cRY
-fxi
-aPF
-aPF
-fxi
-aPF
-aPF
-aPF
-aPF
+bIT
+fXU
+fXU
+bIT
+fXU
+fXU
+fXU
+fXU
 hlO
-egc
-egc
-egc
-egc
-egc
-egc
+gyu
+gyu
+gyu
+gyu
+gyu
+gyu
 hlO
-aPF
+fXU
 kUN
 wYo
 nCx
-czr
+dIm
 ooI
 kUN
-esc
+bVO
 rjD
 hRI
 uVE
-fis
+fPo
 uVE
 hRI
 bLc
@@ -72382,20 +72385,20 @@ iDK
 uDa
 tUT
 gmI
-pCO
+rzy
 wIN
 dTK
 bMt
 pxK
 gCa
-wYl
+vVu
 wYo
 wLR
 kLD
 txw
 efa
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -72599,32 +72602,32 @@ wFD
 wWB
 mjG
 bzl
-egc
-egc
-egc
-egc
-liN
-egc
-egc
-egc
+gyu
+gyu
+gyu
+gyu
+kIf
+gyu
+gyu
+gyu
 dHg
 dHg
 dHg
+gyu
+gyu
+gyu
 egc
-egc
-egc
-fXU
 exf
 eiS
-fXU
-exf
-fXU
 egc
-aPF
+exf
+egc
+gyu
+fXU
 aqQ
 wYo
-eWL
-cTL
+nUx
+fzj
 lVK
 kUN
 hRI
@@ -72639,8 +72642,8 @@ auj
 gJA
 vBZ
 fjA
-pCO
-dok
+rzy
+owJ
 dyu
 bMt
 bIC
@@ -72652,7 +72655,7 @@ ekQ
 dke
 efa
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -72856,39 +72859,39 @@ wFD
 wWB
 mjG
 bzl
-aPF
-bPB
-aPF
-aPF
-aPF
-aPF
-aPF
-bPB
-aPF
-aPF
-aPF
-bPB
-aPF
-dHg
 fXU
+kaQ
+fXU
+fXU
+fXU
+fXU
+fXU
+kaQ
+fXU
+fXU
+fXU
+kaQ
+fXU
+dHg
+egc
 iFg
 okH
 maO
 rvK
-fXU
 egc
-aPF
-aPF
+gyu
+fXU
+fXU
 kUN
 vct
 vct
 vct
 kUN
-qGl
-qGl
-qGl
-qGl
-qGl
+pPI
+pPI
+pPI
+pPI
+pPI
 fsN
 gNZ
 auj
@@ -72896,20 +72899,20 @@ fUQ
 lCp
 tUT
 iDK
-pCO
+rzy
 cjg
-mnK
+pSU
 dxH
 bIC
 gCa
-wYl
+vVu
 wYo
 xXZ
 wQp
 xbj
 efa
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -73118,29 +73121,29 @@ kUN
 kUN
 kUN
 kUN
-gvC
+tXl
 kUN
 kUN
 kUN
 kUN
 kUN
-pJN
-aPF
-egc
-aLA
+fpD
+fXU
+gyu
+iLY
 kbT
 uVE
 eyK
 ghs
-hJy
-egc
-egc
-egc
+eup
+gyu
+gyu
+gyu
 fUv
-aPF
-aPF
-aPF
-jFq
+fXU
+fXU
+fXU
+fVm
 xdj
 xdj
 xdj
@@ -73153,7 +73156,7 @@ jLx
 cAC
 gVL
 tKj
-pCO
+rzy
 wIN
 iDK
 hOB
@@ -73166,7 +73169,7 @@ bIh
 pHQ
 efa
 crb
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -73382,22 +73385,22 @@ kUN
 kUN
 kUN
 kUN
-aPF
+fXU
 cBZ
-fXU
+egc
 bUh
-sfM
-eGQ
+woj
+oBq
 bhu
-fXU
 egc
-egc
-egc
+gyu
+gyu
+gyu
 fUv
-aPF
-aPF
-aPF
-vfF
+fXU
+fXU
+fXU
+aQw
 xdj
 xdj
 xdj
@@ -73411,19 +73414,19 @@ auj
 auj
 blx
 qQR
-wKN
+wGF
 fjH
 fjH
 bmJ
 gCa
 gCa
 dAO
-cuS
-cuS
-cuS
+qtc
+qtc
+qtc
 efa
 efa
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -73629,8 +73632,8 @@ mjG
 vgV
 kUN
 kUN
-rSO
-cAU
+nEP
+nbd
 gCa
 gCa
 kUN
@@ -73638,23 +73641,23 @@ gCa
 gCa
 gCa
 gCa
-dZO
-aPF
-dHg
+blG
 fXU
-bwW
+dHg
+egc
+fws
 uVE
 eyK
-qEH
-fXU
+fzY
 egc
-egc
-egc
+gyu
+gyu
+gyu
 fUv
-aPF
-ekK
-aPF
-aPF
+fXU
+nyG
+fXU
+fXU
 xdj
 xdj
 xdj
@@ -73666,21 +73669,21 @@ iDK
 fjh
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 aVZ
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 wYo
 ibY
 gVp
 fVQ
-cuS
+qtc
 cbu
-dsx
+aEe
 eLE
 yhT
 yhT
@@ -73886,27 +73889,27 @@ mjG
 vgV
 kUN
 kUN
-rGe
+qjU
 cUt
 dyH
 dLs
 kUN
-itn
 eJq
-dUk
+fRv
+sfM
 gCa
-qXj
-aPF
-dHg
-lUs
-dCp
-mNi
-qDc
-wLY
+wZU
 fXU
+dHg
+gow
+cQc
+ylp
+cAU
+ica
 egc
-aPF
-aPF
+gyu
+fXU
+fXU
 kUN
 kUN
 kUN
@@ -73923,20 +73926,20 @@ iDK
 iDK
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 aVZ
 gCa
 ava
-npf
-vVu
+hri
+xpf
 gCa
 bmJ
 exn
 bFe
 uuD
 efa
-nyG
+uso
 hQE
 eLE
 yhT
@@ -74143,33 +74146,33 @@ aLB
 vgV
 kUN
 kUN
-lsh
+bup
 cWc
 dyH
 gCa
 kUN
-itn
 eJq
-dUk
+fRv
+sfM
 gCa
 kUN
-aPF
+fXU
 cBZ
-fXU
-exf
-lUs
-fXU
-exf
-aLA
 egc
-aPF
-pJN
+exf
+gow
+egc
+exf
+iLY
+gyu
+fXU
+fpD
 kUN
 kUN
 kUN
 kUN
 kUN
-bEV
+vkj
 fEj
 fEj
 fEj
@@ -74180,12 +74183,12 @@ fjh
 gmI
 iDK
 auj
-pCO
+rzy
 gBD
 aVZ
 gCa
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -74193,7 +74196,7 @@ gAy
 efa
 efa
 efa
-oVS
+dUO
 hQE
 eLE
 yhT
@@ -74400,26 +74403,26 @@ mjG
 vgV
 kUN
 kUN
-gyu
+eLq
 gCa
 gCa
-gkY
+gwf
 kUN
-nEP
-exN
-owJ
+wif
+bhO
+xtg
 gCa
 kUN
-aPF
+fXU
 bwq
 dHg
-egc
-egc
-egc
-egc
-egc
+gyu
+gyu
+gyu
+gyu
+gyu
 hlO
-aPF
+fXU
 kUN
 kUN
 kUN
@@ -74437,8 +74440,8 @@ fjh
 hOB
 iDK
 auj
-pCO
-vQw
+rzy
+wgS
 aVZ
 gCa
 gCa
@@ -74446,11 +74449,11 @@ gCa
 gMt
 gCa
 bmJ
-tst
+wRa
 efa
 ucR
 efa
-crx
+fnc
 hQE
 eLE
 yhT
@@ -74662,34 +74665,34 @@ kUN
 ohV
 kUN
 kUN
-itn
 eJq
-dUk
+fRv
+sfM
 gCa
 kUN
-aPF
-aPF
-aPF
-fxi
-nye
-aPF
-aPF
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
+bIT
+wpc
+fXU
+fXU
+fXU
+fXU
+fXU
 kUN
 kUN
 ddx
-daL
-bqI
+lsh
+vQn
 kUN
 kUN
 hRI
 hRI
 hRI
 hRI
-bIT
-ccg
+qjN
+mZs
 fjh
 iDK
 tZP
@@ -74699,7 +74702,7 @@ kUN
 gCa
 gCa
 gCa
-fGK
+juA
 gCa
 gCa
 gCa
@@ -74919,26 +74922,26 @@ gCa
 gCa
 eiA
 gCa
-itn
 eJq
-dUk
+fRv
+sfM
 gCa
 cKb
-ffZ
-aPF
+dNa
+fXU
 dWg
-aPF
-aPF
-aPF
-eBU
-aPF
-aPF
-wRa
-flP
+fXU
+fXU
+fXU
+wuU
+fXU
+fXU
+bqI
+bdL
 kUN
-rIU
-eVt
-ohx
+tst
+ekK
+qxm
 kUN
 kUN
 hRI
@@ -74956,11 +74959,11 @@ eiA
 gCa
 gCa
 ava
-npf
-vVu
+hri
+xpf
 gCa
 ibo
-pBk
+flT
 xac
 psU
 efa
@@ -75181,28 +75184,28 @@ gCa
 gCa
 gCa
 kUN
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-fxi
-aPF
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+bIT
+fXU
 kUN
 kUN
-kZh
-ajO
-fVm
+dLC
+ocq
+gza
 kUN
 kUN
 hRI
 hRI
 hRI
 wYo
-rsi
+vjW
 iDK
 iDK
 iDK
@@ -75213,7 +75216,7 @@ eiA
 fjS
 fmW
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -75436,23 +75439,23 @@ gCa
 gCa
 gCa
 gCa
-nZC
+cuS
 kUN
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
-nye
-aPF
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
+wpc
+fXU
 kUN
 kUN
-aQw
-bNV
-bNV
+exg
+tco
+tco
 kUN
 kUN
 hRI
@@ -75695,28 +75698,28 @@ gCa
 gCa
 fOg
 kUN
-ffZ
-aPF
+dNa
+fXU
 dWg
-aPF
-aPF
-aPF
+fXU
+fXU
+fXU
 dWg
-aPF
-fxi
-wRa
+fXU
+bIT
+bqI
 kUN
 kUN
-gHU
-xsf
-dEL
+tbE
+yck
+eay
 kUN
 kUN
 hRI
 bBU
 exl
 kUN
-qFM
+pCO
 gmI
 pVU
 tac
@@ -75950,23 +75953,23 @@ gCa
 gCa
 gCa
 gCa
-tMr
+nJC
 kUN
-aPF
-aPF
-dIq
-aPF
-aPF
-aPF
-aPF
-aPF
-aPF
+fXU
+fXU
+gxS
+fXU
+fXU
+fXU
+fXU
+fXU
+fXU
 kUN
 kUN
 kUN
-eiz
-ohx
-iUU
+cbG
+qxm
+eGQ
 kUN
 kUN
 hRI
@@ -76199,13 +76202,13 @@ mjG
 vgV
 kUN
 kUN
-bAz
-bAz
-bAz
+ddI
+ddI
+ddI
 kUN
 kUN
 kUN
-dZO
+blG
 kUN
 kUN
 kUN
@@ -76219,11 +76222,11 @@ kUN
 kUN
 kUN
 kUN
-nHE
-ohx
-ohx
-ohx
+qGl
 qxm
+qxm
+qxm
+rsi
 kUN
 kUN
 hRI
@@ -76456,31 +76459,31 @@ mjG
 vgV
 kUN
 kUN
-qTe
-qTe
-qTe
+fjJ
+fjJ
+fjJ
 kUN
 dcd
 emK
 emK
 emK
-qfj
-nHM
-fRv
-lFt
+gWk
+dEL
+uqb
+dIq
 kUN
 geR
-eHr
-eHr
-gBM
-eHr
-wpa
+qMr
+qMr
+vWZ
+qMr
+sTs
 kUN
-lwv
-ohx
-ohx
-ohx
-vbx
+kcf
+qxm
+qxm
+qxm
+fju
 kUN
 kUN
 hRI
@@ -76717,27 +76720,27 @@ kUN
 kUN
 kUN
 kUN
-eFq
+tCl
 emK
 fqF
 emK
-fRv
-fRv
-fRv
-pSU
+uqb
+uqb
+uqb
+caw
 kUN
-aXd
-eHr
-eHr
-gBM
-eHr
-aEe
+wms
+qMr
+qMr
+vWZ
+qMr
+ylL
 kUN
-vjM
-ohx
-ohx
-ohx
-wZU
+mNi
+qxm
+qxm
+qxm
+ehc
 kUN
 kUN
 hRI
@@ -76974,27 +76977,27 @@ dDz
 gyB
 sVT
 kUN
-uhB
+nzO
 emK
 emK
-jBt
-cQc
-fRv
-fRv
-qtc
+aPF
+gqj
+uqb
+uqb
+nsf
 kUN
-fpD
-eHr
-eHr
-gBM
-eHr
-eHr
-tsX
-ohx
-ohx
-ohx
-ohx
-fqB
+wzt
+qMr
+qMr
+vWZ
+qMr
+qMr
+dpW
+qxm
+qxm
+qxm
+qxm
+dPc
 kUN
 kUN
 hRI
@@ -77228,35 +77231,35 @@ vgV
 kUN
 ciU
 acI
-rQv
+rSO
 acI
 kUN
-dgO
+vbx
 emK
 emK
-jBt
-dpW
+aPF
+nHE
 fqF
-fRv
-ica
+uqb
+eOP
 kUN
-wif
-eHr
-eHr
-hOx
-eHr
-wpa
-kUN
-kUN
+wYl
+qMr
+qMr
+ezs
+qMr
+sTs
 kUN
 kUN
-dZO
+kUN
+kUN
+blG
 kUN
 kUN
 kUN
 cSY
-wrg
-qia
+ewe
+nye
 xdj
 dXE
 dXE
@@ -77491,24 +77494,24 @@ ltu
 emK
 dQG
 fqF
-ezs
-nbd
+lwv
+cqu
 emK
-fRv
-fUu
+uqb
+aJI
 kUN
-gBM
-gBM
-gBM
+vWZ
+vWZ
+vWZ
 kUN
-eHr
-tCQ
+qMr
+nZC
 kUN
-hxB
+bve
 rqX
 rqX
 rqX
-dIm
+eMH
 kUN
 kUN
 cSY
@@ -77743,27 +77746,27 @@ kUN
 gyB
 gyB
 gyB
-fzY
+pBk
 kUN
-uso
-fRv
+ohx
+uqb
 emK
-fRv
+uqb
 emK
 emK
-fRv
-woj
+uqb
+gIt
 kUN
-ckD
 eHr
-eHr
-eHr
-eHr
-aEe
+qMr
+qMr
+qMr
+qMr
+ylL
 kUN
-vQn
+dVW
 rqX
-vQn
+dVW
 rqX
 rqX
 kUN
@@ -78002,21 +78005,21 @@ acI
 uBk
 acI
 kUN
-nbd
-nbd
-nbd
-nbd
-fRv
+cqu
+cqu
+cqu
+cqu
+uqb
 emK
 fqF
-fRv
-vlM
-eHr
-eHr
-eHr
-eHr
-eHr
-eHr
+uqb
+xTi
+qMr
+qMr
+qMr
+qMr
+qMr
+qMr
 kUN
 rqX
 rqX
@@ -78028,7 +78031,7 @@ kUN
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -78256,7 +78259,7 @@ vgV
 kUN
 acI
 acI
-dTr
+rGe
 acI
 kUN
 kUN
@@ -78268,16 +78271,16 @@ kUN
 kUN
 kUN
 kUN
-ckD
 eHr
-eHr
-eHr
-eHr
-saE
+qMr
+qMr
+qMr
+qMr
+cXP
 kUN
-tbE
+bHI
 rqX
-vQn
+dVW
 rqX
 cLd
 kUN
@@ -78285,7 +78288,7 @@ kUN
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -78512,8 +78515,8 @@ mjG
 vgV
 kUN
 acI
-fnc
-opa
+lUs
+ckD
 lyd
 kUN
 kUN
@@ -78525,18 +78528,18 @@ kUN
 kUN
 kUN
 kUN
-cCO
 wpa
-wpa
-wpa
-eHr
-eHr
+sTs
+sTs
+sTs
+qMr
+qMr
 ltu
 rqX
 rqX
-cYs
-mOS
-bhO
+rAd
+aqW
+nFt
 kUN
 kUN
 cSY
@@ -79056,7 +79059,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -79285,10 +79288,10 @@ hQE
 hQE
 aoj
 aoj
-dVW
+qXj
 aoj
 aoj
-qjU
+uLP
 vcx
 aoj
 aoj
@@ -79313,7 +79316,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -79543,7 +79546,7 @@ hQE
 aoj
 aoj
 aoj
-dgg
+npf
 emV
 aoj
 aoj
@@ -79570,7 +79573,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -80055,10 +80058,10 @@ fQL
 hQE
 hQE
 dXE
-iLY
-tXd
-eCs
-dLC
+iDd
+qTe
+eLg
+fwZ
 dXE
 aoj
 vcx
@@ -80312,7 +80315,7 @@ fQL
 hQE
 hQE
 dXE
-lmD
+cxY
 dHw
 dHw
 dHw
@@ -80569,7 +80572,7 @@ fQL
 hQE
 hQE
 dXE
-gza
+cYs
 dHw
 dHw
 rSB
@@ -80581,7 +80584,7 @@ aoj
 aoj
 uPr
 cPI
-gDU
+tXd
 hQE
 dXE
 dXE
@@ -80828,7 +80831,7 @@ hQE
 dXE
 dXE
 dXE
-sOm
+tzz
 dXE
 dXE
 hQE
@@ -80846,7 +80849,7 @@ hQE
 hQE
 hQE
 hQE
-eLq
+qEH
 hQE
 hQE
 hQE
@@ -81082,8 +81085,8 @@ mjG
 fQL
 hQE
 hQE
-uyC
-fzj
+jHj
+hqt
 sVP
 lWO
 buN
@@ -81099,9 +81102,9 @@ mYc
 aoj
 aoj
 aoj
-mSP
-mSP
-mSP
+dqh
+dqh
+dqh
 aoj
 aoj
 aoj
@@ -81110,9 +81113,9 @@ dii
 dii
 dii
 dii
-vra
+ndz
 dii
-vra
+ndz
 wFD
 mNE
 wFD
@@ -81339,7 +81342,7 @@ mjG
 fQL
 hQE
 hQE
-uyC
+jHj
 uuq
 lWO
 lWO
@@ -81347,7 +81350,7 @@ hQE
 hQE
 hQE
 hQE
-eLq
+qEH
 hQE
 aoj
 dXE
@@ -81356,9 +81359,9 @@ aoj
 aoj
 aoj
 aoj
-mSP
+dqh
 wpF
-mSP
+dqh
 aoj
 aoj
 aoj
@@ -81367,9 +81370,9 @@ dii
 dii
 dii
 dii
-vra
+ndz
 dii
-vra
+ndz
 wFD
 mNE
 wFD
@@ -81598,7 +81601,7 @@ hQE
 hQE
 lWO
 lWO
-bRm
+rQv
 lWO
 hQE
 hzR
@@ -81617,7 +81620,7 @@ hQE
 hQE
 hQE
 hQE
-eLq
+qEH
 hQE
 buN
 hQE
@@ -81861,7 +81864,7 @@ hQE
 dHw
 flj
 dHw
-iVF
+itn
 hQE
 aoj
 dXE
@@ -81875,7 +81878,7 @@ aoj
 aoj
 aoj
 aoj
-eLq
+qEH
 aoj
 hQE
 cSY
@@ -81883,7 +81886,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 dXE
 dXE
@@ -82118,7 +82121,7 @@ hQE
 flj
 dHw
 dHw
-dli
+dEl
 hQE
 aoj
 dXE
@@ -82140,7 +82143,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 uPr
@@ -82382,7 +82385,7 @@ aoj
 aoj
 aoj
 aoj
-eLq
+qEH
 aoj
 dXE
 dXE
@@ -82397,7 +82400,7 @@ cSY
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -82626,13 +82629,13 @@ hQE
 hQE
 lWO
 jPC
-flT
+jFq
 jPC
 hQE
 hQE
 hQE
 hQE
-eLq
+qEH
 hQE
 hQE
 hQE
@@ -83403,7 +83406,7 @@ hQE
 aoj
 hQE
 hQE
-eLq
+qEH
 hQE
 hQE
 hQE
@@ -84453,7 +84456,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 juh
@@ -84681,9 +84684,9 @@ fQL
 hQE
 hQE
 lWO
-kjh
+fis
 lWO
-yck
+tCQ
 hQE
 aoj
 hQE
@@ -84710,7 +84713,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 cSY
@@ -84967,7 +84970,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 pcO
@@ -85191,14 +85194,14 @@ mjG
 wFD
 wFD
 dtk
-qMr
+vPv
 nEz
 uCP
 bSl
 lWO
 lWO
 lWO
-eLq
+qEH
 mYc
 hQE
 dXE
@@ -85995,7 +85998,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -86993,7 +86996,7 @@ mjG
 fQL
 hQE
 hQE
-eLq
+qEH
 hQE
 hQE
 dXE
@@ -87023,7 +87026,7 @@ nmy
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 dXE
@@ -87280,7 +87283,7 @@ dXE
 cSY
 cSY
 cSY
-fdw
+saE
 dXE
 uPr
 uPr
@@ -88279,7 +88282,7 @@ fQL
 hQE
 hQE
 hQE
-eLq
+qEH
 hQE
 hQE
 hQE
@@ -88307,8 +88310,8 @@ dXE
 dXE
 dXE
 dXE
-uII
-tCl
+cMf
+tsX
 dXE
 dXE
 dXE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -481,12 +481,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "aqh" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Auxillary Storage";
-	req_access_txt = "87"
+/obj/machinery/button/door{
+	id = "densouthgate";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = 25
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "aqn" = (
 /obj/effect/decal/waste,
@@ -499,20 +502,13 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
-"aqQ" = (
-/obj/effect/landmark/poster_spawner/pinup,
-/turf/closed/wall/rust,
-/area/f13/den)
 "aqR" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "aqW" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = -33;
-	density = 0
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "arY" = (
 /obj/structure/table/wood/poker,
@@ -954,6 +950,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"aEe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "aEg" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -1133,10 +1137,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"aJI" = (
-/obj/structure/sink/well,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "aKc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1202,11 +1202,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "aLA" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/turf/open/floor/f13{
-	icon_state = "floordirty"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "aLB" = (
@@ -1333,6 +1338,12 @@
 /obj/item/key/scollar,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"aQw" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "aQU" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -1522,6 +1533,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/brotherhood/archives)
+"aXd" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "aXi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1776,6 +1799,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"bdf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "bdp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/syndicate/brotherhood,
@@ -1936,12 +1967,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bhO" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "bhW" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -2071,10 +2103,17 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/den)
 "blG" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
+/obj/machinery/light/floor,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "blH" = (
 /obj/structure/table,
@@ -2268,6 +2307,9 @@
 /obj/structure/wreck/car/bike,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"bqI" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "bqO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2436,19 +2478,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bup" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/simple_door/metal/fence,
+/obj/structure/decoration/rag,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
 /area/f13/den)
 "bux" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
@@ -2470,6 +2504,26 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"bve" = (
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/storage/bag/plants,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "bvm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2499,14 +2553,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
-"bwq" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/den)
 "bwt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/left,
@@ -2576,11 +2622,14 @@
 	},
 /area/f13/tunnel)
 "bxH" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "bxT" = (
@@ -2664,13 +2713,6 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
-"bAz" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "bAC" = (
 /obj/structure/decoration/shock,
 /turf/closed/wall/r_wall/rust,
@@ -2863,12 +2905,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "bEV" = (
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/water,
+/area/f13/caves)
 "bEY" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -2938,6 +2978,10 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"bHI" = (
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "bIa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -3052,6 +3096,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bKb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/water,
+/area/f13/den)
 "bKc" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
@@ -3116,19 +3168,19 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "bMH" = (
-/obj/item/clothing/head/helmet/roman/fake,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
-"bMI" = (
-/obj/structure/closet/crate/medical/anchored,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Auxillary Storage";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
+"bMI" = (
+/obj/item/flashlight,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "bMS" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -3226,10 +3278,14 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"bPA" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+"bPB" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "greenrusty"
+	},
 /area/f13/den)
 "bPG" = (
 /obj/machinery/light/small{
@@ -3645,6 +3701,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"cbu" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/water,
+/area/f13/den)
 "cbH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/c10mm{
@@ -3754,6 +3819,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
+"cdh" = (
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "cdu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3987,10 +4058,15 @@
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood/operations)
 "ckD" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "ckH" = (
 /obj/structure/cable{
@@ -4174,6 +4250,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/caves)
+"cqu" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "cqC" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -4460,6 +4545,10 @@
 	icon_state = "housebase"
 	},
 /area/f13/tunnel)
+"czr" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "czF" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4568,14 +4657,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
 "cAU" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -31
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "cAV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4694,6 +4778,12 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"cCO" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "cDP" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -4793,7 +4883,7 @@
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/den)
+/area/f13/caves)
 "cGk" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/pdapainter,
@@ -4868,21 +4958,41 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"cIZ" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "cJH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"cJI" = (
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_y = 29;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "cJJ" = (
 /obj/item/stack/sheet/metal/twenty,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "cKb" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/table/wood/poker,
+/obj/item/dice/d00,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/den)
 "cKA" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -4966,11 +5076,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/enclave)
 "cLS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "cLU" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall/r_wall,
@@ -4982,7 +5090,13 @@
 	},
 /area/f13/brotherhood/leisure)
 "cMf" = (
-/obj/machinery/workbench,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/structure/table,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -5021,9 +5135,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/bunker)
-"cPI" = (
-/turf/closed/mineral/random/high_chance,
-/area/f13/den)
 "cPP" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/mineral/random/low_chance,
@@ -5034,24 +5145,15 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/brotherhood/leisure)
-"cQc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
-/area/f13/den)
 "cQe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"cQp" = (
+/obj/structure/chair/stool/bar/brass,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "cQz" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -5096,11 +5198,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "cRY" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 27
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/workbench/bottler,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "cSe" = (
@@ -5121,10 +5224,6 @@
 "cSG" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
-"cSN" = (
-/obj/structure/stairs/west,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "cSV" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -5344,6 +5443,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"cYs" = (
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/sewer)
 "cYG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5480,12 +5591,17 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "ddx" = (
+/obj/machinery/chem_dispenser,
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "darkrusty"
 	},
 /area/f13/den)
+"ddI" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "deM" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp,
@@ -5508,6 +5624,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dgg" = (
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "dgx" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -5545,12 +5665,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
-"dgO" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "dgR" = (
 /obj/structure/bookshelf,
 /turf/open/floor/f13/wood,
@@ -5577,6 +5691,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
+"dhF" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/den)
 "dhP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5828,6 +5945,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"dnP" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 27
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dnQ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/filingcabinet,
@@ -5858,15 +5983,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dok" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
 "dov" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13{
@@ -5898,6 +6014,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dpu" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "dpD" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plating/tunnel,
@@ -5907,16 +6031,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dpW" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/area/f13/den)
+"dqh" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "dqm" = (
 /obj/structure/rack/shelf_metal,
@@ -5989,13 +6111,6 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"dsx" = (
-/obj/machinery/chem_dispenser,
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark,
@@ -6028,10 +6143,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"dtr" = (
-/obj/item/flashlight,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "dty" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6228,15 +6339,6 @@
 /obj/structure/decoration/vent/rusty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"dyH" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "dyQ" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -6295,22 +6397,6 @@
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
-"dAO" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/table,
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "dBj" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -6375,8 +6461,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "dDz" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "dDC" = (
@@ -6401,17 +6490,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"dEl" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/handrail/g_central{
-	dir = 4;
-	pixel_x = 20
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "dEr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6452,18 +6530,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "dFt" = (
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/wall/r_wall/rust,
-/area/f13/den)
-"dFv" = (
-/obj/structure/flora/junglebush/c,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/obj/structure/billboard/den{
-	pixel_y = -17;
-	pixel_x = -12
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/water,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/den)
 "dGP" = (
 /obj/structure/cable{
@@ -6489,28 +6566,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
-"dGU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/water,
-/area/f13/den)
 "dHc" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
 /area/f13/bunker)
-"dHg" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "dHh" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"dHw" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "dHT" = (
 /obj/structure/sign/poster/prewar/poster62,
 /turf/closed/wall/r_wall,
@@ -6522,26 +6587,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
-"dIm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/handrail/g_central{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/water,
-/area/f13/den)
 "dIo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices2nd)
-"dIq" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/den)
 "dII" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -6649,10 +6700,6 @@
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"dLC" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
 "dLK" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -6690,6 +6737,14 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/rnd)
+"dNa" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "dNb" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -6746,11 +6801,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "dOg" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
+/obj/item/reagent_containers/pill/patch/turbo,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "dOt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/wreck/trash/three_barrels,
@@ -6845,7 +6898,6 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/leisure)
 "dQG" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "neutralrustyfull"
 	},
@@ -6926,10 +6978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/bunker)
-"dTr" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/grass,
-/area/f13/den)
 "dTA" = (
 /obj/item/flag/bos,
 /obj/machinery/light/small{
@@ -7073,10 +7121,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "dVW" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/button/door{
+	name = "den clinic shutters"
 	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "dWg" = (
 /obj/structure/table/wood/junk,
@@ -7243,6 +7291,10 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"eay" = (
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "eaB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -7460,9 +7512,6 @@
 /obj/effect/light_emitter,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"egc" = (
-/turf/open/floor/grass,
-/area/f13/den)
 "egg" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -7490,8 +7539,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "ehc" = (
-/obj/effect/landmark/poster_spawner,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "ehe" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -7536,15 +7590,12 @@
 	},
 /area/f13/bunker)
 "eiz" = (
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/structure/table,
-/obj/item/grenade/empgrenade,
-/obj/item/grenade/empgrenade,
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "dennorthgate";
+	name = "North Den Gate"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "eiA" = (
@@ -7750,8 +7801,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "emV" = (
+/obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
+/area/f13/caves)
 "enc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -7983,6 +8035,12 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"eup" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "euv" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -8052,14 +8110,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "exf" = (
-/obj/structure/chair/f13foldupchair,
-/turf/open/floor/carpet/green,
-/area/f13/den)
-"exg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/turf/open/floor/grass,
 /area/f13/den)
 "exl" = (
 /obj/structure/barricade/wooden,
@@ -8148,9 +8199,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ezs" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
 	},
+/obj/effect/light_emitter,
+/turf/open/water,
 /area/f13/den)
 "eAa" = (
 /obj/machinery/vending/sovietsoda,
@@ -8227,13 +8283,9 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "eCs" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "eCF" = (
@@ -8356,11 +8408,6 @@
 /obj/item/key,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
-"eFq" = (
-/obj/structure/table/wood,
-/obj/item/pda,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "eFr" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8419,6 +8466,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
+"eHr" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "eHs" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13{
@@ -8518,11 +8572,20 @@
 	},
 /area/f13/bunker)
 "eJq" = (
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = -34
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/obj/item/clothing/suit/armored/medium/vestarmor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/green,
+/area/f13/den)
+"eJW" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
 /area/f13/den)
 "eJX" = (
 /obj/structure/bed/mattress{
@@ -8553,6 +8616,12 @@
 	light_range = 4
 	},
 /area/f13/brotherhood/archives)
+"eKX" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "eKY" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -8566,6 +8635,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"eLg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "eLy" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -8702,10 +8776,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"eOP" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/den)
 "ePe" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9054,6 +9124,17 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
+"faq" = (
+/obj/machinery/chem_master/advanced,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "faB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9111,15 +9192,6 @@
 /obj/structure/decoration/rag,
 /turf/open/water,
 /area/f13/sewer)
-"fdw" = (
-/obj/structure/handrail/g_central{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/f13{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "fdG" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/dirt,
@@ -9179,11 +9251,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ffZ" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/obj/item/clothing/suit/armored/medium/vestarmor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "fgo" = (
@@ -9244,17 +9316,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
-"fhe" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
 "fhr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9268,13 +9329,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"fis" = (
-/obj/machinery/processor{
-	density = 0;
-	pixel_x = 30
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "fiI" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -9322,6 +9376,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/den)
+"fjJ" = (
+/obj/structure/table/wood/junk,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fjL" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -9334,6 +9397,17 @@
 "fjS" = (
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/green,
+/area/f13/den)
+"fjU" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/den)
 "fka" = (
 /turf/closed/wall/r_wall/rust,
@@ -9363,7 +9437,7 @@
 	icon_state = "gib2-old"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
+/area/f13/caves)
 "fls" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
@@ -9381,12 +9455,10 @@
 /turf/open/water,
 /area/f13/den)
 "flT" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/water,
 /area/f13/den)
 "flW" = (
 /obj/structure/wreck/trash/engine,
@@ -9431,6 +9503,14 @@
 "fmW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
+/area/f13/den)
+"fnc" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Auxillary Storage";
+	req_access_txt = "87"
+	},
+/turf/open/space/basic,
 /area/f13/den)
 "fnq" = (
 /obj/structure/displaycase/trophy,
@@ -9527,8 +9607,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
 "fpD" = (
-/obj/structure/sign/poster,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "fpJ" = (
 /obj/machinery/telecomms/server/presets/legion,
@@ -9551,17 +9635,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"fpT" = (
-/obj/machinery/chem_master/advanced,
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "fpV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -9583,13 +9656,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "fqF" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/junglebush/large,
-/turf/open/water,
 /area/f13/den)
 "fqK" = (
 /obj/structure/barricade/wooden/strong,
@@ -9777,9 +9847,13 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "fws" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "stagestairs2"
 	},
 /area/f13/den)
 "fww" = (
@@ -9801,22 +9875,15 @@
 /area/f13/bunker)
 "fwZ" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "fxi" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/smartfridge/chemistry/preloaded{
+	pixel_x = 30;
+	density = 0
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fxu" = (
@@ -9833,6 +9900,16 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"fxX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/wasteland_vendor/denvendor{
+	pixel_y = -32;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "fyd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/remains/human,
@@ -9899,12 +9976,29 @@
 "fzc" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/rnd)
+"fzj" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/den)
 "fzD" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/seeds/ambrosia,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fzP" = (
 /obj/structure/table/wood/settler,
@@ -9920,10 +10014,6 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustychess"
 	},
-/area/f13/den)
-"fzY" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "fAi" = (
 /obj/machinery/light,
@@ -10097,6 +10187,12 @@
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"fGK" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "fGW" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -10197,6 +10293,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"fJp" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/water,
+/area/f13/den)
 "fJs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10251,15 +10352,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"fLy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "fLK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -10396,6 +10488,28 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"fPo" = (
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
+"fPt" = (
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/structure/table,
+/obj/structure/fluff/railing{
+	density = 0;
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "fPu" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
@@ -10425,6 +10539,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"fQz" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
+"fQB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/den)
 "fQL" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -10436,8 +10563,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fRv" = (
+/obj/structure/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/den)
 "fRK" = (
@@ -10576,14 +10704,8 @@
 	},
 /area/f13/brotherhood/mining)
 "fUu" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "fUv" = (
 /turf/open/floor/f13{
@@ -10620,10 +10742,6 @@
 "fVi" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/bunker)
-"fVm" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "fVA" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 4;
@@ -10686,17 +10804,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"fXU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/vest/old,
-/obj/item/clothing/suit/armor/vest/old,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "fYg" = (
 /obj/structure/table/reinforced,
 /obj/item/folder{
@@ -11076,10 +11183,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "gkm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "gkx" = (
@@ -11200,14 +11305,6 @@
 	name = "plating"
 	},
 /area/f13/bunker)
-"gow" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "goO" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -11435,12 +11532,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
-"gwf" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "gwm" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -11493,6 +11584,14 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/sewer)
+"gyu" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
+"gyB" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gyS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -11584,13 +11683,10 @@
 	},
 /area/f13/clinic)
 "gBM" = (
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/obj/item/locked_box/weapon/melee/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "gCa" = (
 /turf/open/floor/carpet/green,
 /area/f13/den)
@@ -11984,10 +12080,6 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"gNv" = (
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "gNC" = (
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 1;
@@ -12090,19 +12182,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
-"gQW" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/den)
-"gRa" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "dennorthgate";
-	name = "North Den Gate"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/area/f13/caves)
 "gRd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
@@ -12270,10 +12350,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "gWk" = (
-/obj/machinery/button/door{
-	name = "den clinic shutters"
+/obj/machinery/vending/cigarette{
+	pixel_y = -33;
+	density = 0
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "gWH" = (
 /obj/machinery/light/small{
@@ -12416,6 +12497,15 @@
 	dir = 8
 	},
 /area/f13/bunker)
+"gZB" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	dir = 8;
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "gZF" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/bonfire/prelit,
@@ -12871,11 +12961,24 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"hqt" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "hri" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
 /area/f13/den)
 "hrM" = (
 /obj/structure/table,
@@ -13051,13 +13154,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "hxB" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/vest/old,
+/obj/item/clothing/suit/armor/vest/old,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "hxF" = (
@@ -13117,8 +13221,9 @@
 /area/f13/bunker)
 "hzR" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
+/area/f13/caves)
 "hAk" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
@@ -13314,14 +13419,13 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hJy" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/button/door{
+	name = "North Den Gate Shutters";
+	pixel_x = 1;
+	pixel_y = 29
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "hJD" = (
@@ -13368,6 +13472,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"hKN" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/den)
 "hKS" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -13974,6 +14088,13 @@
 "ibY" = (
 /obj/structure/sign/poster/contraband/bountyhunters,
 /turf/closed/wall/f13/wood/interior,
+/area/f13/den)
+"ica" = (
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "icu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14607,6 +14728,22 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ixi" = (
+/obj/machinery/chem_heater,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ixD" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -14958,6 +15095,17 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"iLY" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/handrail/g_central{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "iMa" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -15109,11 +15257,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iPX" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/obj/item/clothing/suit/chickensuit,
-/obj/item/clothing/head/chicken,
-/turf/open/floor/carpet/green,
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
 /area/f13/den)
 "iQf" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
@@ -15273,8 +15420,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "iUU" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/processor{
+	density = 0;
+	pixel_x = 30
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "iUY" = (
 /obj/structure/chair/stool,
@@ -15302,6 +15452,16 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
+"iVF" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter,
+/obj/structure/billboard/den{
+	pixel_y = -17;
+	pixel_x = -12
+	},
+/turf/open/water,
+/area/f13/den)
 "iVP" = (
 /obj/structure/decoration/vent,
 /turf/closed/wall/r_wall,
@@ -15488,14 +15648,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "jaG" = (
-/obj/machinery/button/door{
-	id = "densouthgate";
-	name = "South Den Gate";
-	pixel_x = 6;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "jaU" = (
@@ -15521,6 +15676,13 @@
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"jbM" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jco" = (
 /obj/structure/lattice{
 	density = 1
@@ -15935,7 +16097,7 @@
 "jqn" = (
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/area/f13/caves)
 "jqE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -16301,6 +16463,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"jEr" = (
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "jEt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16386,8 +16560,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jHj" = (
-/obj/item/reagent_containers/pill/patch/turbo,
-/turf/open/indestructible/ground/inside/subway,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/den)
 "jHI" = (
 /obj/structure/bookcase/random,
@@ -17081,6 +17257,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
+"kcf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/water,
+/area/f13/caves)
 "kcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -17324,18 +17505,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"kjh" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/den)
 "kjq" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -18129,16 +18298,6 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"kIf" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_y = 29;
-	pixel_x = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "kIn" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18169,6 +18328,17 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"kJu" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/item/clothing/suit/armored/light/vest/kevlar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "kJB" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -18432,24 +18602,7 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "kTJ" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/obj/item/seeds/agave,
-/obj/item/seeds/agave,
-/obj/item/seeds/xander,
-/obj/item/seeds/xander,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/poppy/broc,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/mutfruit,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/feracactus,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cotton,
-/obj/item/seeds/ambrosia,
+/obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "kTO" = (
@@ -18757,12 +18910,11 @@
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/tunnel)
 "kZh" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = -34
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "kZo" = (
 /obj/machinery/computer/terminal{
@@ -19048,9 +19200,14 @@
 	},
 /area/f13/building)
 "liN" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "liS" = (
@@ -19197,6 +19354,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"lmD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/turf/open/water,
+/area/f13/den)
 "lmG" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -19360,12 +19525,6 @@
 /obj/effect/landmark/start/f13/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"lsh" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "lsw" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Sheriff's Quarters";
@@ -19398,22 +19557,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"ltu" = (
-/obj/machinery/chem_heater,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ltN" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/structure/lattice/catwalk,
@@ -19537,6 +19680,10 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"lyd" = (
+/obj/item/clothing/head/helmet/roman/fake,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lyh" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19605,6 +19752,14 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"lAv" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/den)
 "lAw" = (
 /obj/structure/girder/reinforced,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19663,7 +19818,7 @@
 	name = "drainage system"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
+/area/f13/caves)
 "lBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -19787,6 +19942,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"lFt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "lFR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/smoke{
@@ -20207,16 +20368,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"lTs" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d00,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "lTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20234,24 +20385,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "lUs" = (
-/obj/structure/rack,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/storage/bag/plants,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirty"
+	},
 /area/f13/den)
 "lUw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20297,10 +20436,14 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
 "lVK" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/grenade/empgrenade,
+/obj/machinery/button/door{
+	id = "densouthgate";
+	name = "South Den Gate";
+	pixel_x = 6;
+	pixel_y = -25
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "lWb" = (
@@ -20827,11 +20970,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnK" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "mnU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21172,11 +21313,6 @@
 /obj/effect/landmark/start/f13/sheriff,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"mCP" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/water,
-/area/f13/den)
 "mCX" = (
 /obj/structure/rack/shelf_metal,
 /turf/closed/wall/rust,
@@ -21592,6 +21728,12 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"mSP" = (
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "mSV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/dirt,
@@ -21751,16 +21893,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
-"mYc" = (
-/obj/machinery/button/door{
-	name = "North Den Gate Shutters";
-	pixel_x = 1;
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
 "mYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -21805,16 +21937,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mZs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "mZG" = (
@@ -21898,10 +22028,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nbd" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/wood,
+/obj/item/pda,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "nbm" = (
 /obj/structure/table{
@@ -22041,7 +22170,9 @@
 	},
 /area/f13/brotherhood/operations)
 "nfB" = (
-/obj/structure/simple_door/glass,
+/obj/structure/simple_door/house{
+	icon_state = "glassclosing"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -22315,18 +22446,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
-"npc" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
-/obj/item/clothing/mask/cigarette/rollie,
-/obj/item/clothing/mask/cigarette/rollie,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+"npf" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "npi" = (
 /obj/structure/table/optable/abductor,
@@ -22680,11 +22804,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "nyG" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
+/obj/structure/fence{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "nyX" = (
@@ -22721,6 +22848,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"nzO" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/f13/den)
 "nAa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22795,6 +22926,14 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
+"nBV" = (
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/den)
 "nCl" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
@@ -22876,6 +23015,11 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
+"nFt" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/both,
+/turf/open/floor/grass,
+/area/f13/den)
 "nFD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -22924,11 +23068,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "nGD" = (
-/obj/structure/handrail/g_central{
-	pixel_y = -16
-	},
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	icon_state = "greenrusty"
 	},
 /area/f13/den)
 "nGN" = (
@@ -22972,8 +23113,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
 "nHM" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "nHY" = (
@@ -23027,10 +23171,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/operating)
-"nJC" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
-/area/f13/den)
 "nJG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -24077,16 +24217,11 @@
 	},
 /area/f13/brotherhood/operations)
 "ooI" = (
-/obj/machinery/button/door{
-	id = "densouthgate";
-	name = "South Den Gate";
-	pixel_x = 6;
-	pixel_y = -25
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/den)
+/area/f13/caves)
 "ooJ" = (
 /obj/machinery/light/fo13colored/Pink{
 	dir = 4;
@@ -24298,9 +24433,7 @@
 	},
 /area/f13/building)
 "owJ" = (
-/obj/structure/table/booth,
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/green,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/den)
 "owU" = (
 /obj/item/radio/intercom{
@@ -24445,10 +24578,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"oBq" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "oBy" = (
 /obj/structure/sign/poster/contraband/pinup_pink{
 	pixel_y = 32
@@ -24958,15 +25087,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"oVS" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "oWc" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/glass{
@@ -25876,14 +25996,6 @@
 	name = "cave"
 	},
 /area/f13/tunnel)
-"pCO" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/light,
-/obj/structure/table/glass,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "pDo" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt{
@@ -26245,6 +26357,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"pPI" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirty"
+	},
+/area/f13/den)
 "pQp" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "floor2elevatordoors";
@@ -26875,8 +26995,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qia" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -31
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "qid" = (
 /obj/structure/table/booth,
@@ -26958,6 +27083,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"qjN" = (
+/obj/structure/closet/crate/medical/anchored,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "qjP" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/spider/stickyweb,
@@ -26969,10 +27104,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"qjU" = (
-/obj/structure/chair/stool/bar/brass,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "qki" = (
 /obj/structure/destructible/clockwork/wall_gear{
 	pixel_x = -32
@@ -27258,6 +27389,15 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"qtc" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "greenrusty"
+	},
+/area/f13/den)
 "qtf" = (
 /obj/structure/rack,
 /obj/item/clothing/under/misc/bathrobe,
@@ -27580,12 +27720,6 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
-"qEH" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
-	},
-/turf/open/water,
-/area/f13/den)
 "qEP" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /obj/structure/spider/stickyweb,
@@ -27662,6 +27796,15 @@
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"qFM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical";
+	max_integrity = 600
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/wood/f13/oak,
+/area/f13/den)
 "qFP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -27720,11 +27863,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qIj" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "qIw" = (
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
@@ -27860,6 +27998,15 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"qMr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = 2;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/den)
 "qMP" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -28082,12 +28229,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qTe" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "densouthgate";
-	name = "South Den Gate"
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "qTm" = (
@@ -28577,12 +28724,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rjD" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "rjM" = (
@@ -28877,6 +29024,13 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"rsi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "rsj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29270,6 +29424,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
+"rzy" = (
+/obj/structure/window/fulltile/ruins,
+/obj/structure/barricade/bars,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "rzA" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29577,8 +29736,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
 "rGe" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/den)
+/obj/structure/simple_door/metal/ventilation{
+	name = "drainage system"
+	},
+/turf/open/water,
+/area/f13/caves)
 "rGi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/cult,
@@ -30018,22 +30180,8 @@
 	},
 /area/f13/brotherhood/operating)
 "rSB" = (
-/obj/structure/bed/mattress,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
-"rSO" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
 /area/f13/caves)
-"rSU" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
 "rTg" = (
 /obj/structure/flora/tree/jungle{
 	desc = "Rumor has it that, as long as this tree stands firm, so too will the town of Oasis.";
@@ -30290,7 +30438,7 @@
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
-/area/f13/sewer)
+/area/f13/caves)
 "saS" = (
 /obj/item/mine/shrapnel,
 /turf/open/water,
@@ -30417,10 +30565,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"sfM" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "sfN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
@@ -31261,11 +31405,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"sIa" = (
-/obj/structure/window/fulltile/ruins,
-/obj/structure/barricade/bars,
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "sIA" = (
 /obj/structure/rack,
 /obj/item/toy/gun,
@@ -31433,10 +31572,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sOm" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/den)
 "sOq" = (
 /obj/machinery/light/small{
@@ -31676,10 +31814,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"sVP" = (
-/obj/machinery/door/airlock/abandoned,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "sWe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -31834,6 +31968,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"tbE" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/f13/den)
 "tbT" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -31846,12 +31984,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "tco" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/structure/handrail/g_central{
+	dir = 8;
+	pixel_x = -20
 	},
-/turf/open/water,
+/turf/closed/wall/r_wall/rust,
 /area/f13/den)
 "tcL" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -31960,12 +32097,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
-"thm" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tht" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/purple,
@@ -32543,11 +32674,6 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"tzz" = (
-/turf/open/floor/f13{
-	icon_state = "greenrusty"
-	},
-/area/f13/den)
 "tzH" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -32633,11 +32759,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "tCl" = (
-/obj/structure/simple_door/metal/ventilation{
-	name = "drainage system"
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "densouthgate";
+	name = "South Den Gate"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/sewer)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "tCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32785,7 +32914,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/area/f13/caves)
 "tGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32925,13 +33054,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "tKj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/workbench/bottler,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
+/obj/structure/table/booth,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/green,
 /area/f13/den)
 "tKk" = (
 /obj/structure/curtain,
@@ -33293,12 +33418,28 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"tXd" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/grenade/empgrenade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "tXh" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "tXl" = (
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/flora/junglebush,
+/obj/structure/window/reinforced{
+	color = "#3e3d42"
+	},
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/water,
 /area/f13/den)
 "tXr" = (
 /obj/structure/rack,
@@ -33549,16 +33690,6 @@
 	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood/rnd)
-"uhB" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/den)
 "uhC" = (
 /obj/machinery/vr_sleeper/bos{
 	dir = 8
@@ -33837,14 +33968,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
-"uqb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "uqh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
@@ -33959,16 +34082,6 @@
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
-"uso" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/denvendor{
-	pixel_y = -32;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "usp" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/fakelattice,
@@ -34055,16 +34168,6 @@
 "uuN" = (
 /turf/open/floor/wood/wood_tiled,
 /area/f13/brotherhood/operations)
-"uvj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/den)
 "uvE" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -34076,13 +34179,10 @@
 	},
 /area/f13/building)
 "uvI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/den)
+/area/f13/caves)
 "uvR" = (
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
@@ -34120,6 +34220,11 @@
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
+"uyC" = (
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uyS" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -34158,6 +34263,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"uBk" = (
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	color = "#3e3d42";
+	dir = 4
+	},
+/obj/effect/light_emitter,
+/turf/open/water,
+/area/f13/den)
 "uBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -34247,7 +34367,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/den)
+/area/f13/caves)
 "uCR" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/showcase/machinery/cloning_pod,
@@ -34450,6 +34570,14 @@
 "uLI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"uLP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uLR" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -34699,6 +34827,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"uUB" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uUH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -34926,6 +35064,13 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"vbx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/den)
 "vbU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
@@ -34979,17 +35124,41 @@
 	},
 /area/f13/den)
 "vcx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
 	},
-/obj/machinery/light/floor,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/den)
 "vcC" = (
 /obj/structure/chair/f13chair1,
@@ -35119,11 +35288,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
 "vfF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/obj/item/clothing/suit/armored/light/vest/kevlar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
 	},
 /area/f13/den)
 "vfU" = (
@@ -35196,14 +35365,6 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/brotherhood/dorms)
-"vjM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "vjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/pinup_shower{
@@ -35266,15 +35427,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"vkI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = 2;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
-/area/f13/den)
 "vlu" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
@@ -35429,12 +35581,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"vra" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/den)
 "vrx" = (
 /obj/structure/sink{
 	dir = 4;
@@ -35479,6 +35625,14 @@
 /obj/structure/flora/wasteplant/wild_yucca,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vsF" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/key,
+/obj/item/lock_construct,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "vsI" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
@@ -36250,10 +36404,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vPv" = (
-/obj/effect/landmark/poster_spawner/pinup,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/den)
 "vPx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36291,6 +36441,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vQw" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -36424,6 +36578,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"vVu" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/den)
 "vVx" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -36566,8 +36726,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wam" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/den)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "waB" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/tunnel,
@@ -36751,14 +36916,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "wgS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor2elevatordoors";
-	name = "Den Airlock";
-	req_access_txt = "87"
-	},
+/obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+	icon_state = "neutralrustyfull"
 	},
 /area/f13/den)
 "whA" = (
@@ -36781,6 +36941,18 @@
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/mining)
+"wif" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/den)
 "wir" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
@@ -36823,7 +36995,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wjM" = (
-/turf/closed/mineral/random/low_chance/underground,
+/obj/item/kirbyplants/random,
+/turf/open/floor/grass,
 /area/f13/den)
 "wkf" = (
 /obj/structure/showcase/horrific_experiment{
@@ -36890,10 +37063,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
-"wms" = (
-/obj/structure/flora/grass/both,
-/turf/open/floor/grass,
-/area/f13/den)
 "wmL" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -36916,6 +37085,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/mining)
+"woj" = (
+/obj/structure/barricade/bars,
+/turf/open/water,
+/area/f13/caves)
 "wom" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -36931,25 +37104,17 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "wpa" = (
-/obj/machinery/smartfridge/chemistry/preloaded{
-	pixel_x = 30;
-	density = 0
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5,
+/obj/item/clothing/mask/cigarette/rollie,
+/obj/item/clothing/mask/cigarette/rollie,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
-/area/f13/den)
-"wpc" = (
-/obj/structure/flora/junglebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/water,
 /area/f13/den)
 "wpj" = (
 /obj/machinery/light/small{
@@ -36971,43 +37136,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
-	},
-/area/f13/den)
-"wpF" = (
-/obj/structure/closet/crate/freezer{
-	storage_capacity = 30
-	},
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/heart,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/lungs,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/stomach,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/liver,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/eyes,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/ears,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/obj/item/organ/tongue,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "wqt" = (
@@ -37043,6 +37171,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"wrg" = (
+/obj/machinery/door/airlock/abandoned,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "wrm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -37295,6 +37427,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
+"wzt" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/den)
 "wzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -37639,9 +37779,13 @@
 /area/f13/brotherhood/operations)
 "wKN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor2elevatordoors";
+	name = "Den Airlock";
+	req_access_txt = "87"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/den)
 "wKX" = (
@@ -38102,6 +38246,12 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices2nd)
+"wYl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/den)
 "wYo" = (
 /turf/closed/wall/rust,
 /area/f13/den)
@@ -38706,12 +38856,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"xpf" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/den)
 "xpg" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/glass,
@@ -38853,6 +38997,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"xtg" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/den)
 "xtk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -39676,11 +39826,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"xTi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/den)
 "xTm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39928,6 +40073,11 @@
 /obj/machinery/computer/security/telescreen,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"yck" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/open/water,
+/area/f13/caves)
 "ycl" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -40204,14 +40354,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "ylp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical";
-	max_integrity = 600
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/wood/f13/oak,
-/area/f13/den)
+/obj/structure/bed/mattress,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/caves)
 "ylv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -40238,10 +40383,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/stage_tr,
 /area/f13/building)
-"ylL" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/f13/den)
 "ymg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -64841,7 +64982,7 @@ sKt
 dXE
 dXE
 dXE
-buN
+uPr
 dXE
 vPg
 vPg
@@ -65098,7 +65239,7 @@ mjG
 dXE
 dXE
 dXE
-mjG
+bqI
 dXE
 dXE
 dXE
@@ -65352,10 +65493,10 @@ wFD
 wFD
 mjG
 mjG
-mjG
-mjG
-mjG
-mjG
+mSP
+bqI
+bqI
+bqI
 ddv
 ddv
 wFD
@@ -65607,12 +65748,12 @@ lYx
 wFD
 wFD
 wFD
-mjG
-mjG
-mjG
-mjG
-mjG
-mjG
+snI
+snI
+snI
+snI
+snI
+snI
 ddv
 ddv
 wFD
@@ -65865,18 +66006,18 @@ kUN
 kUN
 kUN
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
+kUN
+kUN
+kUN
+kUN
+kUN
 wYo
 wYo
-hRI
-hRI
-hRI
-hRI
-wYo
+wFD
+wFD
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -66128,12 +66269,12 @@ vgV
 vgV
 vgV
 vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+vgV
+cAe
+cYs
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -66371,26 +66512,26 @@ dXE
 hQE
 hQE
 kUN
-wam
+dhF
 kUN
-ezs
-ezs
-ezs
-dgO
-wYo
-kUN
+sOm
+sOm
+sOm
+sOm
+sOm
+bMH
 vgV
 vgV
 vgV
 vgV
 vgV
 vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+vgV
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -66623,17 +66764,17 @@ dXE
 wFD
 wFD
 bbB
-tCl
+mSP
 uPr
 uPr
 uPr
-wam
-wam
+dhF
+dhF
 kUN
-ezs
-ezs
-ezs
-dgO
+sOm
+sOm
+sOm
+cCO
 wYo
 kUN
 vgV
@@ -66642,12 +66783,12 @@ vgV
 vgV
 vgV
 vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+vgV
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -66887,24 +67028,24 @@ hQE
 kUN
 kUN
 kUN
-ezs
-ezs
-ezs
-dgO
+sOm
+sOm
+sOm
+cCO
 wYo
 kUN
+gZB
+gZB
+aXd
+gZB
+gZB
+eFv
 vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 aoj
 aoj
@@ -67144,24 +67285,24 @@ hQE
 kUN
 kUN
 kUN
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
 wYo
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+mZs
+bxH
+ffZ
+ffZ
+ffZ
+nHM
 nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -67401,24 +67542,24 @@ wCB
 kUN
 kUN
 kUN
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
 wYo
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+eJW
+iPX
+gkm
+gkm
+gkm
+eJW
 nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -67658,24 +67799,24 @@ hQE
 kUN
 kUN
 kUN
-aqh
+fnc
 wYo
 wYo
 wYo
 wYo
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+eJW
+gkm
+gkm
+jaG
+gkm
+nyG
 nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
 vPg
 vPg
@@ -67915,27 +68056,27 @@ kUN
 kUN
 kUN
 kUN
-ezs
-ezs
-ezs
-dgO
+sOm
+sOm
+sOm
+cCO
 wYo
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+eJW
+gkm
+gkm
+gkm
+gkm
+bup
 nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
-tur
-tur
+dXE
+dXE
 tur
 tur
 gpM
@@ -68172,27 +68313,27 @@ kUN
 kUN
 kUN
 kUN
-jaG
-ezs
-ezs
-dgO
+aqh
+sOm
+sOm
+cCO
 wYo
 kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
+eJW
+vfF
+gkm
+gkm
+lAv
+nyG
 nGD
-hRI
-hRI
-hRI
-hRI
-wYo
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
-tur
-vxm
+dXE
+eLg
 lfk
 ube
 qXj
@@ -68427,28 +68568,28 @@ vjW
 rQv
 eBU
 tiS
-tzz
-kUN
-jaG
-ezs
-ezs
-dgO
-wYo
-kUN
-vgV
-vgV
-vgV
-vgV
-vgV
-vgV
 nGD
-hRI
-hRI
-hRI
-hRI
+kUN
+aqh
+sOm
+sOm
+cCO
 wYo
+kUN
+eJW
+gkm
+gkm
+gkm
+dpW
+eJW
+nGD
+mjG
+abB
+wFD
+wFD
+dXE
 vPg
-tur
+dXE
 tGq
 dxj
 dxj
@@ -68684,28 +68825,28 @@ wRa
 wvj
 vgV
 dmS
-cLS
-wgS
-ezs
-ezs
-ezs
-ezs
+lFt
+wKN
+sOm
+sOm
+sOm
+sOm
 wYo
 kUN
+bPB
+qtc
+qtc
+qtc
+qtc
+cIZ
 vgV
-vgV
-vgV
-vgV
-vgV
-vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-kUN
+mjG
+abB
+wFD
+wFD
 hQE
-tur
+hQE
+dXE
 jqn
 dxj
 dxj
@@ -68941,7 +69082,7 @@ ekK
 ajO
 sMl
 itn
-cLS
+lFt
 kUN
 dTG
 dTG
@@ -68950,20 +69091,20 @@ dTG
 hFt
 kUN
 vgV
+dpu
+dpu
+dpu
+dpu
 vgV
 vgV
-vgV
-vgV
-vgV
-nGD
-hRI
-hRI
-hRI
-hRI
-kUN
+mjG
+abB
+wFD
+wFD
 hQE
-tur
-tur
+hQE
+dXE
+dXE
 tur
 vtz
 tur
@@ -69204,7 +69345,7 @@ vgV
 vgV
 vgV
 vgV
-qTe
+cqu
 vgV
 vgV
 vgV
@@ -69212,9 +69353,9 @@ vgV
 vgV
 vgV
 vgV
-nGD
-wFD
-wFD
+vgV
+mjG
+abB
 wFD
 wFD
 wFD
@@ -69469,9 +69610,9 @@ vgV
 vgV
 vgV
 vgV
-nGD
-wFD
-wFD
+vgV
+mjG
+abB
 wFD
 wFD
 wFD
@@ -69711,7 +69852,7 @@ gMZ
 iDK
 auj
 auj
-wKN
+vbx
 fIf
 fIf
 vgV
@@ -69932,32 +70073,32 @@ wFD
 mjG
 aou
 kUN
-dgO
-ezs
-ezs
+cCO
+sOm
+sOm
 dZO
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
-bxH
-ezs
-ezs
-gwf
+vsF
+sOm
+sOm
+eCs
 bIT
-ezs
-gwf
-ezs
-ezs
-bxH
+sOm
+eCs
+sOm
+sOm
+vsF
 kUN
-ezs
-ezs
+sOm
+sOm
 dZO
-ezs
-ezs
-ezs
-dgO
+sOm
+sOm
+sOm
+cCO
 kUN
 hRI
 hRI
@@ -70189,32 +70330,32 @@ wFD
 mjG
 bzl
 kUN
-dgO
-ezs
-ezs
+cCO
+sOm
+sOm
 kUN
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
-dgO
-ezs
-ezs
+cCO
+sOm
+sOm
 kUN
-ezs
+sOm
 bIT
 kUN
-ezs
-ezs
-dgO
-ehc
-ezs
-ezs
+sOm
+sOm
+cCO
+kUN
+sOm
+sOm
 kUN
 wYo
-ezs
-ezs
-dgO
+sOm
+sOm
+cCO
 kUN
 hRI
 hRI
@@ -70446,32 +70587,32 @@ wFD
 mjG
 bzl
 kUN
-mYc
-ezs
-ezs
+hJy
+sOm
+sOm
 kUN
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
-ezs
-ezs
-ezs
-ehc
-ezs
+sOm
+sOm
+sOm
+kUN
+sOm
 bIT
 kUN
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
-ezs
-ezs
+sOm
+sOm
 kUN
-aqQ
-ezs
-ezs
-dgO
+wYo
+sOm
+sOm
+cCO
 kUN
 hRI
 hRI
@@ -70703,32 +70844,32 @@ wWB
 mjG
 agK
 kUN
-kIf
-ezs
-ezs
+cJI
+sOm
+sOm
 kUN
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
-dAO
-dAO
-dAO
+fPt
+fPt
+fPt
 kUN
 bIT
 bIT
 kUN
-dAO
-dAO
-dAO
-ehc
-ezs
-ezs
+fPt
+fPt
+fPt
+kUN
+sOm
+sOm
 kUN
 wYo
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
 hRI
 hRI
@@ -70743,7 +70884,7 @@ lCp
 tUT
 vBZ
 kDG
-dEl
+iLY
 okb
 dyB
 gCa
@@ -70755,7 +70896,7 @@ tBY
 xbj
 efa
 aLf
-dLC
+cAU
 eLE
 yhT
 yhT
@@ -70929,7 +71070,6 @@ rwZ
 aQU
 wFD
 wFD
-mNE
 wFD
 wFD
 wFD
@@ -70953,7 +71093,8 @@ wFD
 wFD
 wFD
 wFD
-mNE
+wFD
+wFD
 ryY
 bbB
 bbB
@@ -70968,24 +71109,24 @@ bIT
 bIT
 nye
 bIT
-ezs
-ezs
-ezs
-ezs
-fxi
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
+bIT
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
 kUN
 wYo
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 kUN
 hRI
 hRI
@@ -70999,8 +71140,8 @@ auj
 cAC
 gVL
 gVL
-ylp
-vkI
+qFM
+qMr
 gMZ
 cbQ
 bIC
@@ -71186,7 +71327,7 @@ nKZ
 aTi
 wFD
 wFD
-lCv
+wFD
 wFD
 wFD
 wFD
@@ -71210,25 +71351,25 @@ wFD
 wFD
 wFD
 wFD
-lCv
+wFD
 ryY
 bbB
 bbB
 mjG
 mjG
-gRa
-ezs
-ezs
-ezs
-ezs
+eiz
+sOm
+sOm
+sOm
+sOm
 bIT
-ezs
-ezs
+sOm
+sOm
 bIT
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
 hlO
 hlO
 hlO
@@ -71237,12 +71378,12 @@ hlO
 hlO
 hlO
 hlO
-ezs
+sOm
 kUN
 wYo
-ezs
-ezs
-ooI
+sOm
+sOm
+lVK
 kUN
 hRI
 hRI
@@ -71256,8 +71397,8 @@ auj
 auj
 auj
 auj
-rSU
-lTs
+fpD
+cKb
 dTK
 bMt
 pxK
@@ -71448,8 +71589,8 @@ dXE
 dXE
 dXE
 dXE
-agf
-agf
+myy
+myy
 dXE
 dXE
 dXE
@@ -71473,33 +71614,33 @@ wFD
 wWB
 mjG
 bzl
-ezs
-ezs
-ezs
-ezs
-fxi
-ezs
-ezs
-ezs
-bIT
-bIT
-bIT
-ezs
-ezs
 hlO
-egc
-egc
+hlO
+hlO
+hlO
+fjU
+hlO
+hlO
+hlO
+wzt
+wzt
+wzt
+hlO
+hlO
+hlO
+exf
+exf
 eiS
-dTr
-wms
-egc
+wjM
+dgg
+exf
 hlO
-ezs
+sOm
 kUN
-aqQ
-ezs
-ezs
-ooI
+wYo
+sOm
+sOm
+lVK
 kUN
 hRI
 hRI
@@ -71513,8 +71654,8 @@ iDK
 auj
 iDK
 iDK
-rSU
-vcx
+fpD
+blG
 dyu
 bMt
 bIC
@@ -71730,39 +71871,39 @@ wFD
 wWB
 mjG
 bzl
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-bwq
-egc
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+wzt
+exf
 iFg
 okH
 maO
 rvK
-egc
+exf
 hlO
-ezs
-ezs
-dFt
+sOm
+sOm
+kUN
 vct
 vct
 vct
 kUN
-dIm
-dIm
-dIm
-dIm
-dIm
+bKb
+bKb
+bKb
+bKb
+bKb
 fsN
 gNZ
 auj
@@ -71770,7 +71911,7 @@ fUQ
 auj
 auj
 auj
-rSU
+fpD
 cjg
 dyu
 dxH
@@ -71994,27 +72135,27 @@ kUN
 kUN
 kUN
 kUN
-fpD
 kUN
 kUN
 kUN
-fpD
-ezs
+kUN
+kUN
+sOm
 hlO
-qIj
+nFt
 kbT
 uVE
 eyK
 ghs
-ylL
+nzO
 hlO
 hlO
 hlO
 fUv
-ezs
-ezs
-ezs
-dyH
+sOm
+sOm
+sOm
+tCl
 xdj
 xdj
 xdj
@@ -72027,7 +72168,7 @@ jLx
 auj
 auj
 auj
-rSU
+fpD
 wIN
 vWZ
 hOB
@@ -72251,27 +72392,27 @@ kUN
 kUN
 kUN
 kUN
-ehc
-kUN
-ehc
 kUN
 kUN
-ezs
+kUN
+kUN
+kUN
+sOm
 cBZ
-egc
+exf
 bUh
-dFv
-mCP
+iVF
+fJp
 bhu
-egc
+exf
 hlO
-bhO
+hlO
 hlO
 fUv
-ezs
-ezs
-ezs
-liN
+sOm
+sOm
+sOm
+jHj
 xdj
 xdj
 xdj
@@ -72283,7 +72424,7 @@ auj
 fjh
 auj
 auj
-vPv
+blx
 qQR
 fjH
 fjH
@@ -72504,7 +72645,7 @@ vgV
 kUN
 kUN
 dzP
-eFq
+nbd
 dLs
 kUN
 gCa
@@ -72513,22 +72654,22 @@ gCa
 gCa
 gCa
 dZO
-ezs
-bwq
-egc
-fqF
+sOm
+wzt
+exf
+cbu
 uVE
 eyK
-flT
-egc
+lmD
+exf
 hlO
 hlO
 hlO
 fUv
-ezs
-exg
-ezs
-gBM
+sOm
+flT
+sOm
+sOm
 xdj
 xdj
 xdj
@@ -72540,7 +72681,7 @@ iDK
 fjh
 iDK
 auj
-sIa
+rzy
 gKU
 aVZ
 gCa
@@ -72553,7 +72694,7 @@ ibY
 gVp
 fVQ
 cuS
-dHg
+aqW
 hQE
 eLE
 yhT
@@ -72760,30 +72901,30 @@ mjG
 vgV
 kUN
 kUN
-exf
+fUu
 cUt
 tqC
 kUN
-sfM
-owJ
+vQw
+tKj
 cXP
 gCa
 gCa
 kUN
+sOm
+wzt
+tbE
+uBk
+nBV
 ezs
-bwq
-nJC
-bup
-tco
-uhB
-wpc
-egc
+tXl
+exf
 hlO
-ezs
-ezs
-ehc
+sOm
+sOm
 kUN
-ehc
+kUN
+kUN
 kUN
 kUN
 xdj
@@ -72797,13 +72938,13 @@ iDK
 iDK
 iDK
 auj
-sIa
+rzy
 gKU
 aVZ
 gCa
 nZC
-hri
-xpf
+npf
+vVu
 gCa
 bmJ
 exn
@@ -73021,29 +73162,29 @@ gCa
 cWc
 dzP
 kUN
-sfM
-owJ
+vQw
+tKj
 cXP
 gCa
 gCa
-ehc
-ezs
+kUN
+sOm
 cBZ
-egc
-egc
-nJC
-dTr
-egc
-qIj
+exf
+exf
+tbE
+wjM
+exf
+nFt
 hlO
-ezs
-dFt
+sOm
 kUN
 kUN
 kUN
 kUN
 kUN
-bEV
+kUN
+tco
 fEj
 fEj
 fEj
@@ -73054,12 +73195,12 @@ fjh
 gmI
 iDK
 auj
-sIa
+rzy
 lxs
 aVZ
 gCa
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -73278,27 +73419,27 @@ gCa
 gCa
 gCa
 kUN
-qjU
-iPX
+cQp
+ica
 cXP
 gCa
 gCa
 kUN
-ezs
-bwq
-bwq
-hlO
-bhO
+sOm
+wzt
+wzt
 hlO
 hlO
 hlO
 hlO
-ezs
+hlO
+hlO
+sOm
 kUN
 kUN
-dsx
-fpT
-kjh
+ddx
+faq
+wif
 kUN
 kUN
 hRI
@@ -73311,7 +73452,7 @@ fjh
 hOB
 iDK
 auj
-sIa
+rzy
 gKU
 aVZ
 gCa
@@ -73534,28 +73675,28 @@ kUN
 kUN
 kUN
 ohV
-fpD
-sfM
-owJ
+kUN
+vQw
+tKj
 cXP
 gCa
 gCa
 kUN
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 bIT
 nye
-ezs
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
+sOm
 kUN
 kUN
-ddx
-aLA
-nHM
+jbM
+pPI
+uyC
 kUN
 kUN
 hRI
@@ -73792,27 +73933,27 @@ gCa
 gCa
 gCa
 eiA
-sfM
-owJ
+vQw
+tKj
 cXP
 gCa
 gCa
-fpD
-ezs
-ezs
+kUN
+sOm
+sOm
 dWg
-ezs
-ezs
-ezs
-cKb
-ezs
-ezs
+sOm
+sOm
+sOm
+fjJ
+sOm
+sOm
 dWg
 kUN
 kUN
-fhe
-gow
-uvI
+ckD
+bdf
+lUs
 kUN
 kUN
 hRI
@@ -73830,14 +73971,14 @@ eiA
 gCa
 gCa
 nZC
-hri
-xpf
+npf
+vVu
 gCa
 ibo
-dok
+bhO
 xac
 psU
-fis
+iUU
 fKK
 hQE
 eLE
@@ -74055,21 +74196,21 @@ gCa
 gCa
 gCa
 kUN
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
 bIT
-ezs
-dFt
+sOm
 kUN
-ltu
-hJy
-hJy
+kUN
+ixi
+liN
+liN
 kUN
 kUN
 hRI
@@ -74087,7 +74228,7 @@ eiA
 fjS
 fmW
 gCa
-blG
+fGK
 gCa
 gCa
 gCa
@@ -74310,23 +74451,23 @@ gCa
 gCa
 gCa
 gCa
-aqW
+gWk
 kUN
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
 nye
-ezs
-ehc
+sOm
 kUN
-nHM
-nHM
-nHM
+kUN
+uyC
+uyC
+uyC
 kUN
 kUN
 hRI
@@ -74558,7 +74699,7 @@ wFD
 mjG
 vgV
 kUN
-fpD
+kUN
 gCa
 gCa
 gCa
@@ -74569,21 +74710,21 @@ gCa
 gCa
 fOg
 kUN
-ezs
-ezs
+sOm
+sOm
 dWg
-ezs
-ezs
-ezs
+sOm
+sOm
+sOm
 dWg
-ezs
+sOm
 bIT
 dWg
 kUN
 kUN
-cRY
-nHM
-nHM
+dnP
+uyC
+uyC
 kUN
 kUN
 hRI
@@ -74824,23 +74965,23 @@ gCa
 gCa
 gCa
 gCa
-eJq
+kZh
 kUN
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-ezs
-gBM
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+sOm
+xtg
 kUN
 kUN
 kUN
-vjM
-nHM
-nHM
+uLP
+uyC
+uyC
 kUN
 kUN
 hRI
@@ -75080,24 +75221,24 @@ kUN
 kUN
 kUN
 dZO
-dFt
 kUN
 kUN
 kUN
 kUN
-ehc
-rSU
-rSU
+kUN
+kUN
+fpD
+fpD
 nfB
 nfB
-rSU
-rSU
+fpD
+fpD
 kUN
-bAz
-nHM
-nHM
-nHM
-bMI
+fQz
+uyC
+uyC
+uyC
+qjN
 kUN
 kUN
 hRI
@@ -75335,26 +75476,26 @@ gCa
 gCa
 kUN
 dcd
-fRv
-fRv
-fRv
-mnK
-oVS
-uqb
-fzD
+dQG
+dQG
+dQG
+cdh
+qTe
+aEe
+eHr
 kUN
-dVW
+fRv
 anK
 anK
 anK
 anK
-kZh
+dNa
 kUN
-rjD
-nHM
-nHM
-nHM
-cAU
+ehc
+uyC
+uyC
+uyC
+qia
 kUN
 kUN
 hRI
@@ -75586,32 +75727,32 @@ wFD
 mjG
 vgV
 kUN
-fpD
+kUN
 gCa
 gCa
 gCa
 kUN
-cMf
-fRv
-fRv
-fRv
-uqb
-uqb
-uqb
-dpW
+wgS
+dQG
+lwv
+dQG
+aEe
+aEe
+aEe
+jEr
 kUN
-dVW
+fRv
 anK
 anK
 anK
 anK
-kZh
+dNa
 kUN
-hxB
-thm
-nHM
-thm
-pCO
+uUB
+eup
+uyC
+eup
+dDz
 kUN
 kUN
 hRI
@@ -75848,15 +75989,15 @@ gCa
 gCa
 gCa
 kUN
-fLy
-fRv
-fRv
+rjD
+dQG
+dQG
 aPF
-lVK
-uqb
-uqb
-eiz
-dFt
+tXd
+aEe
+aEe
+cMf
+kUN
 anK
 anK
 anK
@@ -75864,11 +76005,11 @@ anK
 anK
 anK
 kUN
-wpF
-nHM
-nHM
-nHM
-wpF
+vcx
+uyC
+uyC
+uyC
+vcx
 kUN
 kUN
 hRI
@@ -76105,21 +76246,21 @@ gCa
 gCa
 gCa
 kUN
-lsh
-fRv
-fRv
+aQw
+dQG
+dQG
 aPF
-fXU
+hxB
 lwv
-uqb
-tKj
+aEe
+cRY
 kUN
-eCs
-mZs
-mZs
-mZs
-mZs
-mZs
+hKN
+dFt
+dFt
+dFt
+dFt
+dFt
 kUN
 kUN
 kUN
@@ -76128,9 +76269,9 @@ dZO
 kUN
 kUN
 kUN
-hRI
-exl
-bVp
+cSY
+yck
+bEV
 xdj
 dXE
 dXE
@@ -76358,19 +76499,19 @@ mjG
 vgV
 kUN
 kUN
-cSN
-cSN
-cSN
+eay
+eay
+eay
 kUN
-fRv
 dQG
-fRv
-vfF
-ffZ
-fRv
-uqb
-gkm
-gWk
+wYl
+lwv
+kJu
+eJq
+dQG
+aEe
+rsi
+dVW
 anK
 anK
 anK
@@ -76378,17 +76519,17 @@ anK
 anK
 anK
 kUN
-fVm
-tXl
-tXl
-tXl
-aJI
+dqh
+owJ
+owJ
+owJ
+czr
 kUN
 kUN
-hRI
-hRI
-hRI
-xdj
+cSY
+cSY
+cSY
+dii
 buN
 uPr
 uPr
@@ -76615,37 +76756,37 @@ mjG
 vgV
 kUN
 kUN
-gQW
-gQW
-gQW
+fzj
+fzj
+fzj
 kUN
-uvj
-fRv
-fRv
-fRv
-fRv
-fRv
-uqb
-uso
+aLA
+aEe
+dQG
+aEe
+dQG
+dQG
+aEe
+fxX
 kUN
 anK
 anK
 anK
 anK
 anK
-dIq
+hqt
 kUN
 cLd
-tXl
+owJ
 cLd
-tXl
-tXl
+owJ
+owJ
 kUN
 kUN
-hRI
-hRI
-hRI
-xdj
+cSY
+cSY
+cSY
+dii
 dXE
 dXE
 dXE
@@ -76876,33 +77017,33 @@ kUN
 kUN
 kUN
 kUN
-nbd
-nbd
-nbd
-nbd
-fRv
-fRv
+fqF
+fqF
+fqF
+fqF
+aEe
+dQG
 lwv
-uqb
-cQc
+aEe
+hri
 anK
 anK
 anK
 anK
 anK
-fws
+eKX
 kUN
-vra
-tXl
-tXl
-tXl
-oBq
+fQB
+owJ
+owJ
+owJ
+bHI
 kUN
 kUN
-hRI
-hRI
-hRI
-fdw
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -77150,16 +77291,16 @@ anK
 anK
 kUN
 cLd
-tXl
+owJ
 cLd
-tXl
+owJ
 cLd
 kUN
 kUN
-hRI
-hRI
-hRI
-fdw
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -77399,23 +77540,23 @@ kUN
 kUN
 kUN
 kUN
+fxi
 wpa
-npc
 sTs
+eKX
+anK
+anK
 fws
-anK
-anK
-fUu
-tXl
-tXl
-lUs
+owJ
+owJ
+bve
+fzD
 kTJ
-fzY
 kUN
 kUN
-hRI
-hRI
-hRI
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -77641,38 +77782,38 @@ wFD
 wFD
 mjG
 mjG
-kUN
-kUN
-cPI
-cPI
-cPI
-emV
-wjM
-rGe
-cPI
-cPI
-cPI
-rGe
-wam
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-hRI
-hRI
-hRI
+hQE
+hQE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -77897,40 +78038,40 @@ mjG
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wjM
-wjM
-bMH
-emV
-emV
-jHj
-cPI
-cPI
-rGe
-rGe
-wam
-wam
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+fQL
+hQE
+hQE
+aoj
+aoj
+lyd
+aoj
+aoj
+dOg
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -78154,40 +78295,40 @@ mjG
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wjM
-wjM
-eOP
-emV
-emV
-dOg
-cPI
-cPI
-wam
-cPI
-wam
-wam
-wam
-rGe
+fQL
+hQE
+hQE
+aoj
+aoj
+gyB
+aoj
+aoj
+fPo
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 lAR
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -78411,40 +78552,40 @@ mjG
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wjM
-wjM
-wjM
-iUU
-iUU
-cPI
-cPI
-cPI
-wam
-cPI
-wam
-wam
-wam
-wam
-kUN
-rGe
-rGe
-wam
-wam
-wam
-wam
-rGe
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+fQL
+hQE
+hQE
+aoj
+aoj
+aoj
+emV
+emV
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+mNY
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -78668,39 +78809,39 @@ agK
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wYo
-wYo
-wYo
-wYo
-iUU
-wYo
-cPI
-cPI
-wam
-wam
-cPI
-wam
-rGe
-wam
-kUN
-rGe
-wam
-rGe
-rGe
-rGe
-rGe
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+fQL
+hQE
+hQE
+dXE
+dXE
+dXE
+dXE
+emV
+dXE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+uPr
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -78925,39 +79066,39 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wYo
-bPA
-dtr
-xTi
-qia
-wYo
-wam
-wam
-rGe
-wam
-cPI
-cPI
-cPI
-rGe
-kUN
-wam
-wam
-rGe
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+fQL
+hQE
+hQE
+dXE
+eLg
+bMI
+ddI
+gyu
+dXE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+uPr
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -79182,39 +79323,39 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wYo
-sOm
-dHw
-dHw
-dHw
-wYo
-rGe
-wam
-rGe
-rGe
-wam
-wam
-rGe
-cPI
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+fQL
+hQE
+hQE
+dXE
+tGq
+rSB
+rSB
+rSB
+dXE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+uPr
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -79439,39 +79580,39 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-wYo
-gNv
-dHw
-dHw
+fQL
+hQE
+hQE
+dXE
+jqn
 rSB
-wYo
-rGe
-wam
-wam
-wam
-rGe
-rGe
-wam
-wam
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+rSB
+ylp
+dXE
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+hQE
+dXE
+dXE
+dXE
+dXE
+dXE
+dXE
+uPr
+dXE
+dXE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -79696,39 +79837,39 @@ mjG
 wFD
 wFD
 dtk
-mjG
-kUN
-kUN
-wYo
-wYo
-wYo
-sVP
-wYo
-wYo
-kUN
-kUN
-ckD
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-qEH
-kUN
-kUN
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+fQL
+hQE
+hQE
+dXE
+dXE
+dXE
+wrg
+dXE
+dXE
+hQE
+hQE
+buN
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+rGe
+hQE
+hQE
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -79953,40 +80094,40 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-dDz
+fQL
+hQE
+hQE
+uvI
 gQR
-dDz
-dDz
-ckD
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-ckD
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-xdj
-xdj
-xdj
-xdj
-dGU
-xdj
-dGU
+uvI
+uvI
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+buN
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+dii
+dii
+dii
+dii
+kcf
+dii
+kcf
 wFD
 mNE
 wFD
@@ -80210,40 +80351,40 @@ abB
 wFD
 wWB
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-kUN
-kUN
-kUN
-qEH
-kUN
-wam
-wam
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-xdj
-xdj
-xdj
-xdj
-dGU
-xdj
-dGU
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+hQE
+hQE
+hQE
+rGe
+hQE
+uPr
+dXE
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+dii
+dii
+dii
+dii
+kcf
+dii
+kcf
 wFD
 mNE
 wFD
@@ -80467,39 +80608,39 @@ abB
 wFD
 wWB
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
 hzR
-dHw
+rSB
 flj
-dHw
-kUN
-wam
-wam
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-qEH
-kUN
-ckD
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
+rSB
+hQE
+uPr
+dXE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+rGe
+hQE
+buN
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
 cGg
 dXE
 dXE
@@ -80724,40 +80865,40 @@ mjG
 wFD
 wWB
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-dHw
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+rSB
 flj
-dHw
-hzR
-kUN
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-qEH
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+rSB
+gBM
+hQE
+uPr
+dXE
+dXE
+dXE
+dXE
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+rGe
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 dXE
 dXE
@@ -80981,40 +81122,40 @@ mjG
 wFD
 wWB
 mjG
-mjG
-kUN
-kUN
-dDz
+fQL
+hQE
+hQE
+uvI
 uCP
-dDz
-dDz
-kUN
+uvI
+uvI
+hQE
 flj
-dHw
-dHw
-hzR
-kUN
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+rSB
+rSB
+mnK
+hQE
+uPr
+dXE
+dXE
+dXE
+dXE
+hQE
+uPr
+dXE
+dXE
+dXE
+dXE
+dXE
+hQE
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 uPr
 uPr
@@ -81238,40 +81379,40 @@ mjG
 wFD
 wWB
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-dHw
-dHw
-dHw
-dHw
-kUN
-wam
-wam
-wam
-wam
-wam
-qEH
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-fdw
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+cLS
+rSB
+rSB
+rSB
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+rGe
+uPr
+dXE
+dXE
+dXE
+dXE
+dXE
+hQE
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+saE
 dXE
 uPr
 dXE
@@ -81495,40 +81636,40 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-nyG
-dDz
-kUN
-kUN
-kUN
-kUN
-qEH
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
-kUN
+fQL
+hQE
+hQE
+uvI
+uvI
 wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-xdj
+uvI
+hQE
+hQE
+hQE
+hQE
+rGe
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+hQE
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+dii
 dXE
 uPr
 uPr
@@ -81752,40 +81893,40 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-xdj
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+dii
 buN
 uPr
 uPr
@@ -82009,40 +82150,40 @@ abB
 wFD
 wFD
 mjG
-mjG
-kUN
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-hRI
-hRI
-hRI
-hRI
-hRI
-xdj
+fQL
+hQE
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+cSY
+cSY
+cSY
+cSY
+cSY
+dii
 dXE
 uPr
 dXE
@@ -82266,18 +82407,18 @@ abB
 wFD
 wFD
 mjG
-mjG
+fQL
 hQE
-kUN
-dDz
-dDz
+hQE
+uvI
+uvI
 gQR
-dDz
-kUN
-wam
-kUN
-kUN
-qEH
+uvI
+hQE
+uPr
+hQE
+hQE
+rGe
 hQE
 hQE
 hQE
@@ -82294,12 +82435,12 @@ nmy
 nmy
 nmy
 dXE
-ddv
-wFD
-wFD
-wFD
-wFD
-vlu
+dXE
+cSY
+cSY
+cSY
+cSY
+cGg
 dXE
 uPr
 dXE
@@ -82525,16 +82666,16 @@ wFD
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 hQE
 dXE
 dXE
@@ -82554,9 +82695,9 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 dXE
@@ -82782,16 +82923,16 @@ wFD
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -82811,9 +82952,9 @@ eaH
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 dXE
@@ -83039,16 +83180,16 @@ wFD
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 fLU
 eCe
 pYd
@@ -83068,9 +83209,9 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 glr
@@ -83296,16 +83437,16 @@ wFD
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 fLU
 pYd
 eEt
@@ -83325,8 +83466,8 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -83553,16 +83694,16 @@ bbB
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 fLU
 pYd
 eFi
@@ -83582,8 +83723,8 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -83810,16 +83951,16 @@ bbB
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-dDz
-dDz
-kUN
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+uvI
+uvI
+hQE
+uPr
+hQE
+uPr
+uPr
 fLU
 pYd
 eHs
@@ -83839,8 +83980,8 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -84066,17 +84207,17 @@ wFD
 wFD
 dtk
 fQL
-rSO
-dDz
-dDz
-dDz
-dDz
-dDz
-qEH
-wam
-kUN
-wam
-wam
+uvI
+uvI
+uvI
+uvI
+uvI
+uvI
+rGe
+uPr
+hQE
+uPr
+uPr
 fLU
 pYd
 pYd
@@ -84096,9 +84237,9 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 dba
@@ -84324,16 +84465,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-kUN
-dDz
-kUN
-kUN
-kUN
-wam
-kUN
-wam
-wam
+hQE
+hQE
+uvI
+hQE
+hQE
+hQE
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -84353,9 +84494,9 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 dXE
@@ -84581,16 +84722,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-dDz
-dDz
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -84610,9 +84751,9 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 uPr
 dXE
@@ -84838,16 +84979,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
+hQE
 gQR
-dDz
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+uvI
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -84867,8 +85008,8 @@ nmy
 nmy
 nmy
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -85095,16 +85236,16 @@ wFD
 bbB
 fQL
 hQE
-kUN
-dDz
-dDz
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -85124,9 +85265,9 @@ dXE
 nmy
 nmy
 cSY
-wFD
-wFD
-bbB
+cSY
+cSY
+dii
 dXE
 uPr
 dXE
@@ -85350,18 +85491,18 @@ mjG
 wFD
 wFD
 bbB
-mjG
+fQL
 hQE
-kUN
-dDz
-dDz
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 pYd
@@ -85381,9 +85522,9 @@ dXE
 nmy
 nmy
 cSY
-wFD
-wFD
-bbB
+cSY
+cSY
+dii
 buN
 uPr
 uPr
@@ -85609,16 +85750,16 @@ wFD
 bbB
 fQL
 hQE
-kUN
-dDz
-dDz
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uvI
+uvI
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 gFC
 eCe
@@ -85638,9 +85779,9 @@ dXE
 nmy
 nmy
 cSY
-wFD
-wFD
-bbB
+cSY
+cSY
+dii
 dXE
 uPr
 dXE
@@ -85866,16 +86007,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-qEH
-kUN
-kUN
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+rGe
+hQE
+hQE
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 hQE
 dXE
@@ -85895,8 +86036,8 @@ jpr
 nmy
 nmy
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -86123,16 +86264,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 hQE
 dXE
@@ -86152,8 +86293,8 @@ dXE
 dXE
 dXE
 cSY
-wFD
-wFD
+cSY
+cSY
 saE
 dXE
 uPr
@@ -86380,16 +86521,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 hQE
 dXE
@@ -86409,9 +86550,9 @@ dXE
 dXE
 dXE
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 dXE
 dXE
@@ -86637,16 +86778,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 hQE
 dXE
@@ -86666,9 +86807,9 @@ dXE
 dXE
 dXE
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 dXE
 dXE
@@ -86894,16 +87035,16 @@ wWB
 mjG
 fQL
 hQE
-kUN
-wam
-wam
-wam
-wam
-wam
-wam
-kUN
-wam
-wam
+hQE
+uPr
+uPr
+uPr
+uPr
+uPr
+uPr
+hQE
+uPr
+uPr
 hQE
 hQE
 dXE
@@ -86923,9 +87064,9 @@ dXE
 dXE
 dXE
 cSY
-wFD
-wFD
-vlu
+cSY
+cSY
+cGg
 dXE
 dXE
 dXE
@@ -87151,17 +87292,17 @@ wWB
 mjG
 fQL
 hQE
-kUN
-kUN
-qEH
-kUN
-kUN
-kUN
-kUN
-kUN
-wam
-wam
-snI
+hQE
+hQE
+rGe
+hQE
+hQE
+hQE
+hQE
+hQE
+uPr
+uPr
+hQE
 hQE
 dXE
 dXE
@@ -87174,15 +87315,15 @@ wwT
 dXE
 dXE
 dXE
-ddv
+dXE
 uPr
 dXE
 dXE
 dXE
 dXE
-ddv
-mNE
-vfj
+dXE
+woj
+ooI
 dXE
 dXE
 dXE


### PR DESCRIPTION
## About The Pull Request

The Den lost its shop out of serious outcry. They keep their vendor. The Den now has an "entertainment" building to their south and a pretty pond. The focus is now on the casino to facilitate gimmicks,
![image](https://user-images.githubusercontent.com/93557430/170898465-be57e8b9-6ecf-43ae-9d46-d40cf93a0d0b.png)

There is a lil dungeon to the east that requires mining tools now.

## Why It's Good For The Game

No longer Oasis 2,

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

:cl:
tweak: tweaked a few things
balance: rebalanced something
/:cl:
