### PR TITLE
funny ammo

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -147,14 +147,8 @@
 	..()
 
 /obj/item/projectile/bullet/pellet/trainshot
-	damage = 15
-	stamina = 10
-	armour_penetration = 0.45
-	wound_bonus = 15
-	bare_wound_bonus = 15
-	sharpness = SHARP_NONE //crunch
-	tile_dropoff = 0
-	tile_dropoff_s = 0
+	damage = 15 // less pellets, more dam + tiny bit of pen
+	armour_penetration = 0.01 //works on pa, doesnt shred you at all ranges though
 
 /obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
idk when it got given more pen than most rifles while also having knockback, big wound bonus, 3 pellets a click and no dropoff, but yeah thats gone now. now its just 3pellet PA-penning buckshot that launches people into walls or eachother. anyone with a lever action shotgun and some trainshot could simply spam and do more damage than most rifles could without much thought nor need for aim. if you want to use a shotgun properly at range, slug boys exist

https://user-images.githubusercontent.com/76122712/172455818-87046b80-e882-4fa3-8958-1168e9f9395b.mp4


