### PR TITLE
some nerfs

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -13918,7 +13918,9 @@
 	},
 /area/f13/building)
 "fBm" = (
-/obj/machinery/mineral/wasteland_trader,
+/obj/machinery/mineral/wasteland_trader{
+	goods_list = list(/obj/item/stack/sheet/mineral/diamond = 20, /obj/item/stack/sheet/mineral/gold = 10, /obj/item/stack/sheet/mineral/silver = 5, /obj/item/stack/sheet/metal = 1.5, /obj/item/reagent_containers/food/snacks/grown/wheat = 1, /obj/item/reagent_containers/food/snacks/grown/rice = 1, /obj/item/reagent_containers/food/snacks/grown/oat = 1, /obj/item/stack/sheet/hay = 1, /obj/item/reagent_containers/food/snacks/grown/broc = 5, /obj/item/reagent_containers/food/snacks/grown/xander = 5, /obj/item/reagent_containers/food/snacks/grown/pungafruit = 5, /obj/item/reagent_containers/food/snacks/grown/feracactus = 5, /obj/item/reagent_containers/food/snacks/grown/fungus = 5, /obj/item/reagent_containers/food/snacks/grown/agave = 5, /obj/item/reagent_containers/pill/patch/jet = 10, /obj/item/reagent_containers/pill/patch/healingpowder = 30, /obj/item/reagent_containers/hypospray/medipen/psycho = 20, /obj/item/reagent_containers/hypospray/medipen/medx = 75, /obj/item/reagent_containers/pill/patch/healpoultice = 50, /obj/item/reagent_containers/hypospray/medipen/stimpak = 25, /obj/item/reagent_containers/hypospray/medipen/stimpak/super = 50)
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -90,8 +90,8 @@
 	name = "Legendary Raider"
 	desc = "Another murderer churned out by the wastes - this one seems a bit faster than the average..."
 	color = "#FFFF00"
-	maxHealth = 450
-	health = 450
+	maxHealth = 400
+	health = 400
 	speed = 1.2
 	obj_damage = 300
 	aggro_vision_range = 15
@@ -102,8 +102,8 @@
 	name = "Legendary Raider"
 	desc = "Another murderer churned out by the wastes, wielding a decent pistol and looking very strong"
 	color = "#FFFF00"
-	maxHealth = 600
-	health = 600
+	maxHealth = 450
+	health = 450
 	retreat_distance = 1
 	minimum_distance = 2
 	projectiletype = /obj/item/projectile/bullet/m44/simple


### PR DESCRIPTION
:)
## About The Pull Request

Changes the selling price of stims/supers from 50/100 to 25/50 since it was printing way too many fucking caps

Legendary raiders got their HP changed:

Melee from 450 to 400
Ranged from 600 (the health of a normal deathclaw btw) into 450

## Why It's Good For The Game
Saves the economy maybe and the Legendary Raiders with health of a deathclaw was annoying

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

:cl:
tweak: kills the stim selling economy maybe?
balance: raiders no longer have health of a normal deathclaw
/:cl:

