### PR TITLE
Fixed Oasis bunker

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -443,6 +443,10 @@
 	name = "temple wall"
 	},
 /area/f13/bunker)
+"blF" = (
+/obj/effect/landmark/map_load_mark/dungeons/oasisbunker,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "bms" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -3698,6 +3702,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
+"hhS" = (
+/obj/effect/landmark/map_load_mark/dungeons/north,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "hil" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -49659,7 +49667,7 @@ heT
 heT
 heT
 heT
-heT
+hhS
 heT
 heT
 heT
@@ -67362,7 +67370,7 @@ heT
 heT
 heT
 heT
-heT
+blF
 heT
 heT
 heT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Title

## Why It's Good For The Game

Because I removed it by accident

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added the Oasis bunker back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
