### PR TITLE
ATVs + Janicarts at No mans land kill, No more.

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -2516,6 +2516,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ete" = (
+/obj/machinery/porta_turret/xray{
+	faction = list("hostile");
+	name = "old turret"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "eub" = (
 /obj/structure/debris/v3{
 	pixel_x = -11;
@@ -25626,12 +25633,12 @@ xdX
 xdX
 xdX
 xdX
-ksx
+ete
 ksx
 ulp
 vOG
 ksx
-ksx
+ete
 nGs
 xdX
 nGs

--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -1949,10 +1949,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"dBP" = (
-/obj/vehicle/ridden/janicart,
-/turf/open/floor/circuit/red,
-/area/f13/legion)
 "dCA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2519,10 +2515,6 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
-"ete" = (
-/obj/vehicle/ridden/atv/turret,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "eub" = (
 /obj/structure/debris/v3{
@@ -21292,7 +21284,7 @@ rgU
 obO
 obO
 obO
-dBP
+obO
 obO
 obO
 obO
@@ -25634,12 +25626,12 @@ xdX
 xdX
 xdX
 xdX
-ete
+ksx
 ksx
 ulp
 vOG
 ksx
-ete
+ksx
 nGs
 xdX
 nGs


### PR DESCRIPTION
## About The Pull Request

Free ATVs at the nam no mans land, is a big NO. Janicart is gone but key is still there. They are removed and placed with turrets which dont kill mobs.

## Why It's Good For The Game

Better for the gameplay

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
replace: ATV with regular turrets
remove: Janicart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
