### PR TITLE
Casino C4 Fix

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -15953,7 +15953,8 @@
 /area/f13/bunker)
 "sET" = (
 /obj/machinery/door/poddoor/ert{
-	id = "lock1"
+	id = "lock1";
+	resistance_flags = 64
 	},
 /turf/open/floor/pod/dark,
 /area/f13/casino)
@@ -16097,7 +16098,8 @@
 /area/f13/underground/cave)
 "sOf" = (
 /obj/machinery/door/poddoor/ert{
-	id = "lock2"
+	id = "lock2";
+	resistance_flags = 64
 	},
 /turf/open/floor/pod/dark,
 /area/f13/casino)
@@ -16244,7 +16246,8 @@
 /area/f13/casino)
 "sXH" = (
 /obj/machinery/door/poddoor/ert{
-	id = "lock3"
+	id = "lock3";
+	resistance_flags = 64
 	},
 /turf/open/floor/pod/dark,
 /area/f13/casino)
@@ -16590,7 +16593,8 @@
 /area/f13/ncr)
 "twV" = (
 /obj/machinery/door/poddoor/ert{
-	id = "lock4"
+	id = "lock4";
+	resistance_flags = 64
 	},
 /turf/open/floor/pod/dark,
 /area/f13/casino)

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -565,7 +565,10 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Great Khan Jorts",				/obj/item/clothing/under/f13/khan/shorts,							10),
 		new /datum/data/wasteland_equipment("Great Khan Booty Shorts",		/obj/item/clothing/under/f13/khan/booty,							10),
 		new /datum/data/wasteland_equipment("Great Khan boots",				/obj/item/clothing/shoes/f13/military/khan,							15),
-		new /datum/data/wasteland_equipment("Great Khan pelt boots",		/obj/item/clothing/shoes/f13/military/khan_pelt,					15)
+		new /datum/data/wasteland_equipment("Great Khan pelt boots",		/obj/item/clothing/shoes/f13/military/khan_pelt,					15),
+		new /datum/data/wasteland_equipment("Stinger Grenade",				/obj/item/grenade/f13/stinger,										200),
+		new /datum/data/wasteland_equipment("HE Grenade",					/obj/item/grenade/syndieminibomb/concussion, 						200),
+		new /datum/data/wasteland_equipment("C4",							/obj/item/grenade/plastic/c4, 										250)
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Jet",							/obj/item/reagent_containers/pill/patch/jet,						30),
@@ -586,7 +589,10 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Great Khan Jorts",				/obj/item/clothing/under/f13/khan/shorts,							10),
 		new /datum/data/wasteland_equipment("Great Khan Booty Shorts",		/obj/item/clothing/under/f13/khan/booty,							10),
 		new /datum/data/wasteland_equipment("Great Khan boots",				/obj/item/clothing/shoes/f13/military/khan,							15),
-		new /datum/data/wasteland_equipment("Great Khan pelt boots",		/obj/item/clothing/shoes/f13/military/khan_pelt,					15)
+		new /datum/data/wasteland_equipment("Great Khan pelt boots",		/obj/item/clothing/shoes/f13/military/khan_pelt,					15),
+		new /datum/data/wasteland_equipment("Stinger Grenade",				/obj/item/grenade/f13/stinger,										200),
+		new /datum/data/wasteland_equipment("HE Grenade",					/obj/item/grenade/syndieminibomb/concussion, 						200),
+		new /datum/data/wasteland_equipment("C4",							/obj/item/grenade/plastic/c4, 										250),
 		)
 
 /obj/machinery/mineral/wasteland_vendor/denvendor

--- a/code/modules/fallout/misc/gangs.dm
+++ b/code/modules/fallout/misc/gangs.dm
@@ -74,8 +74,6 @@ GLOBAL_DATUM_INIT(greatkhans, /datum/gang/greatkhans, new)
 		/datum/gang_item/weapon/brass,
 
 		/datum/gang_item/equipment/emp,
-		/datum/gang_item/equipment/stinger,
-		/datum/gang_item/equipment/he,
 
 		/datum/gang_item/weapon/shuriken,
 		/datum/gang_item/equipment/necklace,


### PR DESCRIPTION
## About The Pull Request
Gives the Casino C4 Blast Doors the Indestructible flag so they can no longer be opened forcefully with C4. Also removed the HE/Stinger/C4 from the Khan gang tool and moved it to their vendor.

## Why It's Good For The Game
Forces the player to go through the dungeon as was intended.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
fix: fixed a few things
add: Khan explosives in vendor
del:  Khan explosives in gang tool
/:cl:
