### PR TITLE
Removal of VR chambers in BOs for the moment + T60 removal.

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -13359,17 +13359,6 @@
 	anchored = 1;
 	name = "power armor frame"
 	},
-/obj/item/clothing/suit/armor/f13/power_armor/t60{
-	anchored = 1;
-	desc = "A broken piece of T-60 powered armor. It is entirely destroyed and un-usable. Developed in early 2077 after the Anchorage Reclamation, the T-60 series of power armor was designed to eventually replace the T-51b as the pinnacle of powered armor technology in the U.S. military arsenal.";
-	name = "Broken T-60a power armor"
-	},
-/obj/item/clothing/head/helmet/f13/power_armor/t60{
-	anchored = 1;
-	desc = "A broken T-60 powered helmet, destroyed to the point it is entirely unusable. Their workable variants however are equipped with, targetting software suite, Friend-or-Foe identifiers, dynamic HuD, and an intersnal music player.";
-	name = "Broken T-60a power helmet";
-	pixel_y = 12
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "hZW" = (
@@ -13743,7 +13732,7 @@
 "ilD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vr_sleeper/bos{
+/obj/structure/fluff/empty_sleeper/nanotrasen{
 	dir = 4
 	},
 /turf/open/floor/circuit/f13_red,
@@ -26632,7 +26621,7 @@
 	},
 /area/f13/den)
 "rle" = (
-/obj/machinery/vr_sleeper/bos{
+/obj/structure/fluff/empty_sleeper/nanotrasen{
 	dir = 4
 	},
 /turf/open/floor/circuit/f13_red,
@@ -29629,7 +29618,7 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "tci" = (
-/obj/machinery/vr_sleeper/bos{
+/obj/structure/fluff/empty_sleeper/nanotrasen{
 	dir = 1
 	},
 /turf/open/floor/circuit/f13_red,
@@ -30606,7 +30595,7 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
 "tKY" = (
-/obj/machinery/vr_sleeper/bos{
+/obj/structure/fluff/empty_sleeper/nanotrasen{
 	dir = 8
 	},
 /turf/open/floor/circuit/f13_red,
@@ -34632,7 +34621,7 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wvD" = (
-/obj/machinery/vr_sleeper/bos,
+/obj/structure/fluff/empty_sleeper/syndicate,
 /turf/open/floor/circuit/f13_red,
 /area/f13/brotherhood/operations)
 "wvW" = (


### PR DESCRIPTION
## About The Pull Request

VR removal from BOS is currently that way, as it seems to be a tad bit "broken" well the statement is ICly. If people would want to request it to be 'fixed' again, then it can be spawnable back in. VR will be back at a later date. So this PR also removes the t60 people were cheesing it by salvaging it.
![image](https://user-images.githubusercontent.com/29418371/174393739-9c457a7e-f223-4994-88d9-4c18fdab40a6.png)
![image](https://user-images.githubusercontent.com/29418371/174393750-3fc6f0ab-ce71-48c0-9379-5a884d292642.png)

## Why It's Good For The Game

It is good for the moment, makes things a bit better and healthier.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
remap: VR + t60 removal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
