### PR TITLE
Bobs hellhole (Legion buff)

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -52,8 +52,8 @@
 		D.DefaultCombatKnockdown(120)
 		log_combat(A, D, "slammed (CQC)")
 	return TRUE
-
-/datum/martial_art/cqc/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/*
+ /datum/martial_art/cqc/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
 	var/damage = damage_roll(A,D)
@@ -76,7 +76,8 @@
 		var/atom/throw_target = get_edge_target_turf(D, A.dir)
 		D.throw_at(throw_target, 1, 14, A)
 		log_combat(A, D, "kicked (CQC)")
-	return TRUE
+	return TRUE 
+*/
 
 /datum/martial_art/cqc/proc/Pressure(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))

--- a/code/modules/clothing/gloves/f13gloves.dm
+++ b/code/modules/clothing/gloves/f13gloves.dm
@@ -188,4 +188,4 @@
 	icon_state = "legion_legate"
 	item_state = "legion_legate"
 	transfer_prints = FALSE
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 35, "energy" = 20, "bomb" = 35, "bio" = 35, "rad" = 35, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 45, "bullet" = 45, "laser" = 55, "energy" = 20, "bomb" = 35, "bio" = 35, "rad" = 15, "fire" = 0, "acid" = 0)

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -475,7 +475,7 @@
 	desc = "A custom forged steel full helmet complete with abstract points and arches. The face is extremely intimidating, as it was meant to be. This particular one was ordered to be forged by Caesar, given to his second legate in exchange for his undying loyalty to Caesar."
 	icon_state = "legion-legate"
 	item_state = "legion-legate"
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 60)
+	armor = list("melee" = 80, "bullet" = 80, "laser" = 80, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 10, "fire" = 80, "acid" = 0, "wound" = 60)
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR
 	resistance_flags = LAVA_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -318,7 +318,7 @@
 	icon_state = "legion_legate"
 	item_state = "legion_legate"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
+	armor = list("melee" = 80, "bullet" = 80, "laser" = 80, "energy" = 35, "bomb" = 45, "bio" = 60, "rad" = 10, "fire" = 80, "acid" = 0)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 15) // Wouldn't it be hilarious if we just tore apart Legate's armor?
 
 /obj/item/clothing/suit/armor/f13/combat/legion

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -131,16 +131,20 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit = /obj/item/clothing/suit/armor/f13/legion/legate
 	head = /obj/item/clothing/head/helmet/f13/legion/legate
 	gloves = /obj/item/clothing/gloves/legion/legate
-	glasses = /obj/item/clothing/glasses/sunglasses/big
+	glasses = /obj/item/clothing/glasses/night/polarizing
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
 	r_pocket = /obj/item/storage/bag/money/small/legion
 	l_pocket = /obj/item/flashlight/lantern
 	r_hand = /obj/item/melee/unarmed/powerfist/goliath
 	l_hand = /obj/item/tank/internals/oxygen
-	backpack = null
-	satchel = null
 	ears = /obj/item/radio/headset/headset_legion/cent
 	box = /obj/item/storage/box/legate
+		backpack_contents = list(
+		/obj/item/book/granter/martial/cqc = 1,
+		/obj/item/storage/bag/money/small/legion = 1,
+		/obj/item/warpaint_bowl = 1,
+		/obj/item/binoculars = 1,
+		)
 
 
 // ORATOR

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -238,18 +238,16 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	mask = /obj/item/clothing/mask/bandana/legion/legcenturion
 	ears = /obj/item/radio/headset/headset_legion/cent
 	neck = /obj/item/clothing/neck/mantle/legion
-	gloves = /obj/item/melee/unarmed/powerfist/goliath
+	gloves = /obj/item/clothing/gloves/legion/plated
 	glasses = /obj/item/clothing/glasses/night/polarizing
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	r_pocket = /obj/item/restraints/handcuffs
 	l_pocket = /obj/item/flashlight/lantern
 	box = /obj/item/storage/survivalkit_tribal/chief
 	backpack_contents = list(
-		/obj/item/restraints/legcuffs/bola = 1,
+		/obj/item/book/granter/martial/cqc = 1,
 		/obj/item/storage/bag/money/small/legion = 1,
 		/obj/item/warpaint_bowl = 1,
-		/obj/item/ammo_box/a357 = 1,
-		/obj/item/gun/ballistic/revolver/colt357 = 1,
 		/obj/item/binoculars = 1,
 		)
 
@@ -540,13 +538,13 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/warpaint_bowl = 1,
 		/obj/item/ammo_box/tube/a357 = 3,
+		/obj/item/melee/unarmed/powerfist/goliath,
 		)
 
 /datum/outfit/loadout/vexbear
 	name = "Mountain Bear"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/combvexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 
@@ -554,7 +552,6 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Desert Fox"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/vexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 
@@ -562,7 +559,6 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Night Stalker"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/nightvexil
 	backpack_contents = list(
-		/obj/item/melee/onehanded/machete/spatha = 1,
 		/obj/item/grenade/plastic/c4 = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request

Cent and Vex having a few switch-arounds. 

Vex gets the Goliath now

Legate also buffed for admins because I've used them before, their loadout is aids. Not that it matters much tbh

## Why It's Good For The Game
Vex given better melee, no real change to their armor/speed. Gives them the goliath so the vex can be a lot more known for melee as the spatha is good but it isn't used at all. And buffing the spatha would end up buffing more then 1 loadout. So. Lazy solution is there.

Cent given CQC. Yeah I did it. CQC is soon to also have another nerf but until then I want to see how CQC effects players in-game a bit more as the short while I've seen it, it isn't OP or as broken as people claim it to be. I've only seen a handful of scenarios where someone dies to CQC because they chose to rush cent with melee or rush cent in general.

Legate also gains a buff. Not that its really used but for admins I've seen admins spawn in as legate and having to THEN spawn bags/books/ammo e.c.t. This way legate can have their bag e.c.t. Their armor is also buffed to what imo it should be. AKA: High as fuck. 

Admins can now spawn in as a legate without var.edit spamming their armor until its better. 

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.