### PR TITLE
Legion Roles

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -238,18 +238,16 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	mask = /obj/item/clothing/mask/bandana/legion/legcenturion
 	ears = /obj/item/radio/headset/headset_legion/cent
 	neck = /obj/item/clothing/neck/mantle/legion
-	gloves = /obj/item/melee/unarmed/powerfist/goliath
+	gloves = /obj/item/clothing/gloves/legion/plated
 	glasses = /obj/item/clothing/glasses/night/polarizing
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	r_pocket = /obj/item/restraints/handcuffs
 	l_pocket = /obj/item/flashlight/lantern
 	box = /obj/item/storage/survivalkit_tribal/chief
 	backpack_contents = list(
-		/obj/item/restraints/legcuffs/bola = 1,
+		/obj/item/book/granter/martial/cqc = 1,
 		/obj/item/storage/bag/money/small/legion = 1,
 		/obj/item/warpaint_bowl = 1,
-		/obj/item/ammo_box/a357 = 1,
-		/obj/item/gun/ballistic/revolver/colt357 = 1,
 		/obj/item/binoculars = 1,
 		)
 
@@ -540,13 +538,13 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/warpaint_bowl = 1,
 		/obj/item/ammo_box/tube/a357 = 3,
+		/obj/item/melee/unarmed/powerfist/goliath,
 		)
 
 /datum/outfit/loadout/vexbear
 	name = "Mountain Bear"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/combvexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 
@@ -554,7 +552,6 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Desert Fox"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/vexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 
@@ -562,7 +559,6 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Night Stalker"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/nightvexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 


### PR DESCRIPTION
Gives the vex the goliath instead of the centurion,
Gives the cent CQC back.
Removes the .357 from cent (its both never used and leaving it in would just be iffy on balance)



## About The Pull Request

Legate (admin spawn) has higher armor, a bag and CQC now. You admins can now have a round where you don't have less armor then the cent. You are also an admin so... Try not to break the game? You have really fucking powerful gear. Don't abuse it please! (I know they will anyways but eh, why not.)

Vex the melee king is now given a goliath instead of a spatha. Because it makes a LOT more sense.

Centurion is given CQC again, there is no reason to remove it as it doesn't really become OP until its abused via bugs/exploits. 

## Why It's Good For The Game

Legate buffed for admins to abuse, vex given better melee, why not.

Vex is supposed to be a melee loadout with a flag on their back and a melee in-hand but at the moment they're just ranged. This way you can start going ape and melee sweat as a vex. 

CQC Cent is back, I know people will mald about this but I'll be straight, there are not many scenarios where CQC cent is OP as fuck. Their CQC is being nerfed in the next PR so don't get too comfy. Next PR involving CQC will remove their insta-knockout from kicking them on the floor. Because yeah, insta-knockouts are dumb as fuck.

Legate also spawns with CQC now so admins can fight CQC cent and fight in general. They're apes now. Enjoy.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
