### PR TITLE
Buffs to janitorial equipment

### DIFF
--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -56,7 +56,7 @@
 	for(var/obj/item/garbage in target.contents)
 		if(!garbage.anchored)
 			step(garbage, sweep_dir)
-		if(++i > 20)
+		if(++i > 40)
 			break
 	if(i)
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -24,7 +24,7 @@
 	throw_speed = 3
 	throw_range = 7
 	grind_results = list(/datum/reagent/lye = 10)
-	var/cleanspeed = 50 //slower than mop
+	var/cleanspeed = 10 //small timer, not instant like mops
 	force_string = "robust... against germs"
 
 /obj/item/soap/Initialize()
@@ -38,17 +38,16 @@
 /obj/item/soap/homemade
 	desc = "A homemade bar of soap. Smells of... well...."
 	icon_state = "soapgibs"
-	cleanspeed = 45 // a little faster to reward chemists for going to the effort
+	cleanspeed = 20 //slower because badly made
 
 /obj/item/soap/deluxe
 	desc = "A deluxe Waffle Co. brand bar of soap. Smells of high-class luxury."
 	icon_state = "soapdeluxe"
-	cleanspeed = 40 //same speed as mop because deluxe -- captain gets one of these
+	cleanspeed = 5 //luxury soap, faster
 
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
-	cleanspeed = 10 //much faster than mop so it is useful for traitors who want to clean crime scenes
 
 /obj/item/soap/suicide_act(mob/user)
 	user.say(";FFFFFFFFFFFFFFFFUUUUUUUDGE!!", forced="soap suicide")

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -68,7 +68,7 @@
 	var/shards_required = 4
 
 /obj/item/lightreplacer/New()
-	uses = max_uses / 2
+	uses = max_uses
 	failmsg = "The [name]'s refill light blinks red."
 	..()
 

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -52,13 +52,12 @@
 
 	var/turf/T = get_turf(A)
 
-	if(istype(A, /obj/item/reagent_containers/glass/bucket) || istype(A, /obj/structure/janitorialcart))
+	if(istype(A, /obj/item/reagent_containers/glass/bucket) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/structure/mopbucket))
 		return
 
 	if(T)
 		user.visible_message("[user] cleans \the [T] with [src].", "<span class='notice'>You clean \the [T] with [src].</span>")
 		clean(T)
-		user.DelayNextAction(CLICK_CD_MELEE)
 		user.do_attack_animation(T, used_item = src)
 		if(istype(L))
 			L.adjustStaminaLossBuffered(stamusage)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -7,7 +7,6 @@
 	item_state = "waterbackpack"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	slowdown = 1
 	actions_types = list(/datum/action/item_action/toggle_mister)
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
@@ -181,7 +180,6 @@
 	item_state = "waterbackpackatmos"
 	icon_state = "waterbackpackatmos"
 	volume = 200
-	slowdown = 0
 
 /obj/item/watertank/atmos/Initialize()
 	. = ..()
@@ -434,7 +432,6 @@
 	item_state = "waterbackpackjani"
 	w_class = WEIGHT_CLASS_NORMAL
 	volume = 2000
-	slowdown = 0
 
 /obj/item/watertank/op/Initialize()
 	. = ..()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -17,7 +17,7 @@
 
 /obj/structure/janitorialcart/Initialize()
 	. = ..()
-	create_reagents(100, OPENCONTAINER)
+	create_reagents(500, OPENCONTAINER)
 
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/mop, mob/user)
 	if(reagents.total_volume < 1)
@@ -185,4 +185,3 @@
 		. += "cart_sign[signs]"
 	if(reagents.total_volume > 0)
 		. += "cart_water"
-

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -10,7 +10,7 @@
 
 /obj/structure/mopbucket/Initialize()
 	. = ..()
-	create_reagents(100, OPENCONTAINER)
+	create_reagents(500, OPENCONTAINER)
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/mop))

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -69,7 +69,6 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.01
 	clothing_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
 	strip_delay = 50
 	equip_delay_other = 50
 	resistance_flags = NONE


### PR DESCRIPTION
Cleaning is less CBT now with these changes.
- Mop has no cooldown
- Soap cleans much faster than it did before
- Janitorial cart and mop bucket have 500 units of capacity, was 100
- Fixes mops cleaning the tile under mop buckets if refilling
- Water backpacks no longer have slowdown (except chemical backpack since it could be very OP if ever spawned)
- Galoshes have no slowdown
- Light replacers start with the full 20 lights, not 10
- Brooms can sweep 40 items at a time, was 20