### PR TITLE
intercom for osasis

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -41148,6 +41148,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qfY" = (
+/obj/item/radio/intercom,
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "qga" = (
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/wasteland)
@@ -57226,6 +57230,10 @@
 	pixel_x = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/building)
+"wQn" = (
+/obj/item/radio/intercom,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "wQq" = (
 /obj/item/reagent_containers/food/condiment/soymilk,
@@ -91548,7 +91556,7 @@ bWs
 fsm
 uhi
 ees
-gts
+wQn
 dCV
 cKy
 dCV
@@ -92091,7 +92099,7 @@ rRe
 rRe
 rRe
 tba
-dCV
+qfY
 btW
 uhY
 btW


### PR DESCRIPTION
i hate police
## About The Pull Request
Adds an intercom for each gate in Oasis, one north and one south, since I'm getting annoyed about Oasis going full lockdown without a headset 

![image](https://user-images.githubusercontent.com/13832819/171994353-a84d9b7a-1397-4601-afff-e3cff90af2a8.png)
![image](https://user-images.githubusercontent.com/13832819/171994362-e090b490-1127-49d0-b821-489bb8606eb4.png)


## Why It's Good For The Game

Something about having better access to town without the need of getting a headset/radio just to ask "hey oasis open up?"

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog

:cl:

tweak: adds intercoms for Oasis gates

/:cl:
