### PR TITLE
Substantially nerfs the Peacekeeper Revolver

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -252,7 +252,7 @@
 	icon_state = "m29peace"
 	extra_damage = 45
 	automatic = 1
-	autofire_shot_delay = 3
+	autofire_shot_delay = 2.5
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_scope = FALSE
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -252,7 +252,7 @@
 	icon_state = "m29peace"
 	extra_damage = 45
 	automatic = 1
-	autofire_shot_delay = 1
+	autofire_shot_delay = 3
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_scope = FALSE
 


### PR DESCRIPTION

## About The Pull Request

The Peacekeeper Revolver now has a substantial delay between automatic shots instead of firing all six shots in a half-second or so.

( 1 -> 2.5)

## Why It's Good For The Game

I'm sorry, since when were one click-wins fun for this game? At some point we realised 'hey, instant win cards aren't fun!', and so we removed a number of items, such as the combat hypospray, from being able to one shot, yet one of the easiest head roles to unlock has access to, what is, in all honesty, the strongest weapon in the game, being able to one-shot fucking anyone in one click. This isn't balanced. Fucking sue me.

## Changelog


:cl:
balance: Peacekeeper revolver is no longer batshit insane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
