### PR TITLE
some map changes, mainly QoL/small dungeon changes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -4664,6 +4664,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/ncr)
+"bQk" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/bunker)
 "bQr" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -11771,6 +11777,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/village)
+"eKt" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plasteel/barber{
+	icon_state = "platingdmg3"
+	},
+/area/f13/bunker)
 "eKz" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -36891,6 +36903,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"oqU" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/bunker)
 "oqV" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -41817,6 +41836,7 @@
 "qqQ" = (
 /obj/item/clothing/head/helmet/f13/power_armor/excavator,
 /obj/item/clothing/suit/armor/f13/power_armor/excavator,
+/obj/structure/closet/crate/secure,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qqW" = (
@@ -97477,7 +97497,7 @@ qbD
 byv
 bRT
 boD
-boD
+oqU
 dwR
 qbD
 qbD
@@ -97996,7 +98016,7 @@ boD
 qbD
 mDM
 jXh
-lFD
+eKt
 mDM
 jXh
 lFD
@@ -99792,7 +99812,7 @@ gcK
 gcK
 qbD
 hre
-lxW
+bQk
 lxW
 mEh
 lxW

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -17451,7 +17451,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "lfs" = (
-/obj/machinery/workbench,
+/obj/machinery/autolathe/constructionlathe,
 /obj/structure/sink/kitchen{
 	dir = 8;
 	pixel_x = 12
@@ -19996,7 +19996,7 @@
 	},
 /area/f13/clinic)
 "nhH" = (
-/obj/machinery/autolathe,
+/obj/machinery/workbench,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -30318,7 +30318,7 @@
 "uHZ" = (
 /obj/machinery/defibrillator_mount/loaded,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood)
 "uIm" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/glasses/regular,
@@ -79508,12 +79508,12 @@ nLq
 jSy
 mDq
 vPg
-eLE
-eLE
+vPg
+vPg
 vPg
 aoj
-eLE
-eLE
+vPg
+vPg
 vPg
 dXE
 wFD
@@ -79768,7 +79768,7 @@ vPg
 vPg
 vPg
 aoj
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -80765,10 +80765,10 @@ vPg
 aoj
 aoj
 vPg
-eLE
-eLE
-eLE
-eLE
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -81019,8 +81019,8 @@ vPg
 vPg
 vPg
 vPg
-eLE
-eLE
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -81276,7 +81276,7 @@ vPg
 vPg
 vPg
 aoj
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -89997,8 +89997,8 @@ twI
 twI
 fUG
 fUG
-dBk
-dBk
+uHZ
+uHZ
 dBk
 dBk
 dBk
@@ -90252,12 +90252,12 @@ uoc
 uoc
 naX
 naX
-uHZ
+ujt
 xJp
 qSY
 xhj
 rXz
-uHZ
+ujt
 xgN
 dBk
 dBk


### PR DESCRIPTION
## About The Pull Request
Starting with BoS:
![image](https://user-images.githubusercontent.com/13832819/175768627-585bd9da-4880-4d57-b945-70516ca73e81.png)
Botany has autolathe and the workbench switched around so stims can now be created a bit easier
![image](https://user-images.githubusercontent.com/13832819/175768649-69dc4ce2-be52-432d-b0be-cae98775b5a2.png)
Wall defibs now work since last time I put them on the wrong walls without checking, my bad

Also removed random dense rocks around sewers that were from old dungeons and did nothing but randomly block the way

Surface:
![image](https://user-images.githubusercontent.com/13832819/175768706-44c0f266-c554-4925-976b-699cb46331cf.png)
Old nuclear silo gets few more Mr. handies as protection since I'm tired of watching people go in there around the salvage and rush in just to get a laser gun by not even killing that Gutsy protecting it

![image](https://user-images.githubusercontent.com/13832819/175768737-f6836e6c-1abd-406e-becb-22be68447042.png)
Excavator PA is now in a secured chest since people would rush in and just take it before deathclaws killed them, now they at least have to do the funny minigame instead of just picking it up by rush


## Why It's Good For The Game

minor QoL and making few things a bit less rushable/avoidable 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog
:cl:
tweak: few things changed around the BoS, mainly botany/operation
balance: made some surface dungeons a bit more challenging/less possible to blindly rush
/:cl: