### PR TITLE
Reverts the blastmaster changes

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -268,7 +268,10 @@ Raider
 		/obj/item/kitchen/knife/butcher = 1,
 		/obj/item/book/granter/crafting_recipe/blueprint/trapper = 1,
 		/obj/item/radio/headset = 1,	
-		/obj/item/book/granter/trait/explosives = 1
+		/obj/item/book/granter/trait/explosives = 1,
+		/obj/item/bottlecap_mine = 1,
+		/obj/item/grenade/homemade/coffeepotbomb = 4,
+		/obj/item/grenade/homemade/firebomb = 4
 		)
 
 /datum/outfit/loadout/raider_sadist


### PR DESCRIPTION


## About The Pull Request

Reverts the reduction in explosives to the blastmaster made in prior PRs.

## Why It's Good For The Game

They sort of ruined the loadout.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: Reverts the reduction to blastmaster explosives.
/:cl:
