### PR TITLE
Replace Chaplain requirements to Preacher

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -1,4 +1,4 @@
-/obj/item/claymore 
+/obj/item/claymore
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
 	icon_state = "claymore"
@@ -782,7 +782,7 @@
 	if(user.a_intent == INTENT_HARM)
 		return ..()
 
-	if(!user.mind || user.mind.assigned_role != "Chaplain")
+	if(!user.mind || user.mind.assigned_role != "Preacher")
 		to_chat(user, "<span class='notice'>You are not close enough with [deity_name] to use [src].</span>")
 		return
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		return
 	if(GLOB.bible_icon_state) // if there is already a bible icon return FALSE
 		return FALSE
-	if(user.job != "Chaplain") // if the user is not the chaplain, return FALSE
+	if(user.job != "Preacher") // if the user is not the chaplain, return FALSE
 		return FALSE
 
 	var/list/skins = list()
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		return FALSE
 	if(user.incapacitated())
 		return FALSE
-	if(user.job != "Chaplain")
+	if(user.job != "Preacher")
 		return FALSE
 	return TRUE
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -21,10 +21,10 @@
 	var/font_color = "purple"
 	var/prayer_type = "PRAYER"
 	var/deity
-	if(usr.job == "Chaplain")
+	if(usr.job == "Preacher")
 		cross.icon_state = "kingyellow"
 		font_color = "blue"
-		prayer_type = "CHAPLAIN PRAYER"
+		prayer_type = "SANCTIFIED PRAYER"
 		if(GLOB.deity)
 			deity = GLOB.deity
 	else if(iscultist(usr))
@@ -46,7 +46,7 @@
 		if(C.prefs.chat_toggles & CHAT_PRAYER)
 			to_chat(C, msg)
 			if(C.prefs.toggles & SOUND_PRAYERS)
-				if(usr.job == "Chaplain")
+				if(usr.job == "Preacher")
 					SEND_SOUND(C, sound('sound/effects/pray.ogg'))
 				else
 					SEND_SOUND(C, sound('sound/effects/ding.ogg'))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -159,7 +159,7 @@
 
 	if(user.mind)
 		//Chaplains are very good at speaking with the voice of god
-		if(user.mind.assigned_role == "Chaplain")
+		if(user.mind.assigned_role == "Preacher")
 			power_multiplier *= 2
 		//Command staff has authority
 		if(user.mind.assigned_role in GLOB.command_positions)
@@ -619,7 +619,7 @@
 	// Not sure I want to give extra power to anyone at the moment...? We'll see how it turns out
 	if(user.mind)
 		//Chaplains are very good at indoctrinating
-		if(user.mind.assigned_role == "Chaplain")
+		if(user.mind.assigned_role == "Preacher")
 			power_multiplier *= 1.2
 		//Command staff has authority
 		if(user.mind.assigned_role in GLOB.command_positions)

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -591,7 +591,7 @@
 
 	//role resistance
 	//Chaplains are already brainwashed by their god
-	if(owner.mind.assigned_role == "Chaplain")
+	if(owner.mind.assigned_role == "Preacher")
 		deltaResist *= 1.2
 	//Command staff has authority,
 	if(owner.mind.assigned_role in GLOB.command_positions)


### PR DESCRIPTION
Fixes the following that Preachers were supposed to have:
- Choosing your bible
- Using prayer beads
- Special prayer
- Voice of God boost
- Enthrall resist