### PR TITLE
Snips enclave slots by 3

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -325,8 +325,8 @@
 /datum/job/enclave/f13specialist
 	title = "Enclave Specialist"
 	flag = F13USSPECIALIST
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	description = "You are an operative for the remnants of the Enclave. You, unlike the normal privates, have recieved specialist training in either engineering or medicine."
 	supervisors = "The Lieutenant and the Sergeants."
 	outfit = /datum/outfit/job/enclave/peacekeeper/f13specialist
@@ -381,8 +381,8 @@
 /datum/job/enclave/enclavespy
 	title = "Enclave Private"
 	flag = F13USPRIVATE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 2
+	spawn_positions = 2
 	description = "You are an operative for the remnants of the Enclave. Obey your Lieutenant. He sets the Enclave's policies."
 	supervisors = "The Lieutenant and the Sergeants"
 	outfit = /datum/outfit/job/enclave/peacekeeper/enclavespy


### PR DESCRIPTION
We have had a issue in the Enclave where they are regularly the most populated faction when they are meant to be less populated and less active than other factions.

This is the same issue that LS BoS had where they were, on paper, 'strong' because they were 'small', and in practice they've got the most players out of everyone else and thus their strong gear is just good end discussion.

This isn't punishing a faction for being popular. It's just ultimately necessary, because real actual playercount matters more than theoretical faction popsize, and when the Legion's got 12 guys and the Enclave has 15, that's a bit much.

Now the Enclave has 12. They're marginally smaller. 2 privates and a spec gone. People have been pushing for 10-I don't see a way to make that work. People have been pushing for 5-that's just salt.