### PR TITLE
Armor plating for the captains coat custom loadout and some weapon changes

### DIFF
--- a/code/modules/clothing/suits/suit_fashion.dm
+++ b/code/modules/clothing/suits/suit_fashion.dm
@@ -437,12 +437,20 @@
 	unique_reskin = list("M1" = "co_bomber" ,"M2" = "bomber_open")
 	always_reskinnable = "True"
 
+/obj/item/clothing/suit/armor/f13/rangercombat/eliteriot/reclaimed/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)
+
 /obj/item/clothing/suit/bomber_open
 	name = "A fancy bomber jacket."
 	desc = "A nice leather jacket with a fur lined collar that's been unzipped for comfort."
 	icon_state = "bomber_open"
 	item_state = "bomber_open"
 	armor = list("melee" = 35, "bullet" = 50, "laser" = 45, "energy" = 20, "bomb" = 50, "bio" = 0, "rad" = 20, "fire" = 60, "acid" = 30)
+
+/obj/item/clothing/suit/armor/f13/rangercombat/eliteriot/reclaimed/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)	
 
 /* uncomment when old system cleaned out
 /obj/item/clothing/suit/cardborg/equipped(mob/living/user, slot)

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -275,7 +275,7 @@
 	fire_delay = 3
 	force = 15
 	extra_damage = 38
-	extra_penetration = 0.05
+	extra_penetration = 0.1
 	extra_speed = 300
 	recoil = 0.2
 	can_suppress = FALSE

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -381,7 +381,7 @@
 /obj/item/gun/ballistic/revolver/needler
 	name = "Needler pistol"
 	desc = "You suspect this Bringham needler pistol was once used in scientific field studies. It uses small hard-plastic hypodermic darts as ammo. "
-	extra_damage = 21
+	extra_damage = 35
 	icon_state = "needler"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -325,7 +325,7 @@
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"
-	damage = 33
+	damage = 35
 
 /obj/item/projectile/beam/laser/lasgun/hitscan //hitscan aer9 test
 	name = "laser beam"
@@ -420,7 +420,7 @@
 
 /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
 	name = "penetrating laser beam"
-	damage = 15
+	damage = 20
 	hitscan = TRUE
 	armour_penetration = 0.2 //rare laser to keep its AP, since base model is so bad
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -562,14 +562,14 @@
 
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
-	damage = 38
+	damage = 39
 	armour_penetration = 0.6
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/aer14/hitscan
-	damage = 32
+	damage = 39
 	wound_bonus = 20
 	armour_penetration = 0.05
 	tracer_type = /obj/effect/projectile/tracer/pulse
@@ -588,7 +588,7 @@
 
 /obj/item/projectile/beam/laser/aer12 //AER12
 	name = "laser beam"
-	damage = 34
+	damage = 35
 	armour_penetration = 0.55
 	icon_state = "xray"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
@@ -596,7 +596,7 @@
 
 /obj/item/projectile/beam/laser/aer12/hitscan
 	name = "laser beam"
-	damage = 28
+	damage = 30
 	hitscan = TRUE
 	armour_penetration = 0.02
 	tracer_type = /obj/effect/projectile/tracer/xray

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -111,7 +111,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 11
+	damage = 12
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank


### PR DESCRIPTION
Mirrors the ability to plate the captains armor for a donors custom modkit. Once they use the modkit they can't plate their reskinned armor anymore so I fixed that for them

Buffed buckshot by 1 damage

Buffed a few laser beams by 1-2 damage each.

Gave the desert eagle more penetration because its lackluster in it's current state.

Buffed the needler because once AP was removed it became utterly useless, now its at least somewhat decent with mid level damage but still no pen.