### PR TITLE
kills fucking plasma rifles easly rushable round start + more dense rocks

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -14725,7 +14725,7 @@
 /area/f13/brotherhood/medical)
 "iYB" = (
 /obj/effect/mob_spawn/human/corpse/bs,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
@@ -17585,7 +17585,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
 	},
@@ -23370,7 +23370,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plasteel/freezer,
-/area/f13/bunker)
+/area/f13/caves)
 "phc" = (
 /obj/item/bodypart/l_arm,
 /obj/effect/decal/cleanable/dirt,
@@ -34467,6 +34467,9 @@
 "wtE" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/mining)
+"wtK" = (
+/turf/open/floor/plasteel/freezer,
+/area/f13/caves)
 "wuj" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	desc = "All hail the Chinese Communist Party!"
@@ -67891,7 +67894,7 @@ nsN
 nNF
 ofI
 owX
-nOW
+wtK
 pgw
 pCJ
 fLU
@@ -75848,7 +75851,7 @@ fxu
 eLE
 eLE
 cJH
-eLE
+fLU
 fLU
 xSi
 fxu
@@ -76104,8 +76107,8 @@ eLE
 eLE
 vPg
 vPg
-vPg
 eLE
+fLU
 ase
 fxu
 fxu
@@ -76361,7 +76364,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+eLE
 cJH
 avu
 fxu
@@ -76618,7 +76621,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+eLE
 cJH
 axe
 fxu
@@ -76875,7 +76878,7 @@ aoj
 vPg
 vPg
 vPg
-vPg
+aoj
 eLE
 vPg
 vPg


### PR DESCRIPTION
fuck plasma

## About The Pull Request
Changes 2 easily accessible round start spawns of high tier energy weapons into mid-high, chancing the 25% plasma rifle spawn into few weaker energy weapons 
(The changes are in the deathclaw cave and the Russian commie bunker)
![image](https://user-images.githubusercontent.com/13832819/174484737-6780a49c-6070-4d79-8f20-bced78a9f994.png)

Also:
Adds dense rock behind static PA spawn since people would dig there and use thermite to break the walls to skip the entire dungeon round start
![image](https://user-images.githubusercontent.com/13832819/174484757-2fb32b4d-8c27-46d8-8161-20924a79ae69.png)



## Why It's Good For The Game
No more meta rushers going for quick plasma weapons and power armour
## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: changes few weapon spawns for weaker variants
tweak: no longer you can use thermite to get free PA
/:cl:

