### PR TITLE
Slight update to water purification station

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -8842,6 +8842,14 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"dBj" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/building)
 "dBr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/f13/old/ruinedcornerbl,
@@ -47541,6 +47549,9 @@
 "sCQ" = (
 /obj/structure/table,
 /obj/machinery/light,
+/obj/item/reagent_containers/glass/bottle/nutrient{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building)
 "sCW" = (
@@ -47664,6 +47675,15 @@
 /obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"sGd" = (
+/obj/structure/closet/crate{
+	anchored = 1
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/building)
 "sGg" = (
 /obj/structure/chair/bench,
 /obj/structure/flora/grass/wasteland{
@@ -52418,7 +52438,24 @@
 	},
 /area/f13/building)
 "uxM" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
+/obj/item/reagent_containers/pill/water_purifier,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building)
 "uxR" = (
@@ -80703,7 +80740,7 @@ inC
 dCV
 ajx
 sdG
-uxM
+sGd
 dCV
 suO
 sHq
@@ -81735,7 +81772,7 @@ dCV
 dCV
 sdG
 toK
-xvH
+dBj
 rGK
 sdG
 sdG

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -351,9 +351,21 @@
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen. This one has been purified from radiation."
 	color = "#C3DBDA66" // It's cleaner, kek
 	taste_description = "clean water"
-	value = REAGENT_VALUE_VERY_RARE // Remind me to make it ultra rare once recipes are gone
+	value = REAGENT_VALUE_AMAZING
 	radiation_amount = 0
 	thirst_factor = THIRST_FACTOR * 30 // 22.5 per 5 units; 225 per 50; 1125 per 250
+	can_synth = FALSE
+
+/datum/reagent/water/purified/on_mob_life(mob/living/carbon/M) // Pure water is very, very healthy
+	M.reagents.remove_all_type(/datum/reagent/toxin, 1)
+	M.adjustBruteLoss(-0.5, 0)
+	M.adjustFireLoss(-0.5, 0)
+	M.adjustOxyLoss(-0.5, 0)
+	M.adjustToxLoss(-1, 0, TRUE)
+	M.adjustStaminaLoss(-0.5, FALSE)
+	if(M.radiation > 0)
+		M.radiation -= min(M.radiation, 2)
+	..()
 
 /datum/reagent/water/hollowwater
 	name = "Hollow Water"


### PR DESCRIPTION
## About The Pull Request

Rigbe merged #530 too fast.

- Purified water has a tiny bonus of healing all damage slowly(0.5 per tick for most)
- Station has water purifier pills in auxilary storage now.

## Why It's Good For The Game

- Adds additional reason to use purified water over anything else.
- Basically, loot for wastelanders that were there first, but can't commit to guarding the building for more than 2 minutes.
