### PR TITLE
i'm tired BoS(s)

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -86,9 +86,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "ade" = (
-/obj/machinery/smartfridge,
-/turf/open/space/basic,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "adr" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/handrail/g_central{
@@ -177,6 +181,12 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"agn" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/orange,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "agw" = (
 /obj/machinery/door/poddoor{
 	id = "soup"
@@ -269,6 +279,13 @@
 /obj/structure/falsewall/rust,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ajx" = (
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ajG" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -294,24 +311,26 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "alI" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	name = "Head Paladin Billet";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 2
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_y = 10
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
+"alQ" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "amD" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -510,23 +529,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "avj" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_y = 32
-	},
-/obj/structure/chair/comfy/beige,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/sentinel,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/dorms)
 "avk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -950,7 +959,7 @@
 	},
 /area/f13/sewer)
 "aLM" = (
-/obj/structure/chair/office/dark{
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
 /turf/open/floor/f13{
@@ -988,20 +997,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aNt" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/obj/item/gun/energy/laser/rcw{
-	anchored = 1;
-	cell_type = null;
-	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
-	name = "display laser RCW";
-	pin = null;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/wood/fancy,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "aOi" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib2_flesh"
@@ -1054,16 +1053,10 @@
 	},
 /area/f13/building)
 "aQb" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
 	},
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "aQc" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1110,9 +1103,14 @@
 	},
 /area/f13/building)
 "aSi" = (
-/obj/machinery/computer/card/bos,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/obj/machinery/door/airlock/grunge{
+	name = "Head Paladin Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "aSo" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall/rust,
@@ -1181,10 +1179,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aVi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/offices2nd)
 "aVU" = (
 /obj/structure/flora/rock/pile/largejungle{
 	layer = 3.2;
@@ -1302,6 +1301,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
+"aZm" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "aZp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -1485,9 +1492,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bde" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "bdf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -1552,16 +1564,19 @@
 	},
 /area/f13/brotherhood/rnd)
 "bfc" = (
-/obj/structure/fluff/railing{
-	dir = 9
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood)
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "bfu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -1602,6 +1617,21 @@
 	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood/leisure)
+"bhg" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "bhA" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1;
@@ -1641,6 +1671,15 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"bjx" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "bjI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1737,12 +1776,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "blV" = (
-/obj/structure/furnace,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "bmf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -1892,12 +1930,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/tunnel)
-"brY" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "bsi" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1952,15 +1984,6 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"btc" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Admin Accommodation";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "btx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2272,15 +2295,20 @@
 	},
 /area/f13/tunnel)
 "bBA" = (
-/obj/structure/fluff/railing{
-	dir = 6
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/obj/structure/fluff/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "bBM" = (
 /obj/item/pickaxe/drill,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bCe" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "bCh" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -2346,19 +2374,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "bEm" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "bEp" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2542,14 +2561,14 @@
 	},
 /area/f13/enclave)
 "bLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "bLy" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13{
@@ -2810,13 +2829,18 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "bRw" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/paper_bin,
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
+"bRL" = (
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "bRV" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/f13{
@@ -2948,15 +2972,6 @@
 /obj/item/clothing/under/rank/security/officer/blueshirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"bXJ" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
 "bXM" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -3164,16 +3179,10 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cdu" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cdQ" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -3215,12 +3224,7 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cfu" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices2nd)
 "cfB" = (
 /obj/effect/decal/cleanable/dirt{
@@ -3446,18 +3450,6 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/caves)
-"cmM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "cnf" = (
 /obj/item/electronics/apc,
 /obj/item/stack/cable_coil,
@@ -3553,25 +3545,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cqG" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/leisure)
 "cqI" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3806,10 +3784,10 @@
 	},
 /area/f13/sewer)
 "cAf" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "cAi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3943,9 +3921,7 @@
 	},
 /area/f13/tunnel)
 "cDY" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
-	},
+/turf/open/floor/wood/f13/stage_l,
 /area/f13/brotherhood)
 "cEh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4029,25 +4005,7 @@
 	},
 /area/f13/sewer)
 "cGV" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/oak,
 /area/f13/brotherhood)
 "cGZ" = (
 /obj/structure/table/booth,
@@ -4165,16 +4123,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cLG" = (
-/obj/structure/fluff/railing{
-	dir = 5
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/chemistry)
 "cLK" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -4245,11 +4198,6 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
-"cOc" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
 "cOd" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/closed/mineral/random/low_chance,
@@ -4315,7 +4263,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "cQN" = (
-/obj/effect/landmark/start/f13/knightcap,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cQW" = (
@@ -4360,12 +4311,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "cSe" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/table,
+/obj/item/melee/onehanded/machete/training,
+/obj/item/melee/onehanded/machete/training,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/leisure)
 "cSq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
@@ -4412,14 +4364,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"cUh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
-	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "cUk" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -4524,12 +4468,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"cYh" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "cYk" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/remains{
@@ -4626,11 +4564,18 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "dcO" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/keg,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
+	},
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "ddg" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/f13{
@@ -4788,6 +4733,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
+"djq" = (
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "djS" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -5084,6 +5037,16 @@
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"dtG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "duv" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -5239,6 +5202,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
+"dzf" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "dzs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -5289,6 +5258,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
+"dAy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/medical{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood/medical)
 "dAO" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -6923,15 +6901,6 @@
 "eDX" = (
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"eEh" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/machinery/flasher/portable,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
 "eEq" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7268,6 +7237,14 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"eMo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/wrench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "eMx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
@@ -7375,9 +7352,19 @@
 	},
 /area/f13/brotherhood)
 "ePO" = (
-/obj/structure/table,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/button/door{
+	id = "sentdorm";
+	normaldoorcontrol = 1;
+	pixel_y = 32;
+	specialfunctions = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/rd{
+	desc = "A fine quilted blanket, made with purple and yellow fabric.";
+	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
+	name = "fine bedsheet"
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "ePT" = (
 /obj/structure/nest/deathclaw,
@@ -7656,6 +7643,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"faB" = (
+/obj/machinery/computer/card/bos,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "faQ" = (
 /obj/machinery/door/airlock/vault{
 	name = "Fort Hazard";
@@ -7663,6 +7654,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"fbn" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "fbz" = (
 /obj/structure/fence/pole_b,
 /obj/effect/decal/cleanable/dirt{
@@ -7677,11 +7675,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fce" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "fcz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Fort Hazard Holding Cell";
@@ -7735,10 +7728,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
-"feI" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "ffy" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -8012,10 +8001,16 @@
 	},
 /area/f13/building)
 "fnq" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/structure/fluff/railing{
+	dir = 5
 	},
-/area/f13/brotherhood/archives)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
+/area/f13/brotherhood)
 "fnD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -8160,14 +8155,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "frt" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/figure/hos{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Paladin Action Figure";
-	toysay = "SEMPER INVICTA!"
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
 	},
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/wood/f13/old,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "frz" = (
 /obj/structure/chair/stool/retro/tan,
@@ -8279,13 +8270,27 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "fvU" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Power Armor Maintenance Room";
-	req_access_txt = "120"
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "fwa" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -8304,9 +8309,54 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "fww" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "fwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -8415,10 +8465,13 @@
 	},
 /area/f13/building)
 "fzc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "fzj" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8670,16 +8723,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"fIc" = (
-/obj/structure/sign/poster/prewar/poster63{
-	pixel_y = 32
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "fIf" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -8719,12 +8762,7 @@
 	},
 /area/f13/enclave)
 "fJs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/wrench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
 "fJG" = (
 /obj/structure/chair/wood{
@@ -8846,7 +8884,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "fMP" = (
-/turf/closed/wall/r_wall,
+/obj/structure/anvil/obtainable{
+	anvilquality = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "fMQ" = (
 /obj/structure/flora/junglebush/c,
@@ -8960,11 +9004,13 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fQb" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/chair/wood/fancy{
+	dir = 1
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
+	},
+/area/f13/brotherhood)
 "fQt" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/white/box,
@@ -9035,14 +9081,14 @@
 	},
 /area/f13/clinic)
 "fSi" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "fSl" = (
 /obj/structure/window/fulltile/ruins/broken,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9117,18 +9163,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fUs" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/pda{
-	icon_state = "pda-warden";
-	name = "Armory Warden PDA"
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
 	},
-/obj/item/storage/belt/holster,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/gloves/combat,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "fUu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9146,10 +9185,6 @@
 	},
 /turf/open/floor/wood,
 /area/f13/bunker)
-"fUG" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
 "fUQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9217,6 +9252,12 @@
 /obj/structure/chair/left,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"fXl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "fXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9354,13 +9395,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gcj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/item/clothing/shoes/laceup{
+	pixel_x = 6;
+	pixel_y = -12
 	},
-/obj/machinery/light/floor,
-/obj/structure/fluff/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "gcD" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -9394,15 +9434,6 @@
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gdz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/medical{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
 "gdH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9584,18 +9615,54 @@
 	},
 /area/f13/bunker)
 "gkX" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
 	},
-/obj/item/flashlight/lamp{
-	pixel_y = 11
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
 	},
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
-	pixel_x = 16;
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
 	pixel_y = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -9707,11 +9774,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "gqM" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = -6;
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "gqW" = (
 /obj/structure/pondlily_small{
 	pixel_x = 34;
@@ -9732,6 +9800,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"gse" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "gsv" = (
 /obj/structure/decoration/hatch{
 	dir = 1;
@@ -9748,14 +9821,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gtv" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/door/airlock/grunge{
+	name = "Power Armor Maintenance Room";
+	req_access_txt = "120"
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/armory)
 "gtx" = (
 /obj/effect/decal/waste{
 	pixel_x = -5;
@@ -9969,14 +10042,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gAb" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood)
 "gAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper,
@@ -10056,13 +10132,15 @@
 /turf/open/indestructible/ground/outside/river,
 /area/f13/bunker)
 "gCM" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/obj/item/dice/d1,
-/turf/open/floor/plating/tunnel,
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
 /area/f13/brotherhood)
 "gCN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10385,13 +10463,13 @@
 	},
 /area/f13/bunker)
 "gOq" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood)
 "gOG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10434,10 +10512,17 @@
 	},
 /area/f13/bunker)
 "gPu" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/effect/overlay/junk/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "gPy" = (
 /obj/structure/sign/poster/contraband/buzzfuzz{
 	pixel_y = -32
@@ -10492,14 +10577,11 @@
 	},
 /area/f13/building)
 "gRd" = (
-/obj/structure/anvil/obtainable{
-	anvilquality = 10
-	},
+/obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "gRe" = (
 /obj/item/crowbar,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -10773,23 +10855,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gZQ" = (
-/obj/structure/table,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "gZR" = (
 /obj/structure/fluff/rails,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "haJ" = (
+/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "hcp" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -10826,11 +10909,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"hdP" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "hdT" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -10855,6 +10933,14 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
+"heQ" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "hfr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -10871,10 +10957,15 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hgp" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/obj/structure/plasticflaps,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill{
+	pixel_y = -10
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hgy" = (
@@ -10891,13 +10982,12 @@
 	},
 /area/f13/tcoms)
 "hhe" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "hhi" = (
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -11538,14 +11628,6 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"hNG" = (
-/obj/structure/bed/dogbed,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Paladin Ramos"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "hNO" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/building)
@@ -11642,12 +11724,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
 "hQs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/turf/open/floor/plating/tunnel,
+/obj/item/gun/energy/laser/rcw{
+	anchored = 1;
+	cell_type = null;
+	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
+	name = "display laser RCW";
+	pin = null;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hQy" = (
 /obj/structure/chair/wood{
@@ -11679,29 +11768,28 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "hSp" = (
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "hSz" = (
-/obj/effect/decal/cleanable/robot_debris/limb{
-	layer = 1.5
-	},
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_white,
-/obj/item/stack/cable_coil/random/five,
-/obj/item/circuitboard/machine/ore_silo,
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/rnd)
 "hTd" = (
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "hTw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11824,16 +11912,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "hXe" = (
-/obj/structure/fluff/railing{
-	dir = 6
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/lattice{
-	density = 1
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "hXt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -11842,10 +11933,6 @@
 	pixel_x = 32
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/brotherhood)
-"hXR" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "hXT" = (
 /obj/machinery/newscaster/security_unit{
@@ -11865,17 +11952,13 @@
 	},
 /area/f13/bunker)
 "hYB" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin,
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "hYZ" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -11885,8 +11968,17 @@
 /turf/open/water,
 /area/f13/sewer)
 "hZA" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood)
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "hZW" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -12123,12 +12215,15 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "ija" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/fluff/railing{
+	dir = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/lattice{
+	density = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "iji" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -12171,14 +12266,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ilD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/table,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "imd" = (
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12224,28 +12319,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "ioI" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ioN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12274,22 +12350,9 @@
 	},
 /area/f13/bunker)
 "ipB" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/machinery/light/floor,
 /obj/structure/fluff/railing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
-"iqo" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "iqp" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot_white,
@@ -12479,9 +12542,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iyT" = (
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "izb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12517,18 +12582,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"izR" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
-	dir = 1;
-	name = "Head Knight's Office";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
-	},
-/area/f13/brotherhood)
 "iAm" = (
 /obj/structure/simple_door/repaired,
 /obj/effect/decal/cleanable/dirt,
@@ -12549,12 +12602,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "iBC" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/structure/fans/tiny{
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "iBD" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -12955,16 +13009,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "iTZ" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "iUi" = (
-/obj/structure/table/wood/poker,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "iUn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12994,11 +13045,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iVj" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "iVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -13194,20 +13248,18 @@
 	},
 /area/f13/sewer)
 "jcm" = (
-/obj/structure/bed/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
-"jco" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Paladin Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
+"jco" = (
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "jcG" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13382,13 +13434,15 @@
 	},
 /area/f13/sewer)
 "jiP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
-"jiR" = (
-/obj/machinery/suit_storage_unit/mining,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
+"jiR" = (
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "jjd" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/f13/wood,
@@ -13431,13 +13485,30 @@
 /turf/open/water,
 /area/f13/tunnel)
 "jkw" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/stack/sheet/prewar/five,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "jkL" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/caves)
@@ -13498,21 +13569,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/water,
 /area/f13/tunnel)
-"jmE" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "jmN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -13520,14 +13576,9 @@
 	},
 /area/f13/bunker)
 "jmS" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood)
 "jnc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13668,11 +13719,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"jte" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "jtf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13719,11 +13765,25 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jvI" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
+	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
+	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
+	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
+	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
+	doc_title_1 = "Journal 1 - New Home";
+	doc_title_2 = "Journal 2 - Mining Duty";
+	doc_title_3 = "Journal 3 - Dead-End?";
+	doc_title_4 = "Saved Draft - Crash?";
+	name = "battered terminal";
+	termtag = "Outpost Fargo System"
 	},
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/contraband/have_a_puff{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "jwy" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -13776,8 +13836,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jyZ" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
+	},
 /area/f13/brotherhood)
 "jzC" = (
 /obj/structure/table,
@@ -13887,18 +13951,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEu" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/carpet/arcade,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
+	},
+/area/f13/brotherhood)
 "jEP" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 2;
@@ -14045,10 +14107,6 @@
 /obj/item/trash/f13/porknbeans,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jMF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
 "jMT" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
@@ -14078,62 +14136,10 @@
 	},
 /area/f13/sewer)
 "jOq" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "jOw" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/duffelbag,
@@ -14146,10 +14152,9 @@
 	},
 /area/f13/building)
 "jOL" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/obj/item/kirbyplants,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood/offices2nd)
 "jPn" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/tree/jungle/small,
@@ -14495,12 +14500,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/building)
-"kcz" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "kcJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway{
@@ -14696,10 +14695,9 @@
 /area/f13/tunnel)
 "kkd" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
 "kkg" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/wreck/trash/engine,
@@ -14751,6 +14749,11 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"kni" = (
+/obj/structure/table,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "knr" = (
 /obj/structure/table,
 /obj/effect/holodeck_effect/cards{
@@ -14870,6 +14873,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"kua" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "kuD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14908,8 +14924,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kvw" = (
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "kvU" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -14918,54 +14934,11 @@
 	},
 /area/f13/brotherhood/leisure)
 "kwf" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "kwk" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -15041,9 +15014,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "kAm" = (
-/turf/open/space/basic,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "kAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -15140,6 +15113,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"kCW" = (
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "kDI" = (
 /obj/structure/showcase/machinery/cloning_pod,
 /obj/structure/window/reinforced/spawner,
@@ -15199,19 +15178,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "kFG" = (
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/recharger,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "kFP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -15255,6 +15226,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"kHm" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "kHo" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -15609,16 +15590,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/bunker)
-"kYn" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "kYI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/spider/stickyweb,
@@ -15774,53 +15745,9 @@
 	},
 /area/f13/enclave)
 "lfs" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "lgv" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
@@ -15828,13 +15755,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"lgG" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "lgH" = (
 /turf/open/floor/carpet/green,
 /area/f13/brotherhood/offices2nd)
@@ -15899,12 +15819,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "lja" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/suit_storage_unit/mining,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ljJ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -15988,10 +15905,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "lmc" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "lmn" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -16165,12 +16082,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"luk" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "lup" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -16206,6 +16117,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"lvK" = (
+/obj/structure/chair/f13chair1,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "lwl" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/ruins,
@@ -16309,19 +16224,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
-"lAK" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "lAL" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
@@ -16374,8 +16276,15 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
 "lDe" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "lDg" = (
 /obj/item/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -16406,17 +16315,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "lFa" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Storage";
+	req_access_txt = "120"
 	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	pixel_y = 5
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/armory)
 "lFd" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -16515,10 +16421,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"lLb" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
 "lLo" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -16528,6 +16430,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building)
+"lLs" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "lLu" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/wood/f13/oak,
@@ -16562,27 +16474,8 @@
 	},
 /area/f13/clinic)
 "lMH" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
@@ -16616,6 +16509,12 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"lNt" = (
+/obj/structure/fluff/railing{
+	dir = 6
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
 "lNw" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -16783,6 +16682,19 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
+"lUw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "lVd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -16812,6 +16724,12 @@
 	},
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
+"lVB" = (
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/brotherhood)
 "lWh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/lattice/catwalk,
@@ -16837,6 +16755,11 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"lWW" = (
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
+	},
+/area/f13/brotherhood)
 "lXh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/raider/boss,
@@ -16861,6 +16784,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"lYp" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "lYx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16932,14 +16861,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"mbe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "mcf" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -16954,8 +16875,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "mcz" = (
-/obj/structure/table,
-/obj/item/book/granter/trait/pa_wear,
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/seniorpaladin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mcD" = (
@@ -17035,12 +16956,6 @@
 	baseturfs = /turf/open/floor/plating/f13/outside/desert
 	},
 /area/f13/caves)
-"miB" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -17104,15 +17019,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"mlz" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/melee/powered/ripper,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "mlC" = (
 /obj/structure/table{
 	layer = 2.9
@@ -17146,6 +17052,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"mmf" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "mmi" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17189,9 +17103,6 @@
 	icon_state = "grass2"
 	},
 /area/f13/clinic)
-"mnD" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
 "mnG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb,
@@ -17221,25 +17132,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "mpu" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7{
-	pixel_y = 5
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/item/flashlight/lamp{
+	pixel_y = 11
 	},
-/area/f13/brotherhood/operations)
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "mpC" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "mpK" = (
-/obj/structure/fluff/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/archives)
 "mro" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
@@ -17253,11 +17166,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "mtc" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/bookcase,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/offices2nd)
 "mth" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/biogenerator,
@@ -17288,13 +17202,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "muq" = (
-/obj/structure/fluff/railing{
-	dir = 5
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "muF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17948,12 +17861,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nbm" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/item/clothing/suit/bomb_suit/security,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "nbA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
@@ -18122,11 +18036,16 @@
 	},
 /area/f13/sewer)
 "niu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/auxillary_base{
-	pixel_y = 33
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/gps/mining,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "niz" = (
 /obj/machinery/door/airlock/hatch{
@@ -18397,14 +18316,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "nwf" = (
-/turf/open/floor/wood/f13/stage_r,
-/area/f13/brotherhood)
-"nwI" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
+"nwI" = (
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nxk" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -18678,10 +18600,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/sewer)
-"nIl" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
 "nIu" = (
 /obj/structure/simple_door/metal/barred{
 	req_one_access_txt = "120"
@@ -18895,6 +18813,12 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
+"nRs" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "nRY" = (
 /obj/item/ammo_casing/a556,
 /turf/open/indestructible/ground/inside/subway,
@@ -19099,6 +19023,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
+"nZd" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "nZk" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/building)
@@ -19125,25 +19055,18 @@
 	},
 /area/f13/bunker)
 "obi" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/closet/crate/critter,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "obl" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "obT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/structure/closet/crate,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "ocb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/lattice/catwalk,
@@ -19187,24 +19110,6 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"odd" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
-"odD" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/restraints/legcuffs,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
 "odG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
@@ -19240,9 +19145,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "oev" = (
-/obj/effect/landmark/start/f13/elder,
-/obj/structure/chair/wood/fancy,
-/turf/open/floor/carpet/green,
+/obj/item/kirbyplants{
+	icon_state = "plant-04"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
 /area/f13/brotherhood/offices2nd)
 "oeC" = (
 /obj/item/ammo_casing/c10mm,
@@ -19483,12 +19391,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ool" = (
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed,
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood/offices2nd)
 "ooz" = (
 /obj/effect/decal/waste{
@@ -19498,8 +19404,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ooF" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/table/wood/poker,
+/obj/item/toy/figure/hos{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Paladin Action Figure";
+	toysay = "SEMPER INVICTA!"
+	},
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "ooI" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -19529,21 +19442,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "orp" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "osd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"osu" = (
-/obj/machinery/light/floor,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/archives)
 "osv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19554,25 +19461,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "otW" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
-	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
-	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
-	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
-	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
-	doc_title_1 = "Journal 1 - New Home";
-	doc_title_2 = "Journal 2 - Mining Duty";
-	doc_title_3 = "Journal 3 - Dead-End?";
-	doc_title_4 = "Saved Draft - Crash?";
-	name = "battered terminal";
-	termtag = "Outpost Fargo System"
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
 	},
-/obj/structure/sign/poster/contraband/have_a_puff{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "ouf" = (
 /obj/structure/table/optable,
 /obj/machinery/light,
@@ -19609,19 +19502,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/bunker)
-"ouT" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Paladin's PipBoy"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "ove" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
@@ -19739,6 +19619,13 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"oyL" = (
+/obj/structure/furnace,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "ozo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19965,16 +19852,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
-"oLQ" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "oLX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -20166,10 +20043,22 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "oSB" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -9;
+	pixel_y = 21
 	},
-/turf/open/floor/wood/f13/stage_b,
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "oSF" = (
 /obj/effect/decal/cleanable/dirt{
@@ -20268,13 +20157,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "oZG" = (
-/obj/structure/table,
-/obj/item/melee/onehanded/machete/training,
-/obj/item/melee/onehanded/machete/training,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "oZJ" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/subway,
@@ -20323,18 +20213,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "paO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/machinery/light/floor,
-/obj/structure/fluff/railing{
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "paS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/wood,
@@ -20350,15 +20233,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "pbh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "pbl" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/spacevine{
@@ -20493,12 +20372,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pgs" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "pgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -20535,10 +20411,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "phr" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/construction/rld,
-/turf/open/floor/carpet/arcade,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/decal/cleanable/robot_debris/limb{
+	layer = 1.5
+	},
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_white,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "phB" = (
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/raidermelee,
@@ -20557,17 +20438,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pix" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "piI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -20588,12 +20466,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "pjo" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/trash/f13/electronic/toaster{
-	pixel_y = 10
-	},
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "pjs" = (
@@ -20679,22 +20553,18 @@
 	},
 /area/f13/sewer)
 "pnK" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/turf/open/space/basic,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices2nd)
 "pnO" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Admin Accommodation";
+	req_access_txt = "120"
 	},
-/obj/item/clothing/glasses/meson,
-/obj/item/gps/mining{
-	pixel_x = 10;
-	pixel_y = 10
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/offices2nd)
 "pnS" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -20837,7 +20707,12 @@
 /area/f13/sewer)
 "pub" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
 "pud" = (
 /obj/machinery/light/small{
@@ -20914,6 +20789,11 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/bunker)
+"pyg" = (
+/obj/structure/fluff/railing,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "pyK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21004,16 +20884,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "pCg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -21060,10 +20933,16 @@
 /turf/closed/wall/rust,
 /area/f13/caves)
 "pDM" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/obj/structure/table/reinforced{
+	req_access_txt = "120"
 	},
-/turf/open/floor/plating/tunnel,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "pDU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21120,6 +20999,13 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"pHr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood/medical)
 "pHv" = (
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -21182,10 +21068,17 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
 "pLA" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
 	},
-/turf/open/floor/plating/tunnel,
+/obj/item/storage/belt/holster,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "pMw" = (
 /obj/structure/sign/poster/contraband/hacking_guide{
@@ -21234,6 +21127,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"pNR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pNS" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/carpet/red,
@@ -21349,19 +21247,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "pTV" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/gun/ballistic/automatic/pistol/pistol22,
-/obj/item/gun/ballistic/automatic/pistol/pistol22,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "pUe" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -21499,9 +21388,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pYB" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
+/obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pYF" = (
@@ -21566,6 +21453,18 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"qba" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "qcl" = (
 /obj/structure/campfire/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -21582,6 +21481,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qcK" = (
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
+	},
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
+"qcW" = (
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/rust,
+/area/f13/tunnel)
+"qdg" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -21592,10 +21510,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/archives)
-"qcW" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/wall/rust,
-/area/f13/tunnel)
 "qew" = (
 /obj/structure/car,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -21642,14 +21556,11 @@
 	},
 /area/f13/building)
 "qfy" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "qfX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/bonfire/prelit,
@@ -21669,12 +21580,6 @@
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"qgy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "qgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -21683,6 +21588,20 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"qhj" = (
+/obj/structure/decoration/smokeold{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "qhk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -21729,14 +21648,13 @@
 	},
 /area/f13/bunker)
 "qin" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Storage";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/armory)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
 "qip" = (
 /mob/living/simple_animal/hostile/radscorpion/blue,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22088,11 +22006,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
 "qzL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "qAe" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -22155,9 +22072,13 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "qBI" = (
-/obj/item/kirbyplants,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices2nd)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "qBZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
@@ -22293,13 +22214,11 @@
 /turf/open/water,
 /area/f13/sewer)
 "qHb" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/obj/machinery/vending/wallmed{
-	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/turf/open/floor/wood/f13/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "qHd" = (
 /obj/structure/table,
@@ -22330,11 +22249,11 @@
 /turf/open/water,
 /area/f13/sewer)
 "qIB" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "qIH" = (
 /obj/structure/table,
@@ -22381,13 +22300,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "qKB" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/construction/rld,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "qLi" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -22497,14 +22413,30 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"qQy" = (
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+"qQa" = (
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"qQy" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/keg,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "qQz" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -22524,13 +22456,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
-"qRb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "qRc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -22585,6 +22510,13 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"qTX" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "qUd" = (
 /obj/machinery/light{
 	dir = 1
@@ -22594,10 +22526,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "qUq" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "qUr" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -22670,8 +22604,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "qXf" = (
+/obj/structure/toilet{
+	pixel_y = 10
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
+/obj/item/restraints/legcuffs,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "qXj" = (
 /obj/machinery/light/small,
@@ -22807,11 +22747,6 @@
 /obj/effect/mob_spawn/human/corpse/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"rbj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "rbr" = (
 /obj/structure/closet/crate/large,
 /obj/item/trash/f13/electronic/toaster/atomics,
@@ -22966,17 +22901,18 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"rjT" = (
-/obj/structure/fluff/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "rkb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Fargo Holding Cell";
+/obj/structure/table/reinforced{
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "rkv" = (
@@ -22989,10 +22925,9 @@
 	},
 /area/f13/bunker)
 "rle" = (
-/obj/structure/fluff/railing,
-/obj/effect/landmark/start/f13/seniorscribe,
+/obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/offices2nd)
 "rln" = (
 /obj/structure/chair/wood/fancy,
 /obj/structure/decoration/rag{
@@ -23069,60 +23004,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rnI" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "rnO" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -23179,8 +23062,17 @@
 	},
 /area/f13/bunker)
 "rpS" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
+"rpV" = (
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 3
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
@@ -23317,9 +23209,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rvp" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "rvG" = (
 /obj/structure/fluff/railing,
 /obj/effect/decal/cleanable/insectguts,
@@ -23454,16 +23343,15 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "ryt" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "sentdorm";
-	name = "Head Paladin Billet";
-	req_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "ryw" = (
@@ -23763,20 +23651,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "rIn" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/operations)
 "rJc" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/hot_potato/harmless/toy,
-/turf/open/floor/plating/tunnel,
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
 /area/f13/brotherhood)
 "rJp" = (
 /obj/machinery/button/door{
@@ -23848,6 +23739,15 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"rKX" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/flasher/portable,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "rLv" = (
 /obj/item/trash/f13/dog,
 /obj/effect/decal/cleanable/dirt,
@@ -23905,6 +23805,7 @@
 /obj/structure/fluff/railing{
 	dir = 1
 	},
+/obj/structure/table/wood/fancy/monochrome,
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/brotherhood)
 "rNr" = (
@@ -24058,16 +23959,6 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"rTv" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
 "rTW" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
@@ -24180,19 +24071,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "rYD" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/leisure)
 "rYE" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/wirecutters/power,
@@ -24252,15 +24138,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
-"saB" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "saC" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -24400,11 +24277,14 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shq" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "shB" = (
 /obj/machinery/light/small,
 /obj/item/mine/shrapnel,
@@ -24680,15 +24560,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "svf" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood)
-"svr" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
+"svr" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "sxm" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Head Knight Billet";
@@ -24790,12 +24672,7 @@
 	},
 /area/f13/brotherhood)
 "sAE" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices2nd)
 "sAW" = (
 /obj/structure/table/reinforced,
@@ -24806,12 +24683,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sBF" = (
-/obj/structure/bookcase,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sBG" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -24859,16 +24733,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "sDw" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/effect/overlay/junk/mirror{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "sDG" = (
 /obj/structure/table/wood/fancy/blackred,
@@ -24883,19 +24749,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sEa" = (
-/obj/machinery/button/door{
-	id = "sentdorm";
-	normaldoorcontrol = 1;
-	pixel_y = 32;
-	specialfunctions = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
-	},
-/turf/open/floor/wood/f13/old,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "sEn" = (
 /obj/structure/ladder/unbreakable{
@@ -25154,10 +25012,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sQa" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
+	},
+/area/f13/brotherhood)
+"sQg" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/brotherhood/offices2nd)
 "sQp" = (
 /obj/structure/spider/stickyweb,
@@ -25185,16 +25051,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "sQX" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "sRo" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -25303,10 +25164,29 @@
 	},
 /area/f13/sewer)
 "sXq" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
 	},
-/turf/open/floor/plating/tunnel,
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
+	},
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "sXM" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -25314,12 +25194,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"sXU" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
 "sYr" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
@@ -25344,10 +25218,13 @@
 	},
 /area/f13/enclave)
 "sZz" = (
-/obj/structure/bookcase,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/trash/f13/electronic/toaster{
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "tad" = (
 /obj/structure/chair{
@@ -25482,7 +25359,13 @@
 	},
 /area/f13/brotherhood/chemistry)
 "tgQ" = (
-/turf/open/floor/wood/f13/stage_l,
+/obj/machinery/door/airlock/hatch{
+	name = "Fargo Holding Cell";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood)
 "thm" = (
 /obj/effect/decal/remains{
@@ -25571,13 +25454,6 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
-"tlr" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "tls" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -25600,17 +25476,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tms" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/gps/mining,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "tmz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25828,11 +25695,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
 "tuI" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/bookcase,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
+	icon_state = "casino"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/archives)
 "tvv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25986,26 +25854,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"tAG" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
+"tBh" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
 /area/f13/brotherhood)
-"tBh" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque denoting a room dedicated to the maintenance of mechanized infantry equipment.";
-	name = "Power Armor Maintenance";
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "tBZ" = (
 /obj/machinery/light/floor,
 /obj/structure/chair/folding{
@@ -26164,17 +26017,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "tIR" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill{
-	pixel_y = -10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "tJc" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26186,6 +26042,17 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building)
+"tJx" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "tJy" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -26248,11 +26115,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "tKY" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/leisure)
 "tKZ" = (
 /obj/machinery/workbench,
@@ -26337,15 +26201,6 @@
 /area/f13/sewer)
 "tQb" = (
 /turf/open/floor/carpet/black,
-/area/f13/brotherhood)
-"tQD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/brotherhood)
 "tQH" = (
 /obj/structure/rack,
@@ -26598,14 +26453,11 @@
 	},
 /area/f13/bunker)
 "ueZ" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/obj/structure/lattice{
-	density = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ufY" = (
@@ -26744,20 +26596,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "ulh" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/obj/structure/fluff/railing{
-	dir = 10
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -26837,15 +26683,22 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "upG" = (
-/obj/machinery/conveyor/auto{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "upY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/item/dice/d1,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "uqc" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/black,
@@ -26887,13 +26740,11 @@
 	},
 /area/f13/caves)
 "uqU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/hot_potato/harmless/toy,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ura" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/grass,
@@ -26904,12 +26755,27 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
+"urw" = (
+/obj/structure/table,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "urF" = (
 /obj/effect/decal/waste,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
+"usd" = (
+/obj/structure/closet/cabinet,
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_y = 32
+	},
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "usk" = (
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -27038,18 +26904,16 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "uxx" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_x = 6;
-	pixel_y = -12
-	},
-/turf/open/floor/wood/f13/old,
+/turf/open/floor/wood/f13/stage_r,
 /area/f13/brotherhood)
 "uxz" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/bed/dogbed,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Paladin Ramos"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
@@ -27151,6 +27015,21 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"uDa" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -27226,12 +27105,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uHu" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood)
+/area/f13/brotherhood/medical)
 "uHB" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27292,12 +27170,6 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/f13/oakbroken3,
 /area/f13/sewer)
-"uKV" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "uLn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
@@ -27314,10 +27186,8 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "uLI" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/computer/auxillary_base,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "uLP" = (
 /turf/open/floor/wood/f13/housewoodbroken2,
@@ -27476,14 +27346,31 @@
 	},
 /area/f13/enclave)
 "uTy" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/fluff/railing{
+	dir = 6
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "uTE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"uUH" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "uVg" = (
 /obj/structure/showcase/mecha/marauder{
 	desc = "A stand with an empty old combat suit bolted to it. It represents the brotherhood who took part in the Republic-Enclave war back west. We had honor back then.";
@@ -27513,12 +27400,6 @@
 	dir = 9
 	},
 /area/f13/bunker)
-"uXj" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
 "uXF" = (
 /obj/structure/lattice{
 	layer = 3
@@ -27587,13 +27468,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "uYY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "uZI" = (
 /obj/structure/sign/warning{
 	pixel_x = 6;
@@ -27643,14 +27522,14 @@
 	},
 /area/f13/bunker)
 "vbt" = (
-/obj/structure/chair/stool/retro/black,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "vbx" = (
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
@@ -27746,8 +27625,24 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "vep" = (
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorknight,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "veu" = (
@@ -27762,13 +27657,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "veQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "veR" = (
 /obj/structure/fence,
 /turf/open/floor/f13{
@@ -27837,10 +27732,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vhk" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Canteen";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "vhB" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -27883,11 +27782,10 @@
 	},
 /area/f13/sewer)
 "vkg" = (
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -28101,21 +27999,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"vsP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"vtf" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "vtj" = (
 /obj/machinery/light/floor,
 /obj/item/kirbyplants/random,
@@ -28284,6 +28167,19 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/enclave)
+"vyt" = (
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Paladin's PipBoy"
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "vyy" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/dirt,
@@ -28300,9 +28196,23 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"vzq" = (
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
+	dir = 1;
+	name = "Head Knight's Office";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "vAk" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "vAv" = (
 /obj/structure/plasticflaps,
 /obj/effect/decal/cleanable/dirt{
@@ -28389,6 +28299,61 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"vFu" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "vFx" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/clothing/head/crown,
@@ -28553,10 +28518,6 @@
 "vKj" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"vKz" = (
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "vKK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
@@ -29016,10 +28977,11 @@
 	},
 /area/f13/bunker)
 "wbN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "wbZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -29070,26 +29032,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "weo" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/stack/sheet/prewar/five,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/machinery/vending/robotics,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -29108,38 +29051,22 @@
 	},
 /area/f13/caves)
 "weW" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -9;
-	pixel_y = 21
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 10;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/closet/crate/engineering,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "wft" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wfJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operating)
 "wgb" = (
-/obj/structure/closet/cabinet,
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_y = 32
-	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "wgc" = (
 /obj/structure/table{
 	layer = 2.9
@@ -29189,9 +29116,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "whQ" = (
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "wiz" = (
 /obj/machinery/light/small/broken{
@@ -29225,6 +29156,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"wkf" = (
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "wkw" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -29243,12 +29179,6 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"wlf" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "wln" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -29424,6 +29354,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
+"wtE" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "wtK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/closed/wall/f13/wood/house,
@@ -29587,8 +29521,62 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "wAU" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood)
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "wBa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29669,11 +29657,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wFv" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "wFD" = (
 /turf/open/water,
 /area/f13/sewer)
@@ -29832,14 +29820,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wKL" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/chair/comfy/teal,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/archives)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -29892,17 +29877,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wMJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "wNf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29919,11 +29897,9 @@
 	},
 /area/f13/bunker)
 "wNy" = (
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "wND" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -29953,12 +29929,13 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
 "wPR" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "wQb" = (
 /obj/structure/rack,
@@ -29966,7 +29943,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wQj" = (
-/turf/open/floor/wood/f13/oak,
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
+	},
 /area/f13/brotherhood)
 "wQn" = (
 /obj/structure/cable{
@@ -30016,13 +29996,33 @@
 "wSc" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/armory)
-"wSV" = (
+"wSi" = (
 /obj/structure/falsewall/reinforced{
 	layer = 3
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/archives)
+"wSV" = (
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "wTz" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -30069,11 +30069,13 @@
 /turf/open/water,
 /area/f13/sewer)
 "wWD" = (
-/obj/structure/fluff/railing{
-	dir = 9
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood)
 "wWF" = (
@@ -30154,13 +30156,17 @@
 	},
 /area/f13/caves)
 "wZL" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque denoting a room dedicated to the maintenance of mechanized infantry equipment.";
+	name = "Power Armor Maintenance";
+	pixel_x = -32
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "xas" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -30217,11 +30223,8 @@
 	},
 /area/f13/building)
 "xcW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices2nd)
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "xcX" = (
 /obj/structure/sign/departments/security,
 /obj/effect/decal/cleanable/dirt{
@@ -30232,13 +30235,14 @@
 	},
 /area/f13/bunker)
 "xdk" = (
-/obj/structure/fans/tiny{
-	pixel_x = 32
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
 "xdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30257,15 +30261,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"xev" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
 "xeC" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30278,10 +30273,21 @@
 	},
 /area/f13/bunker)
 "xfi" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/obj/machinery/light,
+/obj/item/gun/energy/laser/plasma/scatter{
+	anchored = 1;
+	cell_type = null;
+	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
+	name = "display multiplas rifle";
+	pin = null;
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/sentinel,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xfq" = (
@@ -30289,7 +30295,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xfJ" = (
-/turf/closed/wall/f13/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/brotherhood)
 "xgs" = (
 /obj/effect/decal/waste{
@@ -30298,8 +30310,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "xgw" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/old,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xgK" = (
 /obj/machinery/conveyor/auto{
@@ -30307,10 +30322,6 @@
 	},
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
-"xgN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "xgY" = (
 /obj/structure/flora/junglebush,
@@ -30322,10 +30333,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/brotherhood/medical)
-"xic" = (
-/obj/structure/closet/crate/critter,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+"xhV" = (
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "xig" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -30359,15 +30372,6 @@
 /obj/structure/bed/old,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
-"xje" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "xjD" = (
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30449,9 +30453,8 @@
 	},
 /area/f13/caves)
 "xlH" = (
-/obj/structure/closet/crate/engineering,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/dorms)
 "xmm" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
@@ -30475,10 +30478,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
-"xns" = (
-/obj/structure/table/wood/fancy/royalblack,
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
 "xnz" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -30594,14 +30593,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "xta" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Canteen";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "xtk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -30613,6 +30607,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
+"xtz" = (
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "xtA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/tunnel,
@@ -30638,12 +30635,6 @@
 /obj/effect/turf_decal/stripes/white/end,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"xuo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "xuq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30749,6 +30740,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"xyn" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood)
 "xyz" = (
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30830,15 +30824,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "xCH" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
+/obj/item/clothing/glasses/meson,
+/obj/item/gps/mining{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "xCI" = (
 /obj/structure/table,
@@ -30911,9 +30905,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xFY" = (
-/obj/machinery/light/small/broken,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood)
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "xGd" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -30925,6 +30924,15 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"xGx" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "xGV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -30979,13 +30987,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "xHW" = (
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 10
+/obj/structure/fluff/railing{
+	dir = 1
 	},
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "xIe" = (
 /obj/structure/spider/cocoon,
@@ -31038,13 +31043,13 @@
 	},
 /area/f13/bunker)
 "xJM" = (
-/obj/structure/chair/wood/fancy{
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
-	},
-/area/f13/brotherhood)
+/obj/structure/bed,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "xKD" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -31138,15 +31143,17 @@
 /turf/open/water,
 /area/f13/sewer)
 "xPm" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "xPu" = (
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = -6;
-	pixel_y = 12
+/obj/structure/sign/poster/prewar/poster63{
+	pixel_y = 32
 	},
-/turf/open/floor/wood/f13/old,
+/obj/item/flag/bos,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "xPO" = (
 /obj/machinery/light/small{
@@ -31177,11 +31184,9 @@
 	},
 /area/f13/enclave)
 "xQh" = (
-/obj/structure/chair/comfy/teal,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "xQo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Fargo Outpost";
@@ -31223,10 +31228,14 @@
 	},
 /area/f13/brotherhood/operations)
 "xRn" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/melee/powered/ripper,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "xRv" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -31345,9 +31354,8 @@
 	},
 /area/f13/bunker)
 "xWB" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
+/obj/machinery/flasher/portable,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "xWH" = (
 /obj/structure/stairs/south{
@@ -31379,11 +31387,8 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
 "xYt" = (
-/obj/structure/bookcase,
 /obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
-	icon_state = "casino"
-	},
+/turf/open/floor/carpet,
 /area/f13/brotherhood/archives)
 "xYB" = (
 /obj/structure/stone_tile/center,
@@ -31431,7 +31436,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "yaZ" = (
-/turf/open/floor/carpet,
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ybf" = (
 /obj/effect/decal/remains/human,
@@ -31475,20 +31481,9 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "yei" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/smartfridge,
+/turf/open/space/basic,
+/area/f13/brotherhood/leisure)
 "yey" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -31601,9 +31596,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "yiX" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "ykf" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating/tunnel{
@@ -31618,20 +31613,15 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "ykR" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7{
+	pixel_y = 5
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "ykY" = (
 /obj/structure/lattice{
 	layer = 3
@@ -31647,6 +31637,18 @@
 	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"ylk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "yln" = (
 /obj/structure/simple_door/metal/iron,
@@ -81561,19 +81563,19 @@ dBk
 dBk
 dBk
 dBk
-hZA
-hZA
+fJs
+fJs
 dBk
 dBk
 dBk
 dBk
 dBk
-gPu
-gPu
+haJ
+haJ
 dBk
-vhk
 mcz
-jyZ
+kni
+wNy
 dBk
 vPg
 aoj
@@ -81818,18 +81820,18 @@ ujt
 aaQ
 ujt
 dBk
-lLb
-fww
+tKY
+yiX
 dBk
-ouT
-xuo
-lAK
+vyt
+wMJ
+kua
 oAL
 dBk
 dBk
 dBk
 iXo
-ePO
+urw
 umo
 dBk
 vPg
@@ -82071,19 +82073,19 @@ vPg
 vPg
 yhT
 dBk
-tQD
+xfJ
 fpe
 ujt
 dcE
-fzc
+pTV
 yix
 dBk
-frt
+ooF
 qCb
 qCb
 dBk
 kvl
-xPu
+gqM
 lPl
 iXo
 umo
@@ -82335,7 +82337,7 @@ dBk
 yix
 sJp
 dBk
-hXR
+wgb
 qCb
 qCb
 dBk
@@ -82592,12 +82594,12 @@ dBk
 sJp
 sJp
 dBk
-sEa
-cYh
+ePO
+jco
 uBp
 dBk
-hdP
-uxx
+iUi
+gcj
 dBk
 dBk
 dBk
@@ -82850,7 +82852,7 @@ sJp
 sJp
 ood
 ood
-ryt
+alI
 dBk
 dBk
 dBk
@@ -82859,7 +82861,7 @@ dBk
 mjR
 wgA
 umo
-cmM
+ylk
 dBk
 vPg
 vPg
@@ -83096,21 +83098,21 @@ vPg
 vPg
 vPg
 ood
-uLI
+nZd
 sJp
-paO
+hSp
 hcp
 rXr
 wrm
-gcj
+qBI
 utF
 sJp
 tQH
 ood
 iXo
 dBk
-weW
-hNG
+oSB
+uxz
 umo
 oAL
 mlC
@@ -83353,27 +83355,27 @@ vPg
 aoj
 aoj
 ood
-shq
+wbN
 sJp
-wNy
+xHW
 wrm
 wrm
 wrm
-rjT
+ipB
 sJp
 sJp
 kEK
 ood
-cUh
-qQy
-qXf
-qXf
+ade
+wPR
+xta
+xta
 umo
 dBk
 sSJ
 umo
 ryZ
-fJs
+eMo
 dBk
 ggZ
 aoj
@@ -83610,7 +83612,7 @@ vPg
 aoj
 aoj
 ood
-saB
+ulh
 sJp
 rXr
 wrm
@@ -83621,15 +83623,15 @@ utF
 sJp
 lxZ
 ood
-avj
+xfi
 iYx
-uHu
-qXf
-vsP
+qHb
+xta
+pNR
 dBk
-cGV
-umo
 vep
+umo
+jOq
 vcp
 dBk
 ggZ
@@ -83867,21 +83869,21 @@ vPg
 aoj
 aoj
 ood
-shq
+wbN
 sJp
-wNy
+xHW
 wrm
 rXr
 iuM
-rjT
+ipB
 sJp
 sJp
 hik
-ood
-niu
-hTd
-qXf
-qXf
+uLI
+umo
+shq
+xta
+xta
 umo
 dBk
 xZn
@@ -84124,16 +84126,16 @@ vPg
 vPg
 vPg
 ood
-uLI
+nZd
 sJp
 hAk
 wrm
 wrm
 wrm
-ipB
+mmf
 utF
 sJp
-oZG
+cSe
 ood
 umo
 umo
@@ -84141,10 +84143,10 @@ umo
 umo
 umo
 dBk
-alI
+qQa
 umo
 yhF
-wMJ
+lUw
 dBk
 ggZ
 vPg
@@ -84389,17 +84391,17 @@ ood
 ood
 ood
 ood
-xta
+vhk
 ood
 ood
 ood
 ood
-jco
+aSi
 ood
 wSc
 wSc
 wSc
-fvU
+gtv
 wSc
 wSc
 wSc
@@ -84648,30 +84650,30 @@ sJp
 sJp
 sJp
 sJp
-pix
+hZA
 ood
 oxm
 xsD
 xsD
 wSc
-ykR
-tBh
+uDa
+wZL
 xDb
 xDb
-cqG
-qgy
+wSV
+paO
 qeX
-nbm
-sXq
-hZA
-hZA
-hZA
+qTX
+jiR
+fJs
+fJs
+fJs
 dBk
-aSi
+faB
 qCb
-aQb
+gAb
 qCb
-xgw
+wtE
 dBk
 vPg
 aoj
@@ -84897,7 +84899,7 @@ oPe
 xOz
 ccJ
 ood
-lja
+hhe
 sJp
 yix
 yix
@@ -84905,29 +84907,29 @@ sJp
 sJp
 sJp
 sJp
-pix
+hZA
 ood
 mvU
 xsD
 xsD
 wSc
-pTV
+hXe
 xDb
 ibx
 xDb
-ioI
-qgy
-rpS
+fvU
+paO
+qfy
 cwz
 wSc
-hSp
-hSp
-hSp
+wQj
+wQj
+wQj
 dBk
-fUs
+pLA
 dEr
 dEr
-svf
+sDw
 gFF
 dBk
 aoj
@@ -85162,30 +85164,30 @@ ffy
 kvU
 bko
 sJp
-pix
+hZA
 ood
 mzi
 xsD
 xsD
 wSc
-jmE
+bhg
 xDb
 ibx
 xDb
-rnI
-uKV
-gqM
-kwf
+vFu
+kFG
+lMH
+gkX
 wSc
-svr
+rpS
 rXC
-svr
+rpS
 dBk
-qHb
+bLn
 qCb
 dEr
 qCb
-xgw
+wtE
 dBk
 vPg
 vPg
@@ -85414,12 +85416,12 @@ ood
 hmO
 sJp
 dma
-tKY
+qUq
 ffy
 ffy
 bko
 sJp
-pix
+hZA
 ood
 mDL
 xsD
@@ -85434,9 +85436,9 @@ xDb
 xDb
 xDb
 ouH
-svr
+rpS
 rXC
-svr
+rpS
 lZb
 rOT
 dBk
@@ -85686,14 +85688,14 @@ piW
 xDb
 ibx
 xDb
-lMH
-fSi
+sXq
+rpV
 pnS
-mlz
+xRn
 wSc
-svr
+rpS
 rXC
-svr
+rpS
 cGk
 iXo
 iXo
@@ -85939,24 +85941,24 @@ xsD
 xsD
 xsD
 wSc
-luk
+uYY
 xDb
 ibx
 xDb
-yei
-qgy
-rpS
+tIR
+paO
+qfy
 cwz
 wSc
-wKL
+fSi
 rXC
-izR
+vzq
 dBk
-rbj
+lmc
 tQb
 tQb
-gkX
-cQN
+mpu
+nwI
 dBk
 aoj
 vPg
@@ -86181,7 +86183,7 @@ bba
 xOz
 xOz
 xOz
-pgs
+fbn
 sJp
 sJp
 sJp
@@ -86196,24 +86198,24 @@ xsD
 xsD
 xsD
 wSc
-rYD
+bfc
 xDb
 mXB
 xDb
-jOq
-qgy
+wAU
+paO
 prd
 wmL
 wSc
-svr
+rpS
 rXC
-svr
+rpS
 vSy
 iXo
 tQb
-yiX
-qIB
-xfi
+lvK
+hTd
+xgw
 dBk
 aoj
 vPg
@@ -86438,7 +86440,7 @@ bcj
 tKv
 xOz
 xOz
-xHW
+xdk
 sJp
 sJp
 sJp
@@ -86446,7 +86448,7 @@ sJp
 nQz
 ffy
 kvU
-xje
+xFY
 lxZ
 ood
 mJr
@@ -86454,7 +86456,7 @@ xsD
 ogl
 wSc
 wSc
-qin
+lFa
 wSc
 wSc
 wSc
@@ -86462,14 +86464,14 @@ wSc
 wSc
 wSc
 wSc
-svr
+rpS
 rXC
-svr
+rpS
 dBk
-aNt
+hQs
 tQb
 tQb
-wZL
+veQ
 iXo
 dBk
 aoj
@@ -86710,20 +86712,20 @@ jgt
 xsD
 xsD
 wSc
-iyT
-mnD
-iyT
+kAm
+kvw
+kAm
 wSc
 wSc
 wSc
 wSc
 wSc
 wSc
-svr
-svr
-svr
+rpS
+rpS
+rpS
 cGk
-orp
+cQN
 iXo
 iXo
 iXo
@@ -86967,9 +86969,9 @@ nct
 xsD
 xsD
 wSc
-fUG
-mnD
-mnD
+obT
+kvw
+kvw
 xJp
 xJp
 xJp
@@ -87205,13 +87207,13 @@ eLE
 (217,1,1) = {"
 eLE
 ood
-wFv
+cqG
 xOz
 ccJ
 xOz
 ood
-vbt
-iUi
+rYD
+jcm
 rSv
 sJp
 sJp
@@ -87224,9 +87226,9 @@ nib
 xsD
 xsD
 wSc
-mnD
-mnD
-odd
+kvw
+kvw
+alQ
 xJp
 rZi
 naX
@@ -87237,11 +87239,11 @@ xhj
 rXz
 rXz
 uHZ
-odD
+qXf
 rni
 dBk
-iBC
-xgN
+qIB
+jiP
 dBk
 vPg
 vPg
@@ -87467,7 +87469,7 @@ tKv
 xOz
 xOz
 ood
-lgG
+muq
 jjA
 rSv
 sJp
@@ -87475,15 +87477,15 @@ sJp
 sJp
 sJp
 sJp
-vkg
+xhV
 ood
 nly
 xsD
 xsD
 wSc
-xlH
-mnD
-xic
+weW
+kvw
+obi
 xJp
 sdy
 szc
@@ -87494,11 +87496,11 @@ xhj
 rXz
 rXz
 uHZ
-hYB
-jOL
+qba
+orp
 dBk
-sDw
-jOL
+gPu
+orp
 oAL
 vPg
 vPg
@@ -87728,8 +87730,8 @@ rSv
 jlt
 rSv
 sJp
-wlf
-kcz
+blV
+pbh
 ood
 ood
 ood
@@ -87738,9 +87740,9 @@ ood
 nEg
 ood
 wSc
-mnD
-mnD
-mnD
+kvw
+kvw
+kvw
 xJp
 enN
 cBa
@@ -87751,11 +87753,11 @@ rXz
 rXz
 rXz
 uHZ
-brY
-xgN
+agn
+jiP
 dBk
-brY
-jte
+agn
+gse
 dBk
 vPg
 vPg
@@ -87978,26 +87980,26 @@ eLE
 ood
 ood
 oFo
-ade
+yei
 ood
 ood
 ood
 ood
-fMP
-fMP
-fMP
-fMP
-fMP
-jvI
-kkd
+xPm
+xPm
+xPm
+xPm
+xPm
+lYp
+kwf
 iEm
-kkd
-kkd
-kkd
-rvp
-rvp
-rvp
-rvp
+kwf
+kwf
+kwf
+xlH
+xlH
+xlH
+xlH
 xJp
 sdy
 szc
@@ -88240,38 +88242,38 @@ sJp
 sJp
 sJp
 sJp
-fMP
-ulh
-blV
-nwI
-fMP
-qKB
-kkd
+xPm
+qcK
+oyL
+iyT
+xPm
+svf
+kwf
 iHF
-kkd
-pBy
-kkd
-rvp
-bLn
-veQ
-bLn
+kwf
+rIn
+kwf
+xlH
+oZG
+avj
+oZG
 xJp
 rZi
 naX
 naX
 naX
 uHZ
-gdz
+dAy
 rXz
 rXz
 uHZ
-sQX
-tAG
-eEh
-tAG
-tAG
+gCM
+aLM
+rKX
+aLM
+aLM
 dBk
-whQ
+wkf
 xkI
 eYr
 dBk
@@ -88497,26 +88499,26 @@ dma
 wtx
 syU
 sJp
+xPm
+lNt
 fMP
-bBA
-gRd
-nwI
-fMP
-iVj
-kkd
-rIn
-kkd
+iyT
+xPm
+weo
+kwf
+kHm
+kwf
 ryS
-kkd
-rvp
-qzL
-upY
-qzL
+kwf
+xlH
+fXl
+xQh
+fXl
 xJp
 xJp
 xJp
 xJp
-jMF
+wfJ
 uHZ
 uvR
 nYR
@@ -88528,9 +88530,9 @@ umZ
 umZ
 diE
 dBk
-whQ
-whQ
-ija
+wkf
+wkf
+gOq
 dBk
 vPg
 aoj
@@ -88749,26 +88751,26 @@ eLE
 ood
 bna
 wtx
-qRb
+bRw
 sJp
 wtx
-qRb
+bRw
 sJp
-fMP
+xPm
 daE
-nwI
-nwI
-nwI
-kkd
-kkd
-kkd
-kkd
-kkd
-kkd
-rvp
-upY
-upY
-upY
+iyT
+iyT
+iyT
+kwf
+kwf
+kwf
+kwf
+kwf
+kwf
+xlH
+xQh
+xQh
+xQh
 pSn
 sgf
 syd
@@ -88779,15 +88781,15 @@ uBO
 rXz
 rXz
 uHZ
-rTv
-tlr
+wWD
+sEa
 umZ
 umZ
 diE
-hhe
-whQ
-whQ
-jkw
+djq
+wkf
+wkf
+heQ
 dBk
 vPg
 aoj
@@ -89011,23 +89013,23 @@ yix
 wtx
 syU
 sJp
-fMP
-nwI
-nwI
-nwI
-nwI
-kkd
-kkd
-kkd
-kkd
+xPm
+iyT
+iyT
+iyT
+iyT
+kwf
+kwf
+kwf
+kwf
 bPo
-kkd
+kwf
 niz
-ooF
-ooF
-jiP
+rnI
+rnI
+svr
 pSn
-mtc
+cLG
 vCQ
 vCQ
 twI
@@ -89036,15 +89038,15 @@ rXz
 rXz
 rXz
 uHZ
-lFa
-aLM
+ryt
+fzc
 diE
 diE
 diE
-bEm
-whQ
-whQ
-whQ
+rkb
+wkf
+wkf
+wkf
 dBk
 vPg
 aoj
@@ -89268,21 +89270,21 @@ sJp
 wtx
 wtx
 sJp
-fMP
-ulh
-nwI
-nwI
-fMP
-sXU
-kkd
-mpu
-kkd
+xPm
+qcK
+iyT
+iyT
+xPm
+bRL
+kwf
+ykR
+kwf
 ryS
-kkd
-rvp
-upY
-ooF
-ooF
+kwf
+xlH
+xQh
+rnI
+rnI
 pSn
 sio
 tht
@@ -89293,14 +89295,14 @@ rXz
 rXz
 rXz
 uHZ
-fce
+qzL
 umZ
 umZ
 umZ
 umZ
-cdu
-whQ
-gtv
+pDM
+wkf
+pix
 iYR
 dBk
 vPg
@@ -89525,20 +89527,20 @@ sJp
 wtx
 syU
 sJp
-fMP
-bBA
-nwI
-nwI
-fMP
-weo
-kkd
+xPm
+lNt
+iyT
+iyT
+xPm
+jkw
+kwf
 iJU
-kkd
-kkd
-kkd
-rvp
-gAb
-upY
+kwf
+kwf
+kwf
+xlH
+uUH
+xQh
 ntK
 pSn
 mcU
@@ -89546,14 +89548,14 @@ vCQ
 vCQ
 twI
 qXl
-cSe
+pHr
 rXz
 rXz
 uHZ
-fce
+qzL
 umZ
 umZ
-vKz
+xWB
 dBk
 dBk
 dBk
@@ -89782,34 +89784,34 @@ sJp
 wtx
 syU
 sJp
-fMP
-fMP
-fMP
-fMP
-fMP
-fQb
-pbh
+xPm
+xPm
+xPm
+xPm
+xPm
+sQX
+dtG
 dfN
 xRm
 xRm
 xRm
-rvp
-jcm
-uYY
-jcm
+xlH
+gRd
+nwf
+gRd
 pSn
 tGL
 twI
 twI
 uCu
-ilD
-uXj
+pub
+uHu
 rXz
 rXz
 uHZ
 dBk
 dBk
-rkb
+tgQ
 dBk
 dBk
 wzU
@@ -90041,26 +90043,26 @@ syU
 sJp
 ood
 lHY
-hQs
+ueZ
 lHY
-fMP
-fMP
-fMP
-fMP
-vtf
-oLQ
-oLQ
-rvp
-rvp
-rvp
-rvp
+xPm
+xPm
+xPm
+xPm
+lDe
+gZQ
+gZQ
+xlH
+xlH
+xlH
+xlH
 pSn
 pSn
 uac
 pSn
 pSn
-tuI
-pub
+wFv
+pgs
 uHZ
 uHZ
 uHZ
@@ -91319,10 +91321,10 @@ eLE
 xNs
 bUV
 lgL
-aVi
+bEm
 epz
 qFd
-rle
+pyg
 aFh
 ify
 wKI
@@ -91339,7 +91341,7 @@ wIR
 wIR
 vYo
 xNs
-hXe
+uTy
 iXo
 iXo
 iXo
@@ -91576,10 +91578,10 @@ eLE
 xNs
 dlr
 fXL
-aVi
+bEm
 lVf
 fXL
-mpK
+bBA
 hpZ
 xSa
 wKI
@@ -91833,10 +91835,10 @@ eLE
 xNs
 wOM
 fXL
-aVi
+bEm
 yey
 fXL
-mpK
+bBA
 xSa
 xSa
 wKI
@@ -91845,17 +91847,17 @@ yey
 qow
 xIu
 xIu
-haJ
+vkg
 vIW
 xIu
 xIu
-haJ
+vkg
 vIW
 vIW
 vIW
 qOQ
 xrV
-mbe
+qin
 xnL
 xrV
 xrV
@@ -91865,7 +91867,7 @@ qOQ
 xrV
 kbw
 egU
-wbN
+kkd
 wgK
 ofv
 nlz
@@ -92089,11 +92091,11 @@ eLE
 eLE
 xNs
 bVG
-xPm
-aVi
+hSz
+bEm
 eyH
 fXL
-mpK
+bBA
 hsX
 xAe
 wKI
@@ -92347,10 +92349,10 @@ eLE
 xNs
 bZT
 cLU
-aVi
+bEm
 eAG
 tFu
-mpK
+bBA
 dOH
 xSa
 wKI
@@ -92367,7 +92369,7 @@ wOf
 wIR
 wIR
 xNs
-ueZ
+ija
 iXo
 iXo
 umo
@@ -92388,7 +92390,7 @@ wvR
 wvR
 wvR
 dBk
-fIc
+xPu
 xSE
 lPR
 dBk
@@ -92605,7 +92607,7 @@ xNs
 caK
 yey
 yey
-gZQ
+ilD
 yey
 xMi
 huC
@@ -92639,7 +92641,7 @@ iXo
 umo
 iXo
 dBk
-kFG
+qhj
 rrh
 rrh
 eLx
@@ -93123,7 +93125,7 @@ xNs
 xNs
 xNs
 xNs
-qUq
+vAk
 xNs
 xNs
 xNs
@@ -93153,7 +93155,7 @@ umo
 umo
 umo
 dBk
-iqo
+bjx
 tkA
 xuw
 gWQ
@@ -93372,16 +93374,16 @@ eLE
 "}
 (241,1,1) = {"
 eLE
-uTy
+sAE
 agx
 agx
 lgH
 agx
-qBI
-uTy
+jOL
+sAE
 dxN
-vAk
-vAk
+cfu
+cfu
 yeD
 yeD
 iab
@@ -93629,16 +93631,16 @@ eLE
 "}
 (242,1,1) = {"
 eLE
-uTy
-xcW
-bRw
+sAE
+ool
+hYB
 lgH
 lgH
 agx
-uTy
-vAk
-vAk
-vAk
+sAE
+cfu
+cfu
+cfu
 yeD
 yeD
 yeD
@@ -93686,7 +93688,7 @@ vPg
 xVz
 xVz
 xVz
-xev
+xGx
 vPg
 xVz
 vPg
@@ -93886,16 +93888,16 @@ eLE
 "}
 (243,1,1) = {"
 eLE
-uTy
-oev
-xns
-obi
+sAE
+aNt
+pBy
+sQg
 lgH
 lgH
 aWQ
-vAk
-vAk
-vAk
+cfu
+cfu
+cfu
 yeD
 iWZ
 sEB
@@ -93915,9 +93917,9 @@ vKK
 tDk
 qMn
 bAm
-otW
-pLA
-dcO
+jvI
+nRs
+qQy
 dBk
 dBk
 dBk
@@ -93925,8 +93927,8 @@ sBM
 dBk
 dBk
 dBk
-wAU
-wAU
+xyn
+xyn
 vPg
 vPg
 aoj
@@ -94143,16 +94145,16 @@ eLE
 "}
 (244,1,1) = {"
 eLE
-kAm
-xcW
-xns
+pnK
+ool
+pBy
 lgH
 lgH
 agx
-uTy
-nIl
-vAk
-vAk
+sAE
+rle
+cfu
+cfu
 xQo
 iWZ
 sEB
@@ -94172,19 +94174,19 @@ vKK
 dBk
 dBk
 dBk
-gCM
+upY
 sBZ
-pDM
+frt
 dBk
-hSz
+phr
 iXo
 iXo
 iXo
-jiR
+lja
 dBk
 wGn
-wAU
-wAU
+xyn
+xyn
 vPg
 vPg
 aoj
@@ -94400,16 +94402,16 @@ eLE
 "}
 (245,1,1) = {"
 eLE
-uTy
+sAE
 agx
 agx
 lgH
 agx
-qBI
-uTy
+jOL
+sAE
 cgC
 gak
-sQa
+fUs
 yeD
 iWZ
 iWZ
@@ -94429,20 +94431,20 @@ vKK
 tDk
 qMn
 dBk
-rJc
+uqU
 sBZ
 sBZ
 tLv
-tIR
+hgp
 iXo
 iXo
 iXo
 vHE
 dBk
 gsv
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
 vPg
 aoj
 aoj
@@ -94657,16 +94659,16 @@ eLE
 "}
 (246,1,1) = {"
 eLE
-uTy
-uTy
-btc
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
+sAE
+sAE
+pnO
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
 yeD
 iWZ
 sEB
@@ -94690,17 +94692,17 @@ dBk
 dBk
 dBk
 dBk
-bde
+pYB
 iXo
-pnO
+xCH
 iXo
 iXo
 dBk
 wHH
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
 xVz
 xVz
 xVz
@@ -94914,21 +94916,21 @@ eLE
 "}
 (247,1,1) = {"
 eLE
-uTy
-lmc
-lDe
-uTy
-sBF
-cOc
-gOq
-cOc
 sAE
-uTy
+pjo
+tms
+sAE
+mtc
+cAf
+oev
+cAf
+aZm
+sAE
 jJl
 iWZ
 sEB
 iWZ
-xYt
+tuI
 iWZ
 sEB
 iWZ
@@ -94937,27 +94939,27 @@ oSi
 iWZ
 qyf
 yeD
-feI
+yaZ
 tQb
-qfy
+vbt
 pPd
 pPd
 tQb
-cLG
-tgQ
-xJM
+fnq
+cDY
+fQb
 dBk
-tms
+niu
 iXo
 ojv
 iXo
 iXo
 sBM
 nlz
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
 xVz
 xVz
 xVz
@@ -95171,16 +95173,16 @@ eLE
 "}
 (248,1,1) = {"
 eLE
-uTy
-cfu
-lDe
-uTy
-sZz
+sAE
+nbm
+tms
+sAE
+kCW
 mHl
 mHl
 mHl
-cOc
-uTy
+cAf
+sAE
 eSu
 iWZ
 sEB
@@ -95194,27 +95196,27 @@ kCd
 ibg
 akC
 qZB
-lfs
+fww
 tQb
-pnK
-pnK
-pnK
+aQb
+aQb
+aQb
 tQb
-cDY
-wQj
-oSB
+tBh
+cGV
+lVB
 dBk
-cAf
+bCe
 iXo
 ols
 iXo
 iXo
 dBk
 daD
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
 xVz
 xVz
 lVx
@@ -95428,16 +95430,16 @@ eLE
 "}
 (249,1,1) = {"
 eLE
-uTy
-pjo
-lDe
-uTy
-jmS
+sAE
+sZz
+tms
+sAE
+iVj
 mHl
-jEu
+dcO
 mHl
-cOc
-uTy
+cAf
+sAE
 xsn
 xsn
 xsn
@@ -95451,28 +95453,28 @@ xsn
 xsn
 xsn
 yeD
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-wWD
-wQj
-xRn
-dBk
 iTZ
+iTZ
+iTZ
+iTZ
+iTZ
+iTZ
+sQa
+cGV
+lWW
+dBk
+ioI
 iXo
 iXo
 vdx
 iXo
 dBk
 qHL
-wAU
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
+xyn
 vPg
 vPg
 vPg
@@ -95685,51 +95687,51 @@ eLE
 "}
 (250,1,1) = {"
 eLE
-uTy
-uTy
-uTy
-uTy
-uqU
+sAE
+sAE
+sAE
+sAE
+upG
 aOU
-phr
+qKB
 cgP
-cOc
-kYn
+cAf
+lLs
 xsn
 xsn
-osu
-xsn
-xsn
-xsn
+xYt
 xsn
 xsn
 xsn
-osu
+xsn
+xsn
+xsn
+xYt
 xsn
 xsn
 raa
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
+iTZ
+iTZ
+iTZ
+iTZ
+iTZ
+iTZ
 rNh
-xWB
-iXo
+lfs
+sBF
 dBk
-hgp
+ajx
 dBk
-xCH
+tJx
 dBk
 xgK
 dBk
 wej
-wAU
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
+xyn
 vPg
 vPg
 vPg
@@ -95942,16 +95944,16 @@ eLE
 "}
 (251,1,1) = {"
 eLE
-uTy
-bXJ
-kvw
-btc
-cOc
+sAE
+bde
+xtz
+pnO
+cAf
 mHl
 uhC
 mHl
-cOc
-uTy
+cAf
+sAE
 xsn
 xsn
 xsn
@@ -95965,28 +95967,28 @@ xsn
 xsn
 xsn
 yeD
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-muq
+iTZ
+iTZ
+iTZ
+iTZ
+iTZ
+iTZ
+rJc
 stk
 rhb
 dBk
-pYB
-upG
+cdu
+dzf
 fYO
-upG
-upG
+dzf
+dzf
 dBk
 vPg
 vPg
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
 vPg
 vPg
 vPg
@@ -96199,28 +96201,28 @@ eLE
 "}
 (252,1,1) = {"
 eLE
-uTy
-ool
-miB
-uTy
-cOc
+sAE
+xJM
+otW
+sAE
+cAf
 mHl
 mHl
 mlH
-cOc
-uTy
+cAf
+sAE
 jLd
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
-fnq
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
 yeD
 nWH
 tQb
@@ -96228,9 +96230,9 @@ pPd
 pPd
 pPd
 tQb
-cDY
+tBh
 stk
-oSB
+lVB
 dBk
 dBk
 dBk
@@ -96240,10 +96242,10 @@ dBk
 dBk
 vPg
 vPg
-wAU
-wAU
-wAU
-wAU
+xyn
+xyn
+xyn
+xyn
 vPg
 vPg
 vPg
@@ -96456,38 +96458,38 @@ eLE
 "}
 (253,1,1) = {"
 eLE
-uxz
-wgb
-kvw
-uTy
-sZz
-xdk
+aVi
+usd
+xtz
 sAE
-cOc
+kCW
+iBC
+aZm
+cAf
+aZm
 sAE
-uTy
 jLd
-fnq
-xQh
+mpK
+wKL
 lHt
 wKj
-fnq
+mpK
 kaE
-xQh
+wKL
 kZo
-qcK
-fnq
-fnq
+qdg
+mpK
+mpK
 yeD
-feI
+yaZ
 tQb
-obT
-pnK
-pnK
+whQ
+aQb
+aQb
 tQb
-bfc
-nwf
-wPR
+jEu
+uxx
+jyZ
 dBk
 vPg
 vPg
@@ -96497,10 +96499,10 @@ vPg
 vPg
 vPg
 vPg
-wAU
-wAU
-wAU
-xfJ
+xyn
+xyn
+xyn
+xcW
 vPg
 vPg
 vPg
@@ -96713,16 +96715,16 @@ eLE
 "}
 (254,1,1) = {"
 eLE
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
-uTy
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
+sAE
 yeD
 yeD
 yeD
@@ -96733,7 +96735,7 @@ yeD
 yeD
 yeD
 yeD
-wSV
+wSi
 yeD
 yeD
 dBk
@@ -96753,11 +96755,11 @@ vPg
 vPg
 vPg
 vPg
-xfJ
-wAU
-wAU
-xFY
-xfJ
+xcW
+xyn
+xyn
+jmS
+xcW
 vPg
 vPg
 xVz
@@ -97010,11 +97012,11 @@ eLE
 eLE
 eLE
 eLE
-xfJ
-hZA
-hZA
-hZA
-xfJ
+xcW
+fJs
+fJs
+fJs
+xcW
 eLE
 eLE
 eLE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -86,12 +86,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "ade" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/smartfridge,
+/turf/open/space/basic,
+/area/f13/brotherhood/leisure)
 "adr" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/handrail/g_central{
@@ -180,16 +177,6 @@
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"agn" = (
-/obj/effect/decal/cleanable/robot_debris/limb{
-	layer = 1.5
-	},
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_white,
-/obj/item/stack/cable_coil/random/five,
-/obj/item/circuitboard/machine/ore_silo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "agw" = (
 /obj/machinery/door/poddoor{
 	id = "soup"
@@ -282,9 +269,6 @@
 /obj/structure/falsewall/rust,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ajx" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood)
 "ajG" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -310,11 +294,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "alI" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "amD" = (
 /obj/structure/handrail/g_central{
@@ -514,13 +510,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "avj" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/obj/machinery/flasher/portable,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/item/gun/energy/laser/plasma/scatter{
+	anchored = 1;
+	cell_type = null;
+	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
+	name = "display multiplas rifle";
+	pin = null;
+	pixel_y = 32
 	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/sentinel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "avk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -945,7 +950,7 @@
 	},
 /area/f13/sewer)
 "aLM" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/f13{
@@ -983,20 +988,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aNt" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/item/gun/energy/laser/rcw{
+	anchored = 1;
+	cell_type = null;
+	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
+	name = "display laser RCW";
+	pin = null;
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "aOi" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib2_flesh"
@@ -1049,60 +1054,17 @@
 	},
 /area/f13/building)
 "aQb" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/obj/item/storage/belt/holster,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood)
 "aQc" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/electropack/shockcollar{
@@ -1148,17 +1110,9 @@
 	},
 /area/f13/building)
 "aSi" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque denoting a room dedicated to the maintenance of mechanized infantry equipment.";
-	name = "Power Armor Maintenance";
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/computer/card/bos,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "aSo" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall/rust,
@@ -1227,9 +1181,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aVi" = (
-/obj/structure/closet/crate/critter,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "aVU" = (
 /obj/structure/flora/rock/pile/largejungle{
 	layer = 3.2;
@@ -1347,14 +1302,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
-"aZm" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
 "aZp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -1537,6 +1484,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bde" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "bdf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -1601,13 +1552,16 @@
 	},
 /area/f13/brotherhood/rnd)
 "bfc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
+	},
+/area/f13/brotherhood)
 "bfu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -1687,15 +1641,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bjx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "bjI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1792,13 +1737,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "blV" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/furnace,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "bmf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -1949,8 +1893,11 @@
 	},
 /area/f13/tunnel)
 "brY" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/structure/bed/old,
+/obj/item/bedsheet/orange,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "bsi" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -2005,6 +1952,15 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"btc" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Admin Accommodation";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "btx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2316,24 +2272,15 @@
 	},
 /area/f13/tunnel)
 "bBA" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
+/obj/structure/fluff/railing{
+	dir = 6
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
 "bBM" = (
 /obj/item/pickaxe/drill,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bCe" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Admin Accommodation";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices2nd)
 "bCh" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -2398,6 +2345,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
+"bEm" = (
+/obj/structure/table/reinforced{
+	req_access_txt = "120"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "bEp" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2580,6 +2541,15 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/enclave)
+"bLn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "bLy" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13{
@@ -2839,13 +2809,14 @@
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"bRL" = (
-/obj/structure/table/wood/poker,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"bRw" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin,
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "bRV" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/f13{
@@ -2978,19 +2949,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bXJ" = (
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/machinery/recharger,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "bXM" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -3198,8 +3164,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cdu" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/structure/table/reinforced{
+	req_access_txt = "120"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -3244,6 +3214,14 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"cfu" = (
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "cfB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3469,18 +3447,16 @@
 	},
 /area/f13/caves)
 "cmM" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cnf" = (
 /obj/item/electronics/apc,
@@ -3577,12 +3553,25 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cqG" = (
-/obj/structure/chair/wood{
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "cqI" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3817,14 +3806,9 @@
 	},
 /area/f13/sewer)
 "cAf" = (
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_x = 4;
-	pixel_y = 3;
-	termtag = "Security"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/old,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cAi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -3959,9 +3943,9 @@
 	},
 /area/f13/tunnel)
 "cDY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorknight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
+	},
 /area/f13/brotherhood)
 "cEh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4045,30 +4029,26 @@
 	},
 /area/f13/sewer)
 "cGV" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/stack/sheet/prewar/five,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cGZ" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/inside/subway,
@@ -4185,11 +4165,16 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cLG" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fluff/railing{
+	dir = 5
 	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
+/area/f13/brotherhood)
 "cLK" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -4329,6 +4314,10 @@
 	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood/leisure)
+"cQN" = (
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cQW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4371,17 +4360,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "cSe" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/effect/overlay/junk/mirror{
-	pixel_y = 32
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/medical)
 "cSq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
@@ -4428,6 +4412,14 @@
 /obj/machinery/reagentgrinder,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"cUh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cUk" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -4532,6 +4524,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
+"cYh" = (
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "cYk" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/remains{
@@ -4625,6 +4623,12 @@
 /obj/structure/falsewall/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
+"dcO" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/keg,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ddg" = (
@@ -4784,11 +4788,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
-"djq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "djS" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -5085,12 +5084,6 @@
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"dtG" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "duv" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -5296,18 +5289,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
-"dAy" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	pixel_y = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
 "dAO" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -6943,28 +6924,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "eEh" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/flasher/portable,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "eEq" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7301,17 +7268,6 @@
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"eMo" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/comfy/teal{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
 "eMx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
@@ -7417,6 +7373,11 @@
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
+/area/f13/brotherhood)
+"ePO" = (
+/obj/structure/table,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "ePT" = (
 /obj/structure/nest/deathclaw,
@@ -7702,14 +7663,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"fbn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
 "fbz" = (
 /obj/structure/fence/pole_b,
 /obj/effect/decal/cleanable/dirt{
@@ -7724,6 +7677,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fce" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "fcz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Fort Hazard Holding Cell";
@@ -7778,8 +7736,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "feI" = (
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "ffy" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -8053,14 +8012,10 @@
 	},
 /area/f13/building)
 "fnq" = (
-/obj/structure/table{
-	layer = 2.9
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/archives)
 "fnD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -8205,11 +8160,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "frt" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/table/wood/poker,
+/obj/item/toy/figure/hos{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Paladin Action Figure";
+	toysay = "SEMPER INVICTA!"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/offices2nd)
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "frz" = (
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/cleanable/dirt,
@@ -8320,13 +8279,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "fvU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/door/airlock/grunge{
+	name = "Power Armor Maintenance Room";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/armory)
 "fwa" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -8343,6 +8303,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"fww" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "fwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -8452,15 +8416,9 @@
 /area/f13/building)
 "fzc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "fzj" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8713,11 +8671,15 @@
 	},
 /area/f13/clinic)
 "fIc" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/sign/poster/prewar/poster63{
+	pixel_y = 32
 	},
-/area/f13/brotherhood/operations)
+/obj/item/flag/bos,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "fIf" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -8756,6 +8718,14 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/enclave)
+"fJs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/wrench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fJG" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8875,6 +8845,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
+"fMP" = (
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "fMQ" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/wasteplant/wild_mesquite,
@@ -8987,11 +8960,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fQb" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "fQt" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/white/box,
@@ -9062,11 +9035,14 @@
 	},
 /area/f13/clinic)
 "fSi" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/area/f13/brotherhood/armory)
 "fSl" = (
 /obj/structure/window/fulltile/ruins/broken,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9141,9 +9117,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fUs" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
+	},
+/obj/item/storage/belt/holster,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "fUu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9162,18 +9147,9 @@
 /turf/open/floor/wood,
 /area/f13/bunker)
 "fUG" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "sentdorm";
-	name = "Head Paladin Billet";
-	req_access_txt = "120"
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
+/obj/structure/closet/crate,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "fUQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9241,14 +9217,6 @@
 /obj/structure/chair/left,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"fXl" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/machinery/light/floor,
-/obj/structure/fluff/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "fXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9385,6 +9353,14 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gcj" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "gcD" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -9419,13 +9395,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gdz" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/paper_bin,
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/medical{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood/medical)
 "gdH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9606,6 +9583,19 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
+"gkX" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/flashlight/lamp{
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -9717,10 +9707,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "gqM" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
 	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "gqW" = (
 /obj/structure/pondlily_small{
 	pixel_x = 34;
@@ -9741,12 +9732,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"gse" = (
-/obj/structure/fluff/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "gsv" = (
 /obj/structure/decoration/hatch{
 	dir = 1;
@@ -9763,12 +9748,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gtv" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/black,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "gtx" = (
 /obj/effect/decal/waste{
@@ -9983,14 +9969,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gAb" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Canteen";
-	req_access_txt = "120"
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "gAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper,
@@ -10070,8 +10056,13 @@
 /turf/open/indestructible/ground/outside/river,
 /area/f13/bunker)
 "gCM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/item/dice/d1,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "gCN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10137,8 +10128,14 @@
 /turf/open/water,
 /area/f13/sewer)
 "gFF" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 3;
+	termtag = "Security"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "gFV" = (
 /obj/structure/barricade/bars,
@@ -10388,13 +10385,13 @@
 	},
 /area/f13/bunker)
 "gOq" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
+/obj/item/kirbyplants{
+	icon_state = "plant-04"
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/offices2nd)
 "gOG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10437,10 +10434,10 @@
 	},
 /area/f13/bunker)
 "gPu" = (
+/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "gPy" = (
 /obj/structure/sign/poster/contraband/buzzfuzz{
 	pixel_y = -32
@@ -10494,6 +10491,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"gRd" = (
+/obj/structure/anvil/obtainable{
+	anvilquality = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "gRe" = (
 /obj/item/crowbar,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -10767,21 +10773,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gZQ" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
-	dir = 1;
-	name = "Head Knight's Office";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
-	},
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "gZR" = (
 /obj/structure/fluff/rails,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"haJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "hcp" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -10819,9 +10827,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "hdP" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "hdT" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -10847,12 +10855,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/bunker)
-"heQ" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/hot_potato/harmless/toy,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "hfr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -10869,15 +10871,10 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hgp" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill{
-	pixel_y = -10
-	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "hgy" = (
@@ -10894,8 +10891,12 @@
 	},
 /area/f13/tcoms)
 "hhe" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "hhi" = (
 /obj/item/paper/crumpled,
@@ -11538,11 +11539,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hNG" = (
-/obj/structure/bed/old,
+/obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/black,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Paladin Ramos"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood)
 "hNO" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/building)
@@ -11638,6 +11641,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
+"hQs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "hQy" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11668,35 +11679,30 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "hSp" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "hSz" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/effect/decal/cleanable/robot_debris/limb{
+	layer = 1.5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_white,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "hTd" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Paladin Office";
-	req_access_txt = "120"
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "hTw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11817,6 +11823,17 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"hXe" = (
+/obj/structure/fluff/railing{
+	dir = 6
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "hXt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -11827,11 +11844,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/brotherhood)
 "hXR" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "hXT" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -11849,6 +11864,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
+"hYB" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "hYZ" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -11857,6 +11884,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/sewer)
+"hZA" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/brotherhood)
 "hZW" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -11907,12 +11937,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "ibx" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
+/obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "ibM" = (
@@ -12098,14 +12123,11 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "ija" = (
-/obj/structure/fluff/railing{
-	dir = 5
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "iji" = (
@@ -12149,11 +12171,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ilD" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/medical)
 "imd" = (
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12199,17 +12224,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "ioI" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/area/f13/brotherhood/armory)
 "ioN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12238,10 +12274,22 @@
 	},
 /area/f13/bunker)
 "ipB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
 /obj/machinery/light/floor,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/rnd)
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
+"iqo" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "iqp" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot_white,
@@ -12431,10 +12479,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iyT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/closet/crate/wooden,
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/armory)
 "izb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12470,6 +12517,18 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
+"izR" = (
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
+	dir = 1;
+	name = "Head Knight's Office";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "iAm" = (
 /obj/structure/simple_door/repaired,
 /obj/effect/decal/cleanable/dirt,
@@ -12490,14 +12549,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "iBC" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "iBD" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -12691,13 +12748,6 @@
 /obj/item/pickaxe,
 /turf/open/water,
 /area/f13/sewer)
-"iMu" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "iMx" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -12905,11 +12955,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "iTZ" = (
-/obj/structure/bookcase,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"iUi" = (
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
 "iUn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12939,11 +12994,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iVj" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/keg,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "iVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -13138,63 +13193,21 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
+"jcm" = (
+/obj/structure/bed/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "jco" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
+/obj/machinery/door/airlock/grunge{
+	name = "Head Paladin Office";
+	req_access_txt = "120"
 	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/leisure)
 "jcG" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13369,14 +13382,12 @@
 	},
 /area/f13/sewer)
 "jiP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "jiR" = (
-/turf/open/floor/wood/f13/oak,
+/obj/machinery/suit_storage_unit/mining,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "jjd" = (
 /obj/structure/kitchenspike,
@@ -13420,13 +13431,12 @@
 /turf/open/water,
 /area/f13/tunnel)
 "jkw" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/structure/chair/f13foldupchair{
+	dir = 8
 	},
-/obj/item/dice/d1,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/brotherhood)
 "jkL" = (
 /turf/closed/wall/f13/tentwall,
@@ -13489,9 +13499,20 @@
 /turf/open/water,
 /area/f13/tunnel)
 "jmE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "jmN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -13499,9 +13520,14 @@
 	},
 /area/f13/bunker)
 "jmS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "jnc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13643,12 +13669,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jte" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "jtf" = (
 /obj/structure/disposalpipe/segment{
@@ -13696,9 +13719,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jvI" = (
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "jwy" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -13751,11 +13776,9 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jyZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "jzC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -13864,14 +13887,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEu" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/structure/table/wood/fancy/blue,
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "jEP" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 2;
@@ -14019,10 +14046,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jMF" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operating)
 "jMT" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
@@ -14051,6 +14077,63 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/sewer)
+"jOq" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "jOw" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/duffelbag,
@@ -14063,9 +14146,10 @@
 	},
 /area/f13/building)
 "jOL" = (
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "jPn" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/tree/jungle/small,
@@ -14412,11 +14496,11 @@
 	},
 /area/f13/building)
 "kcz" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "kcJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway{
@@ -14610,6 +14694,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/dirt,
 /area/f13/tunnel)
+"kkd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "kkg" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/wreck/trash/engine,
@@ -14766,17 +14856,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"ksU" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/glasses/meson,
-/obj/item/gps/mining{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "ksZ" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -14791,15 +14870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"kua" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
-	},
-/area/f13/brotherhood)
 "kuD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14838,11 +14908,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kvw" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "kvU" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -14851,11 +14918,54 @@
 	},
 /area/f13/brotherhood/leisure)
 "kwf" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "kwk" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -14931,15 +15041,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "kAm" = (
-/obj/structure/sign/poster/prewar/poster63{
-	pixel_y = 32
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
+/turf/open/space/basic,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices2nd)
 "kAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -15094,6 +15198,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"kFG" = (
+/obj/structure/decoration/smokeold{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "kFP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -15492,14 +15610,15 @@
 	},
 /area/f13/bunker)
 "kYn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "kYI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/spider/stickyweb,
@@ -15654,6 +15773,55 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
+"lfs" = (
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "lgv" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
@@ -15661,13 +15829,12 @@
 	},
 /area/f13/bunker)
 "lgG" = (
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/bed,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
 "lgH" = (
 /turf/open/floor/carpet/green,
 /area/f13/brotherhood/offices2nd)
@@ -15732,9 +15899,12 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "lja" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "ljJ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -15818,10 +15988,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "lmc" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "lmn" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -15996,18 +16166,11 @@
 	},
 /area/f13/bunker)
 "luk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/machinery/light/floor,
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "lup" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -16043,15 +16206,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"lvK" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/trash/f13/electronic/toaster{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "lwl" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/ruins,
@@ -16155,6 +16309,19 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"lAK" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "lAL" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
@@ -16206,6 +16373,9 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
+"lDe" = (
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "lDg" = (
 /obj/item/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -16236,11 +16406,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "lFa" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/chemistry)
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	pixel_y = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "lFd" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -16340,14 +16516,9 @@
 	},
 /area/f13/building)
 "lLb" = (
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "lLo" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -16391,9 +16562,30 @@
 	},
 /area/f13/clinic)
 "lMH" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
+	},
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
+	},
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "lMK" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /obj/effect/decal/waste{
@@ -16591,14 +16783,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
-"lUw" = (
-/obj/structure/bed/dogbed,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Paladin Ramos"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "lVd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -16677,12 +16861,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
-"lYp" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
 "lYx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16755,23 +16933,12 @@
 	},
 /area/f13/bunker)
 "mbe" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood)
 "mcf" = (
 /obj/structure/spider/stickyweb,
@@ -16869,12 +17036,11 @@
 	},
 /area/f13/caves)
 "miB" = (
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = -6;
-	pixel_y = 12
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -16939,10 +17105,14 @@
 	},
 /area/f13/clinic)
 "mlz" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/melee/powered/ripper,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "mlC" = (
 /obj/structure/table{
 	layer = 2.9
@@ -16954,13 +17124,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "mlH" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "mlV" = (
 /obj/item/radio/intercom{
 	desc = "Is there anyone on the other end? Who's in there?";
@@ -16980,13 +17146,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"mmf" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/archives)
 "mmi" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17038,12 +17197,6 @@
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"mnU" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
 "moK" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -17068,17 +17221,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "mpu" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "mpC" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "mpK" = (
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/fluff/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "mro" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
@@ -17092,14 +17253,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "mtc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/chemistry)
 "mth" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/biogenerator,
@@ -17130,20 +17288,13 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "muq" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
 /obj/structure/fluff/railing{
-	dir = 10
+	dir = 5
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
+/area/f13/brotherhood)
 "muF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17797,10 +17948,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nbm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "nbA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
@@ -18243,14 +18396,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"nwf" = (
+/turf/open/floor/wood/f13/stage_r,
+/area/f13/brotherhood)
 "nwI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/item/wrench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "nxk" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -18525,10 +18679,9 @@
 /turf/open/water,
 /area/f13/sewer)
 "nIl" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "nIu" = (
 /obj/structure/simple_door/metal/barred{
 	req_one_access_txt = "120"
@@ -18742,26 +18895,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"nRs" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "nRY" = (
 /obj/item/ammo_casing/a556,
 /turf/open/indestructible/ground/inside/subway,
@@ -18992,22 +19125,24 @@
 	},
 /area/f13/bunker)
 "obi" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "obl" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "obT" = (
-/obj/machinery/light/floor,
-/obj/structure/chair/folding{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
 	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ocb" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19053,16 +19188,23 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "odd" = (
-/obj/machinery/light/small/broken,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood)
-"odD" = (
-/obj/structure/bookcase,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/light/small,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
+"odD" = (
+/obj/structure/toilet{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/restraints/legcuffs,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "odG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
@@ -19098,9 +19240,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "oev" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/wood/fancy,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "oeC" = (
 /obj/item/ammo_casing/c10mm,
 /obj/effect/decal/cleanable/blood,
@@ -19340,14 +19483,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ool" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe Office";
-	req_access_txt = "120"
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/obj/structure/bed,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/offices2nd)
 "ooz" = (
 /obj/effect/decal/waste{
@@ -19357,10 +19498,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ooF" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "ooI" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -19390,26 +19529,21 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "orp" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/item/clothing/suit/bomb_suit/security,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "osd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "osu" = (
-/obj/structure/anvil/obtainable{
-	anvilquality = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/archives)
 "osv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19420,11 +19554,22 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "otW" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
+	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
+	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
+	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
+	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
+	doc_title_1 = "Journal 1 - New Home";
+	doc_title_2 = "Journal 2 - Mining Duty";
+	doc_title_3 = "Journal 3 - Dead-End?";
+	doc_title_4 = "Saved Draft - Crash?";
+	name = "battered terminal";
+	termtag = "Outpost Fargo System"
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/sign/poster/contraband/have_a_puff{
+	pixel_y = 32
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
@@ -19465,13 +19610,17 @@
 	},
 /area/f13/bunker)
 "ouT" = (
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Paladin's PipBoy"
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "ove" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19590,10 +19739,6 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"oyL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/arcade,
-/area/f13/brotherhood/offices2nd)
 "ozo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19821,9 +19966,15 @@
 	},
 /area/f13/brotherhood/rnd)
 "oLQ" = (
-/obj/effect/landmark/start/f13/knightcap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "oLX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -20015,14 +20166,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "oSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
+/obj/structure/chair/wood/fancy{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/brotherhood)
 "oSF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20120,9 +20268,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "oZG" = (
-/obj/machinery/computer/card/bos,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/item/melee/onehanded/machete/training,
+/obj/item/melee/onehanded/machete/training,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "oZJ" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/subway,
@@ -20171,13 +20323,18 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "paO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/machinery/light/floor,
 /obj/structure/fluff/railing{
-	dir = 9
+	dir = 1
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "paS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/wood,
@@ -20194,9 +20351,14 @@
 /area/f13/bunker)
 "pbh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "pbl" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/spacevine{
@@ -20331,11 +20493,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pgs" = (
-/obj/structure/table,
-/obj/item/melee/onehanded/machete/training,
-/obj/item/melee/onehanded/machete/training,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood/leisure)
 "pgt" = (
@@ -20374,14 +20535,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "phr" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Power Armor Maintenance Room";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/construction/rld,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "phB" = (
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/raidermelee,
@@ -20400,17 +20557,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pix" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/gps/mining,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "piI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -20431,7 +20588,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "pjo" = (
-/turf/closed/wall/r_wall,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/trash/f13/electronic/toaster{
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
 "pjs" = (
 /obj/structure/junk/small/bed2,
@@ -20516,18 +20679,22 @@
 	},
 /area/f13/sewer)
 "pnK" = (
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
+"pnO" = (
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
-"pnO" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
+/obj/item/clothing/glasses/meson,
+/obj/item/gps/mining{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices2nd)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "pnS" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -20669,10 +20836,9 @@
 /turf/open/water,
 /area/f13/sewer)
 "pub" = (
-/obj/structure/table,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "pud" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -20748,10 +20914,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/bunker)
-"pyg" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "pyK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20842,11 +21004,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "pCg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -20892,6 +21059,12 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/wall/rust,
 /area/f13/caves)
+"pDM" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "pDU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -20947,10 +21120,6 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
-"pHr" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
 "pHv" = (
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -21012,6 +21181,12 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
+"pLA" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "pMw" = (
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_x = 32
@@ -21059,18 +21234,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"pNR" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "pNS" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/carpet/red,
@@ -21185,6 +21348,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"pTV" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "pUe" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -21389,16 +21566,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"qba" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/operations)
 "qcl" = (
 /obj/structure/campfire/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -21415,71 +21582,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qcK" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
+/obj/structure/chair/comfy/teal{
+	dir = 1
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/archives)
 "qcW" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"qdg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "qew" = (
 /obj/structure/car,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -21509,15 +21625,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
-"qfe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/brotherhood)
 "qff" = (
 /obj/structure/tires,
 /obj/effect/decal/cleanable/dirt{
@@ -21534,6 +21641,15 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"qfy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "qfX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/bonfire/prelit,
@@ -21554,11 +21670,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qgy" = (
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "qgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -21567,12 +21683,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"qhj" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood)
 "qhk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -21618,6 +21728,15 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"qin" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Storage";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/armory)
 "qip" = (
 /mob/living/simple_animal/hostile/radscorpion/blue,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21838,11 +21957,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"qtk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
 "qtr" = (
 /obj/structure/chair{
 	dir = 4
@@ -21974,20 +22088,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
 "qzL" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/obj/item/gun/energy/laser/rcw{
-	anchored = 1;
-	cell_type = null;
-	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
-	name = "display laser RCW";
-	pin = null;
-	pixel_y = 32
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
+/obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/dorms)
 "qAe" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -22050,9 +22155,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "qBI" = (
-/obj/machinery/suit_storage_unit/mining,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/item/kirbyplants,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood/offices2nd)
 "qBZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
@@ -22188,13 +22293,13 @@
 /turf/open/water,
 /area/f13/sewer)
 "qHb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "qHd" = (
 /obj/structure/table,
@@ -22225,10 +22330,12 @@
 /turf/open/water,
 /area/f13/sewer)
 "qIB" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/construction/rld,
-/turf/open/floor/carpet/arcade,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "qIH" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -22274,11 +22381,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "qKB" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/operations)
 "qLi" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -22388,12 +22497,14 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"qQa" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+"qQy" = (
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "qQz" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -22414,11 +22525,12 @@
 	},
 /area/f13/enclave)
 "qRb" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "qRc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -22473,12 +22585,6 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"qTX" = (
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "qUd" = (
 /obj/machinery/light{
 	dir = 1
@@ -22488,13 +22594,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "qUq" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/rnd)
 "qUr" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -22567,9 +22670,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "qXf" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "qXj" = (
 /obj/machinery/light/small,
@@ -22705,6 +22807,11 @@
 /obj/effect/mob_spawn/human/corpse/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"rbj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "rbr" = (
 /obj/structure/closet/crate/large,
 /obj/item/trash/f13/electronic/toaster/atomics,
@@ -22864,9 +22971,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "rkb" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating";
-	sunlight_state = 1
+/obj/machinery/door/airlock/hatch{
+	name = "Fargo Holding Cell";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/brotherhood)
 "rkv" = (
@@ -22879,11 +22989,10 @@
 	},
 /area/f13/bunker)
 "rle" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/obj/structure/fluff/railing,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "rln" = (
 /obj/structure/chair/wood/fancy,
 /obj/structure/decoration/rag{
@@ -22960,8 +23069,60 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rnI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "rnO" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -23018,15 +23179,11 @@
 	},
 /area/f13/bunker)
 "rpS" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/restraints/legcuffs,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "rpZ" = (
 /obj/structure/fluff/railing,
 /obj/structure/lattice{
@@ -23297,12 +23454,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "ryt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
-	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	name = "Head Paladin Billet";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood)
 "ryw" = (
 /obj/structure/table/wood,
@@ -23318,11 +23480,10 @@
 	},
 /area/f13/caves)
 "ryS" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7{
-	pixel_y = 5
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
@@ -23612,12 +23773,10 @@
 	},
 /area/f13/brotherhood/operations)
 "rJc" = (
-/obj/structure/fluff/railing{
-	dir = 5
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/hot_potato/harmless/toy,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "rJp" = (
 /obj/machinery/button/door{
@@ -23689,13 +23848,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
-"rKX" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood)
 "rLv" = (
 /obj/item/trash/f13/dog,
 /obj/effect/decal/cleanable/dirt,
@@ -23907,12 +24059,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rTv" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "rTW" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
@@ -24025,15 +24180,19 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "rYD" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/figure/hos{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Paladin Action Figure";
-	toysay = "SEMPER INVICTA!"
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
 	},
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "rYE" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/wirecutters/power,
@@ -24094,8 +24253,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "saB" = (
-/turf/open/floor/wood/f13/stage_l,
-/area/f13/brotherhood)
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "saC" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -24181,14 +24346,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"sfl" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "sfu" = (
 /obj/machinery/light{
 	dir = 8
@@ -24243,10 +24400,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shq" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "shB" = (
 /obj/machinery/light/small,
 /obj/item/mine/shrapnel,
@@ -24522,12 +24680,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "svf" = (
-/turf/open/floor/carpet,
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "svr" = (
-/obj/machinery/smartfridge,
-/turf/open/space/basic,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "sxm" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Head Knight Billet";
@@ -24629,11 +24790,13 @@
 	},
 /area/f13/brotherhood)
 "sAE" = (
-/obj/structure/chair/comfy/teal,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "sAW" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/candle_box{
@@ -24643,9 +24806,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sBF" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/bookcase,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "sBG" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -24693,13 +24859,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "sDw" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
 	},
-/obj/machinery/light/floor,
-/obj/structure/fluff/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/effect/overlay/junk/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "sDG" = (
 /obj/structure/table/wood/fancy/blackred,
 /obj/item/candle{
@@ -24713,11 +24883,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sEa" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/obj/machinery/vending/wallmed{
+/obj/machinery/button/door{
+	id = "sentdorm";
+	normaldoorcontrol = 1;
 	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+	specialfunctions = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/rd{
+	desc = "A fine quilted blanket, made with purple and yellow fabric.";
+	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
+	name = "fine bedsheet"
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
@@ -24978,16 +25154,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sQa" = (
-/obj/structure/fluff/railing{
-	dir = 9
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "sQp" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -25013,6 +25184,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"sQX" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "sRo" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -25031,13 +25213,8 @@
 /area/f13/tunnel)
 "sSJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
@@ -25126,11 +25303,11 @@
 	},
 /area/f13/sewer)
 "sXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "sXM" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib4-old"
@@ -25138,14 +25315,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sXU" = (
-/obj/structure/table,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "sYr" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
@@ -25169,6 +25343,12 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/enclave)
+"sZz" = (
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "tad" = (
 /obj/structure/chair{
 	dir = 4
@@ -25302,14 +25482,8 @@
 	},
 /area/f13/brotherhood/chemistry)
 "tgQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/medical{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/wood/f13/stage_l,
+/area/f13/brotherhood)
 "thm" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -25398,24 +25572,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "tlr" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
-	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
-	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
-	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
-	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
-	doc_title_1 = "Journal 1 - New Home";
-	doc_title_2 = "Journal 2 - Mining Duty";
-	doc_title_3 = "Journal 3 - Dead-End?";
-	doc_title_4 = "Saved Draft - Crash?";
-	name = "battered terminal";
-	termtag = "Outpost Fargo System"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/sign/poster/contraband/have_a_puff{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/tunnel,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
 "tls" = (
 /obj/structure/closet/cabinet,
@@ -25439,9 +25600,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tms" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/gps/mining,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "tmz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25659,9 +25828,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
 "tuI" = (
-/turf/open/space/basic,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/medical)
 "tvv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25816,19 +25987,34 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "tAG" = (
-/obj/machinery/iv_drip,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "redmark"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood)
+"tBh" = (
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque denoting a room dedicated to the maintenance of mechanized infantry equipment.";
+	name = "Power Armor Maintenance";
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "tBZ" = (
-/obj/structure/fans/tiny{
-	pixel_x = 32
+/obj/machinery/light/floor,
+/obj/structure/chair/folding{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood)
 "tCQ" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
@@ -25978,12 +26164,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "tIR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/turf/open/floor/plating/tunnel,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill{
+	pixel_y = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "tJc" = (
 /obj/structure/flora/wasteplant/wild_broc,
@@ -26058,11 +26248,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "tKY" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
 "tKZ" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
@@ -26149,11 +26340,13 @@
 /area/f13/brotherhood)
 "tQD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/lattice/catwalk,
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_y = 32
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/brotherhood)
 "tQH" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/boxing/blue,
@@ -26405,8 +26598,15 @@
 	},
 /area/f13/bunker)
 "ueZ" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/old,
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ufY" = (
 /obj/effect/decal/cleanable/dirt{
@@ -26544,13 +26744,20 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "ulh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood)
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -26590,6 +26797,9 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
+"umZ" = (
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "unm" = (
 /obj/structure/nest/deathclaw{
 	max_mobs = 2
@@ -26627,20 +26837,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "upG" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "upY" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "uqc" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/black,
@@ -26682,18 +26887,13 @@
 	},
 /area/f13/caves)
 "uqU" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
+/area/f13/brotherhood/offices2nd)
 "ura" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/grass,
@@ -26704,31 +26904,12 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/tunnel)
-"urw" = (
-/obj/machinery/button/door{
-	id = "sentdorm";
-	normaldoorcontrol = 1;
-	pixel_y = 32;
-	specialfunctions = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood)
 "urF" = (
 /obj/effect/decal/waste,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
-"usd" = (
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "usk" = (
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -26864,17 +27045,11 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "uxz" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/offices2nd)
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
@@ -26940,9 +27115,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/brotherhood/medical)
-"uBW" = (
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood)
 "uCj" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/machinery/light/small{
@@ -26979,10 +27151,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
-"uDa" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -27058,15 +27226,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uHu" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/obj/structure/lattice{
-	density = 1
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "uHB" = (
 /obj/structure/flora/junglebush/large,
@@ -27129,14 +27293,11 @@
 /turf/open/floor/wood/f13/oakbroken3,
 /area/f13/sewer)
 "uKV" = (
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 10
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "uLn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
@@ -27153,15 +27314,11 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "uLI" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "uLP" = (
 /turf/open/floor/wood/f13/housewoodbroken2,
 /area/f13/building)
@@ -27319,21 +27476,14 @@
 	},
 /area/f13/enclave)
 "uTy" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/offices2nd)
 "uTE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"uUH" = (
-/turf/open/floor/wood/f13/stage_r,
-/area/f13/brotherhood)
 "uVg" = (
 /obj/structure/showcase/mecha/marauder{
 	desc = "A stand with an empty old combat suit bolted to it. It represents the brotherhood who took part in the Republic-Enclave war back west. We had honor back then.";
@@ -27364,11 +27514,11 @@
 	},
 /area/f13/bunker)
 "uXj" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "uXF" = (
 /obj/structure/lattice{
 	layer = 3
@@ -27436,6 +27586,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
+"uYY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "uZI" = (
 /obj/structure/sign/warning{
 	pixel_x = 6;
@@ -27485,8 +27643,14 @@
 	},
 /area/f13/bunker)
 "vbt" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "vbx" = (
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
@@ -27582,24 +27746,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "vep" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
-	},
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/start/f13/seniorknight,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "veu" = (
@@ -27614,23 +27762,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "veQ" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_y = 32
-	},
-/obj/structure/chair/comfy/beige,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/sentinel,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/area/f13/brotherhood/dorms)
 "veR" = (
 /obj/structure/fence,
 /turf/open/floor/f13{
@@ -27699,20 +27837,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vhk" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/seniorpaladin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vhB" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -27742,13 +27870,6 @@
 	},
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
-"vjG" = (
-/obj/structure/furnace,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -27762,11 +27883,11 @@
 	},
 /area/f13/sewer)
 "vkg" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/leisure)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -27980,13 +28101,21 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
+"vsP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vtf" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "vtj" = (
 /obj/machinery/light/floor,
 /obj/item/kirbyplants/random,
@@ -28171,17 +28300,6 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"vzq" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood)
 "vAk" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices2nd)
@@ -28436,11 +28554,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "vKz" = (
-/obj/structure/fluff/railing{
-	dir = 6
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/obj/machinery/flasher/portable,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "vKK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
@@ -28900,14 +29016,10 @@
 	},
 /area/f13/bunker)
 "wbN" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Storage";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
 "wbZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -28957,6 +29069,31 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
+"weo" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/stack/sheet/prewar/five,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "weC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -28971,39 +29108,38 @@
 	},
 /area/f13/caves)
 "weW" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -9;
+	pixel_y = 21
 	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 16
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wft" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"wfJ" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "wgb" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/closet/cabinet,
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_y = 32
 	},
-/obj/item/flashlight/lamp{
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
-	pixel_x = 16;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "wgc" = (
 /obj/structure/table{
 	layer = 2.9
@@ -29053,13 +29189,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "whQ" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood)
 "wiz" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29111,18 +29244,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wlf" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/carpet/arcade,
-/area/f13/brotherhood/offices2nd)
+/area/f13/brotherhood/leisure)
 "wln" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -29298,11 +29424,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
-"wtE" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices2nd)
 "wtK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/closed/wall/f13/wood/house,
@@ -29466,30 +29587,8 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "wAU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
-	},
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/bot_red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood)
 "wBa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29570,18 +29669,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wFv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "wFD" = (
 /turf/open/water,
 /area/f13/sewer)
@@ -29689,17 +29781,6 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/rnd)
-"wIU" = (
-/obj/structure/fluff/railing{
-	dir = 6
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/bos,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "wJj" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
@@ -29751,14 +29832,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wKL" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/melee/powered/ripper,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -29811,10 +29892,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wMJ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "wNf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29831,10 +29919,11 @@
 	},
 /area/f13/bunker)
 "wNy" = (
-/obj/structure/fluff/railing,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "wND" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -29864,28 +29953,20 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
 "wPR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/chair/wood/fancy{
+	dir = 1
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
+	},
+/area/f13/brotherhood)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wQj" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Paladin's PipBoy"
-	},
-/turf/open/floor/wood/f13/old,
+/turf/open/floor/wood/f13/oak,
 /area/f13/brotherhood)
 "wQn" = (
 /obj/structure/cable{
@@ -29935,26 +30016,13 @@
 "wSc" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/armory)
-"wSi" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood)
 "wSV" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/archives)
 "wTz" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -30001,19 +30069,13 @@
 /turf/open/water,
 /area/f13/sewer)
 "wWD" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/obj/item/gun/ballistic/automatic/pistol/pistol22,
-/obj/item/gun/ballistic/automatic/pistol/pistol22,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "wWF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -30095,11 +30157,9 @@
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "xas" = (
 /obj/structure/rack,
@@ -30157,8 +30217,10 @@
 	},
 /area/f13/building)
 "xcW" = (
-/obj/structure/table/wood/fancy/royalblack,
-/turf/open/floor/carpet/green,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood/offices2nd)
 "xcX" = (
 /obj/structure/sign/departments/security,
@@ -30169,6 +30231,14 @@
 	icon_state = "2-i"
 	},
 /area/f13/bunker)
+"xdk" = (
+/obj/structure/fans/tiny{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "xdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30188,14 +30258,14 @@
 	},
 /area/f13/clinic)
 "xev" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/brotherhood/offices2nd)
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "xeC" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30208,20 +30278,19 @@
 	},
 /area/f13/bunker)
 "xfi" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/chair/wood{
+	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood)
 "xfq" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xfJ" = (
-/obj/effect/landmark/start/f13/elder,
-/obj/structure/chair/wood/fancy,
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/offices2nd)
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood)
 "xgs" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -30229,16 +30298,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "xgw" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "xgK" = (
 /obj/machinery/conveyor/auto{
@@ -30248,15 +30309,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xgN" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "xgY" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
@@ -30267,19 +30322,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/brotherhood/medical)
-"xhV" = (
-/obj/structure/closet/crate,
+"xic" = (
+/obj/structure/closet/crate/critter,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/armory)
-"xic" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Fargo Holding Cell";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
 "xig" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -30314,10 +30360,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "xje" = (
-/obj/structure/chair/stool/retro/black,
-/obj/machinery/light/small{
+/obj/structure/chair/f13chair1{
 	dir = 1
 	},
+/obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -30430,23 +30476,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
 "xns" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -9;
-	pixel_y = 21
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 10;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "xnz" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -30562,14 +30594,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "xta" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Canteen";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "xtk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -30581,11 +30613,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
-"xtz" = (
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood)
 "xtA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/tunnel,
@@ -30612,10 +30639,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "xuo" = (
-/turf/open/floor/f13{
-	dir = 4;
-	icon_state = "rampdowntop"
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "xuq" = (
 /obj/structure/cable{
@@ -30722,14 +30749,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"xyn" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
 "xyz" = (
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30892,17 +30911,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xFY" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/pda{
-	icon_state = "pda-warden";
-	name = "Armory Warden PDA"
-	},
-/obj/item/storage/belt/holster,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/gloves/combat,
-/turf/open/floor/wood/f13/old,
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood)
 "xGd" = (
 /obj/structure/closet/crate/footlocker{
@@ -30915,16 +30925,6 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
-"xGx" = (
-/obj/structure/closet/cabinet,
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_y = 32
-	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/offices2nd)
 "xGV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -30979,9 +30979,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "xHW" = (
-/obj/item/kirbyplants,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices2nd)
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 10
+	},
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "xIe" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -31032,6 +31037,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"xJM" = (
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
+	},
+/area/f13/brotherhood)
 "xKD" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -31125,7 +31138,15 @@
 /turf/open/water,
 /area/f13/sewer)
 "xPm" = (
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"xPu" = (
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "xPO" = (
 /obj/machinery/light/small{
@@ -31156,9 +31177,11 @@
 	},
 /area/f13/enclave)
 "xQh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/dorms)
+/obj/structure/chair/comfy/teal,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/archives)
 "xQo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Fargo Outpost";
@@ -31200,13 +31223,10 @@
 	},
 /area/f13/brotherhood/operations)
 "xRn" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood)
 "xRv" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -31325,9 +31345,9 @@
 	},
 /area/f13/bunker)
 "xWB" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/turf/open/floor/wood/f13/old,
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
+	},
 /area/f13/brotherhood)
 "xWH" = (
 /obj/structure/stairs/south{
@@ -31379,6 +31399,12 @@
 /obj/structure/table{
 	layer = 2.9
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "xZy" = (
@@ -31405,53 +31431,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "yaZ" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "ybf" = (
 /obj/effect/decal/remains/human,
@@ -31494,6 +31474,21 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"yei" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "yey" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -31605,6 +31600,10 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
+"yiX" = (
+/obj/structure/chair/f13chair1,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "ykf" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating/tunnel{
@@ -31619,8 +31618,17 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "ykR" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 10
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
@@ -31640,10 +31648,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"ylk" = (
-/obj/machinery/light/floor,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/archives)
 "yln" = (
 /obj/structure/simple_door/metal/iron,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -81557,19 +81561,19 @@ dBk
 dBk
 dBk
 dBk
-ajx
-ajx
+hZA
+hZA
 dBk
 dBk
 dBk
 dBk
 dBk
-nIl
-nIl
+gPu
+gPu
 dBk
-mlz
+vhk
 mcz
-pyg
+jyZ
 dBk
 vPg
 aoj
@@ -81814,18 +81818,18 @@ ujt
 aaQ
 ujt
 dBk
-pHr
-oev
+lLb
+fww
 dBk
-wQj
-rle
-uqU
+ouT
+xuo
+lAK
 oAL
 dBk
 dBk
 dBk
 iXo
-pub
+ePO
 umo
 dBk
 vPg
@@ -82067,19 +82071,19 @@ vPg
 vPg
 yhT
 dBk
-qfe
+tQD
 fpe
 ujt
 dcE
-iyT
+fzc
 yix
 dBk
-rYD
+frt
 qCb
 qCb
 dBk
 kvl
-miB
+xPu
 lPl
 iXo
 umo
@@ -82331,7 +82335,7 @@ dBk
 yix
 sJp
 dBk
-ueZ
+hXR
 qCb
 qCb
 dBk
@@ -82588,11 +82592,11 @@ dBk
 sJp
 sJp
 dBk
-urw
-bBA
+sEa
+cYh
 uBp
 dBk
-xWB
+hdP
 uxx
 dBk
 dBk
@@ -82846,7 +82850,7 @@ sJp
 sJp
 ood
 ood
-fUG
+ryt
 dBk
 dBk
 dBk
@@ -82855,7 +82859,7 @@ dBk
 mjR
 wgA
 umo
-sSJ
+cmM
 dBk
 vPg
 vPg
@@ -83092,27 +83096,27 @@ vPg
 vPg
 vPg
 ood
-kwf
+uLI
 sJp
-luk
+paO
 hcp
 rXr
 wrm
-fXl
+gcj
 utF
 sJp
 tQH
 ood
 iXo
 dBk
-xns
-lUw
+weW
+hNG
 umo
 oAL
 mlC
 ont
 nzg
-xZn
+sSJ
 dBk
 ggZ
 aoj
@@ -83349,9 +83353,9 @@ vPg
 aoj
 aoj
 ood
-kvw
+shq
 sJp
-qTX
+wNy
 wrm
 wrm
 wrm
@@ -83360,16 +83364,16 @@ sJp
 sJp
 kEK
 ood
-ryt
-ouT
-gCM
-gCM
+cUh
+qQy
+qXf
+qXf
 umo
 dBk
-xZn
+sSJ
 umo
 ryZ
-nwI
+fJs
 dBk
 ggZ
 aoj
@@ -83606,7 +83610,7 @@ vPg
 aoj
 aoj
 ood
-jEu
+saB
 sJp
 rXr
 wrm
@@ -83617,15 +83621,15 @@ utF
 sJp
 lxZ
 ood
-veQ
+avj
 iYx
-rKX
-gCM
-gPu
+uHu
+qXf
+vsP
 dBk
-vep
+cGV
 umo
-cDY
+vep
 vcp
 dBk
 ggZ
@@ -83863,9 +83867,9 @@ vPg
 aoj
 aoj
 ood
-kvw
+shq
 sJp
-qTX
+wNy
 wrm
 rXr
 iuM
@@ -83875,15 +83879,15 @@ sJp
 hik
 ood
 niu
-lLb
-gCM
-gCM
+hTd
+qXf
+qXf
 umo
 dBk
-qdg
+xZn
 umo
 nzi
-xZn
+sSJ
 dBk
 ggZ
 vPg
@@ -84120,16 +84124,16 @@ vPg
 vPg
 vPg
 ood
-kwf
+uLI
 sJp
 hAk
 wrm
 wrm
 wrm
-sDw
+ipB
 utF
 sJp
-pgs
+oZG
 ood
 umo
 umo
@@ -84137,10 +84141,10 @@ umo
 umo
 umo
 dBk
-mbe
+alI
 umo
 yhF
-wFv
+wMJ
 dBk
 ggZ
 vPg
@@ -84385,17 +84389,17 @@ ood
 ood
 ood
 ood
-gAb
+xta
 ood
 ood
 ood
 ood
-hTd
+jco
 ood
 wSc
 wSc
 wSc
-phr
+fvU
 wSc
 wSc
 wSc
@@ -84644,30 +84648,30 @@ sJp
 sJp
 sJp
 sJp
-pNR
+pix
 ood
 oxm
 xsD
 xsD
 wSc
-vhk
-aSi
+ykR
+tBh
 xDb
 xDb
-nRs
-hSz
+cqG
+qgy
 qeX
-orp
-vkg
-ajx
-ajx
-ajx
+nbm
+sXq
+hZA
+hZA
+hZA
 dBk
-oZG
+aSi
+qCb
+aQb
 qCb
 xgw
-qCb
-lja
 dBk
 vPg
 aoj
@@ -84893,7 +84897,7 @@ oPe
 xOz
 ccJ
 ood
-tQD
+lja
 sJp
 yix
 yix
@@ -84901,30 +84905,30 @@ sJp
 sJp
 sJp
 sJp
-pNR
+pix
 ood
 mvU
 xsD
 xsD
 wSc
-wWD
+pTV
 xDb
+ibx
 xDb
-xDb
-eEh
-hSz
-pBy
+ioI
+qgy
+rpS
 cwz
 wSc
-xuo
-xuo
-xuo
+hSp
+hSp
+hSp
 dBk
-xFY
+fUs
 dEr
 dEr
+svf
 gFF
-cAf
 dBk
 aoj
 vPg
@@ -85158,30 +85162,30 @@ ffy
 kvU
 bko
 sJp
-pNR
+pix
 ood
 mzi
 xsD
 xsD
 wSc
-aNt
+jmE
 xDb
+ibx
 xDb
-xDb
-aQb
-ykR
-upY
-qcK
+rnI
+uKV
+gqM
+kwf
 wSc
-rkb
+svr
 rXC
-rkb
+svr
 dBk
-sEa
+qHb
 qCb
 dEr
 qCb
-lja
+xgw
 dBk
 vPg
 vPg
@@ -85410,12 +85414,12 @@ ood
 hmO
 sJp
 dma
-rTv
+tKY
 ffy
 ffy
 bko
 sJp
-pNR
+pix
 ood
 mDL
 xsD
@@ -85423,16 +85427,16 @@ xsD
 ouH
 xDb
 xDb
-xDb
+ibx
 xDb
 xDb
 xDb
 xDb
 xDb
 ouH
-rkb
+svr
 rXC
-rkb
+svr
 lZb
 rOT
 dBk
@@ -85680,16 +85684,16 @@ ogl
 wSc
 piW
 xDb
-xDb
-xDb
-wAU
 ibx
+xDb
+lMH
+fSi
 pnS
-wKL
+mlz
 wSc
-rkb
+svr
 rXC
-rkb
+svr
 cGk
 iXo
 iXo
@@ -85935,24 +85939,24 @@ xsD
 xsD
 xsD
 wSc
-fQb
+luk
 xDb
+ibx
 xDb
-xDb
-hSp
-hSz
-pBy
+yei
+qgy
+rpS
 cwz
 wSc
-kua
+wKL
 rXC
-gZQ
+izR
 dBk
-pbh
+rbj
 tQb
 tQb
-wgb
-oLQ
+gkX
+cQN
 dBk
 aoj
 vPg
@@ -86177,7 +86181,7 @@ bba
 xOz
 xOz
 xOz
-wfJ
+pgs
 sJp
 sJp
 sJp
@@ -86192,24 +86196,24 @@ xsD
 xsD
 xsD
 wSc
-wSV
+rYD
 xDb
 mXB
 xDb
-jco
-hSz
+jOq
+qgy
 prd
 wmL
 wSc
-rkb
+svr
 rXC
-rkb
+svr
 vSy
 iXo
 tQb
-uDa
-iMu
-cqG
+yiX
+qIB
+xfi
 dBk
 aoj
 vPg
@@ -86434,7 +86438,7 @@ bcj
 tKv
 xOz
 xOz
-uKV
+xHW
 sJp
 sJp
 sJp
@@ -86442,7 +86446,7 @@ sJp
 nQz
 ffy
 kvU
-iBC
+xje
 lxZ
 ood
 mJr
@@ -86450,7 +86454,7 @@ xsD
 ogl
 wSc
 wSc
-wbN
+qin
 wSc
 wSc
 wSc
@@ -86458,14 +86462,14 @@ wSc
 wSc
 wSc
 wSc
-rkb
+svr
 rXC
-rkb
+svr
 dBk
-qzL
+aNt
 tQb
 tQb
-gtv
+wZL
 iXo
 dBk
 aoj
@@ -86706,20 +86710,20 @@ jgt
 xsD
 xsD
 wSc
-jvI
+iyT
 mnD
-jvI
+iyT
 wSc
 wSc
 wSc
 wSc
 wSc
 wSc
-rkb
-rkb
-rkb
+svr
+svr
+svr
 cGk
-ade
+orp
 iXo
 iXo
 iXo
@@ -86963,7 +86967,7 @@ nct
 xsD
 xsD
 wSc
-xhV
+fUG
 mnD
 mnD
 xJp
@@ -87201,13 +87205,13 @@ eLE
 (217,1,1) = {"
 eLE
 ood
-uXj
+wFv
 xOz
 ccJ
 xOz
 ood
-xje
-bRL
+vbt
+iUi
 rSv
 sJp
 sJp
@@ -87222,7 +87226,7 @@ xsD
 wSc
 mnD
 mnD
-xyn
+odd
 xJp
 rZi
 naX
@@ -87233,11 +87237,11 @@ xhj
 rXz
 rXz
 uHZ
-rpS
+odD
 rni
 dBk
-alI
-jmS
+iBC
+xgN
 dBk
 vPg
 vPg
@@ -87463,7 +87467,7 @@ tKv
 xOz
 xOz
 ood
-vtf
+lgG
 jjA
 rSv
 sJp
@@ -87471,7 +87475,7 @@ sJp
 sJp
 sJp
 sJp
-qgy
+vkg
 ood
 nly
 xsD
@@ -87479,7 +87483,7 @@ xsD
 wSc
 xlH
 mnD
-aVi
+xic
 xJp
 sdy
 szc
@@ -87490,11 +87494,11 @@ xhj
 rXz
 rXz
 uHZ
-ioI
-hdP
+hYB
+jOL
 dBk
-cSe
-hdP
+sDw
+jOL
 oAL
 vPg
 vPg
@@ -87724,8 +87728,8 @@ rSv
 jlt
 rSv
 sJp
-cLG
-hXR
+wlf
+kcz
 ood
 ood
 ood
@@ -87747,11 +87751,11 @@ rXz
 rXz
 rXz
 uHZ
-fSi
-jmS
+brY
+xgN
 dBk
-fSi
-djq
+brY
+jte
 dBk
 vPg
 vPg
@@ -87974,22 +87978,22 @@ eLE
 ood
 ood
 oFo
-svr
+ade
 ood
 ood
 ood
 ood
-brY
-brY
-brY
-brY
-brY
-lYp
-jyZ
+fMP
+fMP
+fMP
+fMP
+fMP
+jvI
+kkd
 iEm
-jyZ
-jyZ
-jyZ
+kkd
+kkd
+kkd
 rvp
 rvp
 rvp
@@ -88236,38 +88240,38 @@ sJp
 sJp
 sJp
 sJp
-brY
-muq
-vjG
-wPR
-brY
-xRn
-jyZ
+fMP
+ulh
+blV
+nwI
+fMP
+qKB
+kkd
 iHF
-jyZ
-fzc
-jyZ
+kkd
+pBy
+kkd
 rvp
-mtc
-bfc
-mtc
+bLn
+veQ
+bLn
 xJp
 rZi
 naX
 naX
 naX
 uHZ
-tgQ
+gdz
 rXz
 rXz
 uHZ
-vzq
-aLM
-avj
-aLM
-aLM
+sQX
+tAG
+eEh
+tAG
+tAG
 dBk
-xtz
+whQ
 xkI
 eYr
 dBk
@@ -88493,40 +88497,40 @@ dma
 wtx
 syU
 sJp
-brY
-vKz
-osu
-wPR
-brY
-fIc
-jyZ
+fMP
+bBA
+gRd
+nwI
+fMP
+iVj
+kkd
 rIn
-jyZ
-kYn
-jyZ
+kkd
+ryS
+kkd
 rvp
-sXq
-xQh
-sXq
+qzL
+upY
+qzL
 xJp
 xJp
 xJp
 xJp
-tms
+jMF
 uHZ
 uvR
 nYR
 rXz
 uMU
 diE
-uBW
-uBW
-uBW
+umZ
+umZ
+umZ
 diE
 dBk
-xtz
-xtz
-blV
+whQ
+whQ
+ija
 dBk
 vPg
 aoj
@@ -88745,26 +88749,26 @@ eLE
 ood
 bna
 wtx
-jiP
+qRb
 sJp
 wtx
-jiP
+qRb
 sJp
-brY
+fMP
 daE
-wPR
-wPR
-wPR
-jyZ
-jyZ
-jyZ
-jyZ
-jyZ
-jyZ
+nwI
+nwI
+nwI
+kkd
+kkd
+kkd
+kkd
+kkd
+kkd
 rvp
-xQh
-xQh
-xQh
+upY
+upY
+upY
 pSn
 sgf
 syd
@@ -88775,15 +88779,15 @@ uBO
 rXz
 rXz
 uHZ
-wZL
-pnK
-uBW
-uBW
+rTv
+tlr
+umZ
+umZ
 diE
-gOq
-xtz
-xtz
-cdu
+hhe
+whQ
+whQ
+jkw
 dBk
 vPg
 aoj
@@ -89007,23 +89011,23 @@ yix
 wtx
 syU
 sJp
-brY
-wPR
-wPR
-wPR
-wPR
-jyZ
-jyZ
-jyZ
-jyZ
+fMP
+nwI
+nwI
+nwI
+nwI
+kkd
+kkd
+kkd
+kkd
 bPo
-jyZ
+kkd
 niz
-rnI
-rnI
-jmE
+ooF
+ooF
+jiP
 pSn
-lFa
+mtc
 vCQ
 vCQ
 twI
@@ -89032,15 +89036,15 @@ rXz
 rXz
 rXz
 uHZ
-dAy
-mlH
+lFa
+aLM
 diE
 diE
 diE
-cmM
-xtz
-xtz
-xtz
+bEm
+whQ
+whQ
+whQ
 dBk
 vPg
 aoj
@@ -89264,21 +89268,21 @@ sJp
 wtx
 wtx
 sJp
-brY
-muq
-wPR
-wPR
-brY
-kcz
-jyZ
+fMP
+ulh
+nwI
+nwI
+fMP
+sXU
+kkd
+mpu
+kkd
 ryS
-jyZ
-kYn
-jyZ
+kkd
 rvp
-xQh
-rnI
-rnI
+upY
+ooF
+ooF
 pSn
 sio
 tht
@@ -89289,14 +89293,14 @@ rXz
 rXz
 rXz
 uHZ
-jMF
-uBW
-uBW
-uBW
-uBW
-uxz
-xtz
-qHb
+fce
+umZ
+umZ
+umZ
+umZ
+cdu
+whQ
+gtv
 iYR
 dBk
 vPg
@@ -89521,20 +89525,20 @@ sJp
 wtx
 syU
 sJp
-brY
-vKz
-wPR
-wPR
-brY
-cGV
-jyZ
+fMP
+bBA
+nwI
+nwI
+fMP
+weo
+kkd
 iJU
-jyZ
-jyZ
-jyZ
+kkd
+kkd
+kkd
 rvp
-xta
-xQh
+gAb
+upY
 ntK
 pSn
 mcU
@@ -89542,14 +89546,14 @@ vCQ
 vCQ
 twI
 qXl
-uTy
+cSe
 rXz
 rXz
 uHZ
-jMF
-uBW
-uBW
-usd
+fce
+umZ
+umZ
+vKz
 dBk
 dBk
 dBk
@@ -89778,34 +89782,34 @@ sJp
 wtx
 syU
 sJp
-brY
-brY
-brY
-brY
-brY
-ilD
-qba
+fMP
+fMP
+fMP
+fMP
+fMP
+fQb
+pbh
 dfN
 xRm
 xRm
 xRm
 rvp
-hNG
-fvU
-hNG
+jcm
+uYY
+jcm
 pSn
 tGL
 twI
 twI
 uCu
-oSB
-tAG
+ilD
+uXj
 rXz
 rXz
 uHZ
 dBk
 dBk
-xic
+rkb
 dBk
 dBk
 wzU
@@ -90037,15 +90041,15 @@ syU
 sJp
 ood
 lHY
-tIR
+hQs
 lHY
-brY
-brY
-brY
-brY
-uLI
-xgN
-xgN
+fMP
+fMP
+fMP
+fMP
+vtf
+oLQ
+oLQ
 rvp
 rvp
 rvp
@@ -90055,8 +90059,8 @@ pSn
 uac
 pSn
 pSn
-xfi
-jOL
+tuI
+pub
 uHZ
 uHZ
 uHZ
@@ -91315,10 +91319,10 @@ eLE
 xNs
 bUV
 lgL
-nbm
+aVi
 epz
 qFd
-wNy
+rle
 aFh
 ify
 wKI
@@ -91335,7 +91339,7 @@ wIR
 wIR
 vYo
 xNs
-wIU
+hXe
 iXo
 iXo
 iXo
@@ -91572,10 +91576,10 @@ eLE
 xNs
 dlr
 fXL
-nbm
+aVi
 lVf
 fXL
-gse
+mpK
 hpZ
 xSa
 wKI
@@ -91829,10 +91833,10 @@ eLE
 xNs
 wOM
 fXL
-nbm
+aVi
 yey
 fXL
-gse
+mpK
 xSa
 xSa
 wKI
@@ -91841,17 +91845,17 @@ yey
 qow
 xIu
 xIu
-ipB
+haJ
 vIW
 xIu
 xIu
-ipB
+haJ
 vIW
 vIW
 vIW
 qOQ
 xrV
-ulh
+mbe
 xnL
 xrV
 xrV
@@ -91861,7 +91865,7 @@ qOQ
 xrV
 kbw
 egU
-qtk
+wbN
 wgK
 ofv
 nlz
@@ -92085,11 +92089,11 @@ eLE
 eLE
 xNs
 bVG
-obi
-nbm
+xPm
+aVi
 eyH
 fXL
-gse
+mpK
 hsX
 xAe
 wKI
@@ -92343,10 +92347,10 @@ eLE
 xNs
 bZT
 cLU
-nbm
+aVi
 eAG
 tFu
-gse
+mpK
 dOH
 xSa
 wKI
@@ -92363,7 +92367,7 @@ wOf
 wIR
 wIR
 xNs
-uHu
+ueZ
 iXo
 iXo
 umo
@@ -92384,7 +92388,7 @@ wvR
 wvR
 wvR
 dBk
-kAm
+fIc
 xSE
 lPR
 dBk
@@ -92601,7 +92605,7 @@ xNs
 caK
 yey
 yey
-sXU
+gZQ
 yey
 xMi
 huC
@@ -92635,7 +92639,7 @@ iXo
 umo
 iXo
 dBk
-bXJ
+kFG
 rrh
 rrh
 eLx
@@ -93119,7 +93123,7 @@ xNs
 xNs
 xNs
 xNs
-lmc
+qUq
 xNs
 xNs
 xNs
@@ -93149,7 +93153,7 @@ umo
 umo
 umo
 dBk
-otW
+iqo
 tkA
 xuw
 gWQ
@@ -93157,7 +93161,7 @@ ePA
 wvR
 lPR
 xSE
-obT
+tBZ
 dBk
 vPg
 vPg
@@ -93368,13 +93372,13 @@ eLE
 "}
 (241,1,1) = {"
 eLE
-pjo
+uTy
 agx
 agx
 lgH
 agx
-xHW
-pjo
+qBI
+uTy
 dxN
 vAk
 vAk
@@ -93625,13 +93629,13 @@ eLE
 "}
 (242,1,1) = {"
 eLE
-pjo
-qKB
-gdz
+uTy
+xcW
+bRw
 lgH
 lgH
 agx
-pjo
+uTy
 vAk
 vAk
 vAk
@@ -93682,7 +93686,7 @@ vPg
 xVz
 xVz
 xVz
-upG
+xev
 vPg
 xVz
 vPg
@@ -93882,10 +93886,10 @@ eLE
 "}
 (243,1,1) = {"
 eLE
-pjo
-xfJ
-xcW
-tKY
+uTy
+oev
+xns
+obi
 lgH
 lgH
 aWQ
@@ -93911,9 +93915,9 @@ vKK
 tDk
 qMn
 bAm
-tlr
-wMJ
-iVj
+otW
+pLA
+dcO
 dBk
 dBk
 dBk
@@ -93921,8 +93925,8 @@ sBM
 dBk
 dBk
 dBk
-xPm
-xPm
+wAU
+wAU
 vPg
 vPg
 aoj
@@ -94139,14 +94143,14 @@ eLE
 "}
 (244,1,1) = {"
 eLE
-tuI
-qKB
+kAm
 xcW
+xns
 lgH
 lgH
 agx
-pjo
-fUs
+uTy
+nIl
 vAk
 vAk
 xQo
@@ -94168,19 +94172,19 @@ vKK
 dBk
 dBk
 dBk
-jkw
+gCM
 sBZ
-qRb
+pDM
 dBk
-agn
+hSz
 iXo
 iXo
 iXo
-qBI
+jiR
 dBk
 wGn
-xPm
-xPm
+wAU
+wAU
 vPg
 vPg
 aoj
@@ -94396,16 +94400,16 @@ eLE
 "}
 (245,1,1) = {"
 eLE
-pjo
+uTy
 agx
 agx
 lgH
 agx
-xHW
-pjo
+qBI
+uTy
 cgC
 gak
-pnO
+sQa
 yeD
 iWZ
 iWZ
@@ -94425,20 +94429,20 @@ vKK
 tDk
 qMn
 dBk
-heQ
+rJc
 sBZ
 sBZ
 tLv
-hgp
+tIR
 iXo
 iXo
 iXo
 vHE
 dBk
 gsv
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
 vPg
 aoj
 aoj
@@ -94653,16 +94657,16 @@ eLE
 "}
 (246,1,1) = {"
 eLE
-pjo
-pjo
-bCe
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
+uTy
+uTy
+btc
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
 yeD
 iWZ
 sEB
@@ -94686,17 +94690,17 @@ dBk
 dBk
 dBk
 dBk
-sBF
+bde
 iXo
-ksU
+pnO
 iXo
 iXo
 dBk
 wHH
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
 xVz
 xVz
 xVz
@@ -94910,16 +94914,16 @@ eLE
 "}
 (247,1,1) = {"
 eLE
-pjo
-wtE
-vbt
-pjo
-odD
+uTy
+lmc
+lDe
+uTy
+sBF
 cOc
-whQ
+gOq
 cOc
-aZm
-pjo
+sAE
+uTy
 jJl
 iWZ
 sEB
@@ -94933,27 +94937,27 @@ oSi
 iWZ
 qyf
 yeD
-lMH
+feI
 tQb
-weW
+qfy
 pPd
 pPd
 tQb
-ija
-saB
-qUq
+cLG
+tgQ
+xJM
 dBk
-pix
+tms
 iXo
 ojv
 iXo
 iXo
 sBM
 nlz
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
 xVz
 xVz
 xVz
@@ -95167,16 +95171,16 @@ eLE
 "}
 (248,1,1) = {"
 eLE
-pjo
-sfl
-vbt
-pjo
-iTZ
+uTy
+cfu
+lDe
+uTy
+sZz
 mHl
 mHl
 mHl
 cOc
-pjo
+uTy
 eSu
 iWZ
 sEB
@@ -95190,27 +95194,27 @@ kCd
 ibg
 akC
 qZB
-yaZ
+lfs
 tQb
-wSi
-wSi
-wSi
+pnK
+pnK
+pnK
 tQb
-gqM
-jiR
-qhj
+cDY
+wQj
+oSB
 dBk
-shq
+cAf
 iXo
 ols
 iXo
 iXo
 dBk
 daD
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
 xVz
 xVz
 lVx
@@ -95424,16 +95428,16 @@ eLE
 "}
 (249,1,1) = {"
 eLE
+uTy
 pjo
-lvK
-vbt
-pjo
-xev
+lDe
+uTy
+jmS
 mHl
-wlf
+jEu
 mHl
 cOc
-pjo
+uTy
 xsn
 xsn
 xsn
@@ -95447,28 +95451,28 @@ xsn
 xsn
 xsn
 yeD
-svf
-svf
-svf
-svf
-svf
-svf
-paO
-jiR
-ooF
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
+wWD
+wQj
+xRn
 dBk
-hhe
+iTZ
 iXo
 iXo
 vdx
 iXo
 dBk
 qHL
-xPm
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
+wAU
 vPg
 vPg
 vPg
@@ -95681,51 +95685,51 @@ eLE
 "}
 (250,1,1) = {"
 eLE
-pjo
-pjo
-pjo
-pjo
-fbn
+uTy
+uTy
+uTy
+uTy
+uqU
 aOU
-qIB
+phr
 cgP
 cOc
-ool
+kYn
 xsn
 xsn
-ylk
-xsn
-xsn
-xsn
+osu
 xsn
 xsn
 xsn
-ylk
+xsn
+xsn
+xsn
+osu
 xsn
 xsn
 raa
-svf
-svf
-svf
-svf
-svf
-svf
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
 rNh
-qXf
+xWB
 iXo
 dBk
-qQa
+hgp
 dBk
 xCH
 dBk
 xgK
 dBk
 wej
-xPm
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
+wAU
 vPg
 vPg
 vPg
@@ -95938,16 +95942,16 @@ eLE
 "}
 (251,1,1) = {"
 eLE
-pjo
-fnq
-feI
-bCe
+uTy
+bXJ
+kvw
+btc
 cOc
 mHl
 uhC
 mHl
 cOc
-pjo
+uTy
 xsn
 xsn
 xsn
@@ -95961,28 +95965,28 @@ xsn
 xsn
 xsn
 yeD
-svf
-svf
-svf
-svf
-svf
-svf
-rJc
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
+yaZ
+muq
 stk
 rhb
 dBk
 pYB
-dtG
+upG
 fYO
-dtG
-dtG
+upG
+upG
 dBk
 vPg
 vPg
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
 vPg
 vPg
 vPg
@@ -96195,28 +96199,28 @@ eLE
 "}
 (252,1,1) = {"
 eLE
-pjo
-lgG
-mnU
-pjo
+uTy
+ool
+miB
+uTy
 cOc
 mHl
 mHl
-oyL
+mlH
 cOc
-pjo
+uTy
 jLd
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
-mpK
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
+fnq
 yeD
 nWH
 tQb
@@ -96224,9 +96228,9 @@ pPd
 pPd
 pPd
 tQb
-gqM
+cDY
 stk
-qhj
+oSB
 dBk
 dBk
 dBk
@@ -96236,10 +96240,10 @@ dBk
 dBk
 vPg
 vPg
-xPm
-xPm
-xPm
-xPm
+wAU
+wAU
+wAU
+wAU
 vPg
 vPg
 vPg
@@ -96452,38 +96456,38 @@ eLE
 "}
 (253,1,1) = {"
 eLE
-frt
-xGx
-feI
-pjo
-iTZ
-tBZ
-aZm
-cOc
-aZm
-pjo
-jLd
-mpK
+uxz
+wgb
+kvw
+uTy
+sZz
+xdk
 sAE
+cOc
+sAE
+uTy
+jLd
+fnq
+xQh
 lHt
 wKj
-mpK
+fnq
 kaE
-sAE
+xQh
 kZo
-eMo
-mpK
-mpK
+qcK
+fnq
+fnq
 yeD
-lMH
+feI
 tQb
-bjx
-wSi
-wSi
+obT
+pnK
+pnK
 tQb
-sQa
-uUH
-jte
+bfc
+nwf
+wPR
 dBk
 vPg
 vPg
@@ -96493,10 +96497,10 @@ vPg
 vPg
 vPg
 vPg
-xPm
-xPm
-xPm
-mpu
+wAU
+wAU
+wAU
+xfJ
 vPg
 vPg
 vPg
@@ -96709,16 +96713,16 @@ eLE
 "}
 (254,1,1) = {"
 eLE
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
-pjo
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
+uTy
 yeD
 yeD
 yeD
@@ -96729,7 +96733,7 @@ yeD
 yeD
 yeD
 yeD
-mmf
+wSV
 yeD
 yeD
 dBk
@@ -96749,11 +96753,11 @@ vPg
 vPg
 vPg
 vPg
-mpu
-xPm
-xPm
-odd
-mpu
+xfJ
+wAU
+wAU
+xFY
+xfJ
 vPg
 vPg
 xVz
@@ -97006,11 +97010,11 @@ eLE
 eLE
 eLE
 eLE
-mpu
-ajx
-ajx
-ajx
-mpu
+xfJ
+hZA
+hZA
+hZA
+xfJ
 eLE
 eLE
 eLE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -86,10 +86,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "ade" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/Knight,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "adr" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/handrail/g_central{
@@ -100,18 +102,11 @@
 	},
 /area/f13/sewer)
 "adZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/obj/structure/sign/poster/prewar/poster65{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "aeo" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -186,12 +181,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "agn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/robot_debris/limb{
+	layer = 1.5
 	},
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_white,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "agw" = (
 /obj/machinery/door/poddoor{
@@ -201,13 +198,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "agx" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood/offices2nd)
 "agH" = (
 /obj/structure/flora/rock/pile/largejungle{
 	layer = 3.2;
@@ -291,15 +283,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ajx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/light/small{
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
+/turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
 "ajG" = (
 /obj/structure/simple_door/metal/barred,
@@ -326,33 +310,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "alI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/toilet{
+	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood)
-"alQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	desc = "A RobCo Industries terminal, this one is lovingly tended by at least several technicians, it's in wonderful condition.";
-	doc_content_1 = "We do not help them, or let them in. We keep knowledge they must never have.";
-	doc_content_2 = "Safeguarding humanity is a task only fit for humans. Robots and mutants may not join the Brotherhood. In only the most extraordinary of circumstances, they could be considered assets, associates, or honorary members of the Brotherhood.";
-	doc_content_3 = "While on duty personnel must remain in uniform. For the purposes of disguises only respectable outfits may be utilized. The Brotherhood are not mercenaries but a fraternity with sacred purpose, do not serve outsiders for mere payment.";
-	doc_content_4 = "Orders must be followed from superiors, and those with inferiors must give them direction.";
-	doc_title_1 = "Doctrine 1 - Outsider Interaction";
-	doc_title_2 = "Doctrine 2 - Inhuman Brotherhood";
-	doc_title_3 = "Doctrine 3 - Honor and Dignity";
-	doc_title_4 = "Doctrine 4 - Chains that Bind";
-	name = "codex terminal";
-	pixel_y = 5;
-	termtag = "Outpost Fargo System"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
 "amD" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -551,10 +514,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "avj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/flasher/portable,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "avk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -978,13 +945,13 @@
 	},
 /area/f13/sewer)
 "aLM" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "aLZ" = (
 /obj/structure/sign/warning{
 	pixel_y = -32
@@ -1016,15 +983,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aNt" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/recharger,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/area/f13/brotherhood)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "aOi" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib2_flesh"
@@ -1037,13 +1009,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "aOU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/chair/comfy/teal,
+/obj/effect/landmark/start/f13/headscribe,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "aOY" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1081,12 +1050,59 @@
 /area/f13/building)
 "aQb" = (
 /obj/structure/rack/shelf_metal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/effect/turf_decal/bot_red,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "aQc" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/electropack/shockcollar{
@@ -1138,7 +1154,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
@@ -1210,9 +1227,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "aVi" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/structure/closet/crate/critter,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "aVU" = (
 /obj/structure/flora/rock/pile/largejungle{
 	layer = 3.2;
@@ -1256,9 +1273,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "aWQ" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/archives)
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Administration";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "aXd" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -1326,10 +1348,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "aZm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "aZp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -1512,16 +1537,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bde" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bdf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -1586,11 +1601,13 @@
 	},
 /area/f13/brotherhood/rnd)
 "bfc" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "bfu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -1627,13 +1644,6 @@
 /area/f13/tunnel)
 "bgZ" = (
 /obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
-"bhg" = (
-/obj/machinery/vending/dinnerware,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
 	icon_state = "tealwhdirty_chess2"
 	},
@@ -1678,11 +1688,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bjx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/f13/brotherhood/chemistry)
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "bjI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1779,14 +1792,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "blV" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "redrustyfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "bmf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -1937,12 +1949,8 @@
 	},
 /area/f13/tunnel)
 "brY" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "bsi" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1997,13 +2005,6 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"btc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "btx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2315,26 +2316,24 @@
 	},
 /area/f13/tunnel)
 "bBA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "bBM" = (
 /obj/item/pickaxe/drill,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bCe" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Admin Accommodation";
+	req_access_txt = "120"
 	},
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices2nd)
 "bCh" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -2399,19 +2398,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
-"bEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/military,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bEp" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2594,11 +2580,6 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/enclave)
-"bLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "bLy" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/f13{
@@ -2723,11 +2704,12 @@
 /area/f13/enclave)
 "bPo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorknight,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "bPq" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -2857,25 +2839,13 @@
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"bRw" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "bRL" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/leisure)
 "bRV" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/f13{
@@ -3008,18 +2978,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bXJ" = (
+/obj/structure/decoration/smokeold{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table{
 	layer = 2.9
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/recharger,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "bXM" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -3227,9 +3198,13 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cdu" = (
-/obj/item/kirbyplants,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "cdQ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -3269,13 +3244,6 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"cfu" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
 "cfB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3336,10 +3304,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "cgC" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "cgE" = (
 /obj/structure/simple_door/bunker,
 /obj/effect/decal/cleanable/dirt{
@@ -3348,13 +3315,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "cgP" = (
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
+/obj/structure/chair/f13chair1{
 	dir = 1
 	},
-/obj/structure/bed,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "chl" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -3504,14 +3469,19 @@
 	},
 /area/f13/caves)
 "cmM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/table/reinforced{
+	req_access_txt = "120"
 	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "redrustyfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "cnf" = (
 /obj/item/electronics/apc,
 /obj/item/stack/cable_coil,
@@ -3607,17 +3577,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cqG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "cqI" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -3748,13 +3713,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "cwz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Knight Billet";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "cwN" = (
 /obj/structure/bed/mattress{
@@ -3856,14 +3817,15 @@
 	},
 /area/f13/sewer)
 "cAf" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = 3;
+	termtag = "Security"
 	},
-/obj/item/trash/f13/electronic/toaster{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "cAi" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -3997,8 +3959,9 @@
 	},
 /area/f13/tunnel)
 "cDY" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "cEh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4082,11 +4045,30 @@
 	},
 /area/f13/sewer)
 "cGV" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/stack/sheet/prewar/five,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "cGZ" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/inside/subway,
@@ -4203,12 +4185,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cLG" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/landmark/start/f13/seniorknight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "cLK" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -4280,11 +4261,10 @@
 /turf/open/water,
 /area/f13/sewer)
 "cOc" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "cOd" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/closed/mineral/random/low_chance,
@@ -4349,10 +4329,6 @@
 	icon_state = "tealwhdirty_chess2"
 	},
 /area/f13/brotherhood/leisure)
-"cQN" = (
-/obj/machinery/suit_storage_unit/mining,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "cQW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4395,12 +4371,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "cSe" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/overlay/junk/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "cSq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
@@ -4447,16 +4428,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"cUh" = (
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "cUk" = (
 /obj/structure/wreck/trash/four_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -4561,17 +4532,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"cYh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "cYk" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/remains{
@@ -4594,19 +4554,30 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "daD" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/structure/fluff/railing{
+	dir = 10
 	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/structure/destructible/clockwork/wall_gear{
+	pixel_y = 32
+	},
+/obj/machinery/light/floor{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "daE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging crude metal items such as swords or shields for the desperate.";
+	icon_state = "generator_on";
+	name = "superheating forge";
+	pixel_x = 2;
+	pixel_y = 1
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "dbi" = (
 /obj/item/mine/shrapnel,
 /turf/open/floor/plating/dirt/dark,
@@ -4651,26 +4622,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dcE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
+/obj/structure/falsewall/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"dcO" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_y = 32
-	},
-/obj/machinery/light/floor{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "ddg" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/f13{
@@ -4710,11 +4666,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dfN" = (
-/obj/structure/rack,
-/obj/item/scrap/research,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "dfU" = (
 /obj/structure/chair/wood/worn{
 	dir = 4
@@ -4791,13 +4750,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "diE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "redmark"
 	},
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood)
 "diL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -4829,9 +4785,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/bunker)
 "djq" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "djS" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -5020,7 +4977,9 @@
 	name = "Fort Hazard Medical";
 	req_one_access_txt = "134"
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/enclave)
 "dpV" = (
 /obj/structure/nest/deathclaw,
@@ -5127,8 +5086,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dtG" = (
-/turf/open/floor/wood/f13/stage_r,
-/area/f13/brotherhood/archives)
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "duv" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -5224,11 +5186,9 @@
 	},
 /area/f13/sewer)
 "dxN" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/item/storage/money_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "dxQ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5286,14 +5246,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
-"dzf" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
-	},
-/area/f13/brotherhood/archives)
 "dzs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -5345,11 +5297,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "dAy" = (
-/obj/structure/sign/poster/contraband/rip_badger{
-	pixel_y = -32
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	pixel_y = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "dAO" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -5440,13 +5398,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dEr" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Outpost";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "dEI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6991,12 +6943,28 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "eEh" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "eEq" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -7334,10 +7302,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "eMo" = (
-/obj/structure/bookcase,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/chair/comfy/teal{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/archives)
 "eMx" = (
@@ -7446,15 +7418,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood)
-"ePO" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
 "ePT" = (
 /obj/structure/nest/deathclaw,
 /turf/open/floor/f13{
@@ -7507,11 +7470,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "eSu" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one is lovingly tended by at least several technicians, it's in wonderful condition.";
+	doc_content_1 = "We assist the wastelanders with supplies as much as we possibly can, but we do not supply them with energy weapons as we do not trust them with dangerous technology like that.";
+	doc_content_2 = "Safeguarding humanity is a task only fit for humans. Robots and mutants may not join the Brotherhood. In only the most extraordinary of circumstances, they could be considered assets, associates, or honorary members of the Brotherhood.";
+	doc_content_3 = "While on duty personnel must remain in uniform. For the purposes of disguises only respectable outfits may be utilized. The Brotherhood are not mercenaries but a fraternity with sacred purpose, do not serve outsiders for mere payment.";
+	doc_content_4 = "Orders must be followed from superiors, and those with inferiors must give them direction.";
+	doc_title_1 = "Doctrine 1 - Outsider Interaction";
+	doc_title_2 = "Doctrine 2 - Inhuman Brotherhood";
+	doc_title_3 = "Doctrine 3 - Honor and Dignity";
+	doc_title_4 = "Doctrine 4 - Chains that Bind";
+	name = "codex terminal";
+	pixel_y = 5;
+	termtag = "Outpost Fargo System"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/archives)
 "eSv" = (
@@ -7699,12 +7674,13 @@
 	},
 /area/f13/building)
 "eYr" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/chair/f13foldupchair{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "eYS" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/f13{
@@ -7719,12 +7695,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"faB" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "faQ" = (
 /obj/machinery/door/airlock/vault{
 	name = "Fort Hazard";
@@ -7733,14 +7703,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "fbn" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "casino"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "fbz" = (
 /obj/structure/fence/pole_b,
 /obj/effect/decal/cleanable/dirt{
@@ -7755,13 +7724,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fce" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "fcz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Fort Hazard Holding Cell";
@@ -7816,14 +7778,8 @@
 	},
 /area/f13/brotherhood/rnd)
 "feI" = (
-/obj/structure/bookcase,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "ffy" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -8097,11 +8053,14 @@
 	},
 /area/f13/building)
 "fnq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/archives)
+/obj/item/pda/heads/cmo{
+	name = "Head Scribe PipBoy"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "fnD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -8246,9 +8205,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "frt" = (
-/obj/machinery/light/small/broken,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/falsewall/reinforced{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/offices2nd)
 "frz" = (
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/cleanable/dirt,
@@ -8360,15 +8321,12 @@
 /area/f13/bunker)
 "fvU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "fwa" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -8385,51 +8343,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"fww" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "fwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -8538,17 +8451,16 @@
 	},
 /area/f13/building)
 "fzc" = (
-/obj/structure/closet/crate/large,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "fzj" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -8801,17 +8713,11 @@
 	},
 /area/f13/clinic)
 "fIc" = (
-/obj/structure/closet/crate/large,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "fIf" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -8850,18 +8756,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/enclave)
-"fJs" = (
-/obj/structure/closet/crate/large,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "fJG" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8981,15 +8875,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
-"fMP" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "fMQ" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/wasteplant/wild_mesquite,
@@ -9102,16 +8987,11 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "fQb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk,
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
-	pixel_y = 32
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/twohanded/fireaxe,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/brotherhood)
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "fQt" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/white/box,
@@ -9182,11 +9062,11 @@
 	},
 /area/f13/clinic)
 "fSi" = (
-/obj/structure/bookcase,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/bed/old,
+/obj/item/bedsheet/orange,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "fSl" = (
 /obj/structure/window/fulltile/ruins/broken,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -9261,9 +9141,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "fUs" = (
-/obj/effect/turf_decal/bot_white,
+/obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/offices2nd)
 "fUu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9282,13 +9162,18 @@
 /turf/open/floor/wood,
 /area/f13/bunker)
 "fUG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	id_tag = "sentdorm";
+	name = "Head Paladin Billet";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood)
 "fUQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9357,13 +9242,12 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "fXl" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
 "fXn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9383,16 +9267,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "fXL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "fXU" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -9424,23 +9302,24 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "fYO" = (
-/obj/structure/fluff/railing{
-	dir = 9
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "fZG" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "gak" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "gap" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -9506,12 +9385,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"gcj" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "gcD" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -9546,12 +9419,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gdz" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin,
+/obj/item/pen/fountain/captain{
+	name = "elder's fountain pen"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "gdH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9732,13 +9606,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker)
-"gkX" = (
-/obj/structure/chair/comfy/teal,
-/obj/effect/landmark/start/f13/headscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
 "glc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -9850,15 +9717,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "gqM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "stagestairs2"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "gqW" = (
 /obj/structure/pondlily_small{
 	pixel_x = 34;
@@ -9880,37 +9742,34 @@
 	},
 /area/f13/building)
 "gse" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/fluff/railing,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
+"gsv" = (
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"gsv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
-	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/gps/mining,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "gsA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gtv" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "gtx" = (
 /obj/effect/decal/waste{
 	pixel_x = -5;
@@ -10124,9 +9983,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gAb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Canteen";
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
 "gAp" = (
@@ -10208,11 +10070,9 @@
 /turf/open/indestructible/ground/outside/river,
 /area/f13/bunker)
 "gCM" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "gCN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/space_cola{
@@ -10277,12 +10137,8 @@
 /turf/open/water,
 /area/f13/sewer)
 "gFF" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "gFV" = (
 /obj/structure/barricade/bars,
@@ -10532,9 +10388,13 @@
 	},
 /area/f13/bunker)
 "gOq" = (
-/obj/structure/fluff/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "gOG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -10577,14 +10437,10 @@
 	},
 /area/f13/bunker)
 "gPu" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Administration";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "gPy" = (
 /obj/structure/sign/poster/contraband/buzzfuzz{
 	pixel_y = -32
@@ -10638,14 +10494,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"gRd" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
 "gRe" = (
 /obj/item/crowbar,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -10919,25 +10767,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "gZQ" = (
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/archives)
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
+	dir = 1;
+	name = "Head Knight's Office";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
+/area/f13/brotherhood)
 "gZR" = (
 /obj/structure/fluff/rails,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"haJ" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/machinery/button/door{
-	id = "headscribedorm";
-	normaldoorcontrol = 1;
-	pixel_x = -5;
-	pixel_y = 5;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
 "hcp" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -10975,11 +10819,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "hdP" = (
-/obj/structure/sign/poster/prewar/poster72{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "hdT" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -11005,10 +10848,11 @@
 	},
 /area/f13/bunker)
 "heQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/hot_potato/harmless/toy,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "hfr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -11025,11 +10869,17 @@
 /turf/open/water,
 /area/f13/tunnel)
 "hgp" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill{
+	pixel_y = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "hgy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11044,11 +10894,9 @@
 	},
 /area/f13/tcoms)
 "hhe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "hhi" = (
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -11064,10 +10912,8 @@
 /area/f13/bunker)
 "hik" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -11461,15 +11307,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
 "hAk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
 	},
-/obj/machinery/light/small{
-	light_color = "red"
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "hAW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/auto{
@@ -11692,11 +11538,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hNG" = (
+/obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/effect/landmark/start/f13/knightcap,
+/obj/item/bedsheet/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/dorms)
 "hNO" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/building)
@@ -11792,10 +11638,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
-"hQs" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
 "hQy" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11826,23 +11668,35 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "hSp" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
-"hSz" = (
-/obj/structure/chair/f13chair1{
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
+"hSz" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "hTd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/machinery/door/airlock/grunge{
+	name = "Head Paladin Office";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "hTw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11963,10 +11817,6 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"hXe" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "hXt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -11977,9 +11827,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/brotherhood)
 "hXR" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "hXT" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -11997,13 +11849,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker)
-"hYB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "hYZ" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -12012,15 +11857,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water,
 /area/f13/sewer)
-"hZA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "hZW" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -12071,7 +11907,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "ibx" = (
-/obj/effect/landmark/start/f13/initiate,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "ibM" = (
@@ -12257,10 +12098,16 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "ija" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/fluff/railing{
+	dir = 5
 	},
-/area/f13/brotherhood/archives)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
+/area/f13/brotherhood)
 "iji" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12302,11 +12149,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "ilD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/operations)
 "imd" = (
 /obj/item/circular_saw,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12352,11 +12199,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "ioI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/mirror{
+	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "ioN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12385,19 +12238,10 @@
 	},
 /area/f13/bunker)
 "ipB" = (
-/obj/structure/decoration/hatch{
-	dir = 1;
-	layer = 2.5
-	},
-/obj/effect/overlay/junk/shower{
-	pixel_y = 16
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"iqo" = (
-/turf/closed/wall,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/rnd)
 "iqp" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot_white,
@@ -12587,20 +12431,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "iyT" = (
-/obj/machinery/light/sign{
-	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
-	icon_state = "norm3";
-	layer = 2.9;
-	light_color = "#1c738c";
-	light_power = 4;
-	light_range = 4;
-	name = "inactive fusion reactor tube"
-	},
-/obj/structure/fluff/railing{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/leisure)
 "izb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12636,14 +12470,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"izR" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
 "iAm" = (
 /obj/structure/simple_door/repaired,
 /obj/effect/decal/cleanable/dirt,
@@ -12664,21 +12490,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "iBC" = (
-/obj/structure/fluff/railing{
-	dir = 6
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "iBD" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
@@ -12707,11 +12526,12 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "iEm" = (
-/obj/structure/fluff/railing{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "iED" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
@@ -12789,18 +12609,15 @@
 	},
 /area/f13/sewer)
 "iHF" = (
-/obj/machinery/workbench/forge{
-	desc = "A reactor-heated megafurnace used for forging crude metal items such as swords or shields for the desperate.";
-	icon_state = "generator_on";
-	name = "superheating forge";
-	pixel_x = 2;
-	pixel_y = 1
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "iIg" = (
 /obj/structure/decoration/warning,
 /turf/closed/wall/r_wall/rust,
@@ -12820,11 +12637,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "iJU" = (
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/scrap/research,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/obj/item/book/granter/crafting_recipe/blueprint/aer9{
+	pixel_y = 5
+	},
+/obj/item/advanced_crafting_components/assembly,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "iKe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12870,20 +12692,12 @@
 /turf/open/water,
 /area/f13/sewer)
 "iMu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Knight Action Figure";
-	toysay = "Steel be with you."
-	},
-/obj/item/clothing/shoes/combat/swat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "iMx" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -13091,16 +12905,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "iTZ" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"iUi" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "iUn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13130,15 +12939,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "iVj" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "headscribedorm";
-	name = "Head Scribe Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/archives)
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/keg,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "iVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -13217,12 +13022,15 @@
 	},
 /area/f13/clinic)
 "iYx" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/f13/boscap,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "iYB" = (
 /obj/effect/mob_spawn/human/corpse/bs,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5,
@@ -13231,14 +13039,11 @@
 	},
 /area/f13/tunnel)
 "iYR" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Fargo Holding Cell";
-	req_access_txt = "120"
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "iZd" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/effect/decal/cleanable/greenglow,
@@ -13333,15 +13138,63 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/sewer)
-"jcm" = (
-/obj/structure/fluff/railing{
-	dir = 6
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "jco" = (
-/turf/open/floor/wood/f13/oak,
-/area/f13/brotherhood/archives)
+/obj/structure/rack/shelf_metal,
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/ecp{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/ammo/mfc{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "jcG" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13482,12 +13335,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/enclave)
 "jgt" = (
-/obj/structure/table/wood/poker,
-/obj/structure/disposalpipe/segment,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
 "jgw" = (
 /obj/structure/table,
@@ -13518,19 +13369,15 @@
 	},
 /area/f13/sewer)
 "jiP" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/orange,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
-"jiR" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
+"jiR" = (
+/turf/open/floor/wood/f13/oak,
+/area/f13/brotherhood)
 "jjd" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/f13/wood,
@@ -13573,14 +13420,14 @@
 /turf/open/water,
 /area/f13/tunnel)
 "jkw" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/obj/item/pen/fountain/captain{
-	name = "elder's fountain pen"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/item/dice/d1,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "jkL" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/caves)
@@ -13642,12 +13489,9 @@
 /turf/open/water,
 /area/f13/tunnel)
 "jmE" = (
-/obj/structure/furnace,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/reactor)
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "jmN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13{
@@ -13656,9 +13500,8 @@
 /area/f13/bunker)
 "jmS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "jnc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13800,12 +13643,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jte" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/chair/wood/fancy{
+	dir = 1
 	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
+	},
+/area/f13/brotherhood)
 "jtf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13852,12 +13696,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jvI" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/reactor)
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "jwy" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -13910,12 +13751,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "jyZ" = (
-/obj/structure/weightmachine/stacklifter,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "jzC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -14024,13 +13864,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "jEu" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
+	dir = 1;
 	light_color = "red"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "jEP" = (
 /obj/machinery/door/window/brigdoor/security/cell/northleft{
 	dir = 2;
@@ -14178,12 +14019,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "jMF" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "jMT" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
@@ -14212,12 +14051,6 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/sewer)
-"jOq" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
 "jOw" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/duffelbag,
@@ -14230,13 +14063,9 @@
 	},
 /area/f13/building)
 "jOL" = (
-/obj/structure/fans/tiny{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/medical)
 "jPn" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/tree/jungle/small,
@@ -14539,14 +14368,13 @@
 	},
 /area/f13/tunnel)
 "kaE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
+	dir = 4
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/archives)
 "kaQ" = (
 /obj/structure/decoration/vent/rusty,
 /turf/open/floor/f13{
@@ -14584,11 +14412,11 @@
 	},
 /area/f13/building)
 "kcz" = (
-/obj/machinery/workbench/advanced,
+/obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "kcJ" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway{
@@ -14782,11 +14610,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/dirt,
 /area/f13/tunnel)
-"kkd" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
 "kkg" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/wreck/trash/engine,
@@ -14838,13 +14661,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"kni" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/obj/structure/plasticflaps,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "knr" = (
 /obj/structure/table,
 /obj/effect/holodeck_effect/cards{
@@ -14951,16 +14767,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "ksU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 12
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/item/clothing/glasses/meson,
+/obj/item/gps/mining{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ksZ" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -14976,9 +14792,13 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "kua" = (
-/obj/structure/rack,
-/obj/item/scrap/research,
-/turf/open/floor/plating/tunnel,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
+	},
 /area/f13/brotherhood)
 "kuD" = (
 /obj/structure/cable{
@@ -15005,22 +14825,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "kvl" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/holster,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "kvn" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kvw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
 "kvU" = (
@@ -15031,9 +14851,9 @@
 	},
 /area/f13/brotherhood/leisure)
 "kwf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/leisure)
 "kwk" = (
@@ -15111,15 +14931,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "kAm" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/structure/sign/poster/prewar/poster63{
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/item/flag/bos,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "kAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -15216,13 +15036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"kCW" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "kDI" = (
 /obj/structure/showcase/machinery/cloning_pod,
 /obj/structure/window/reinforced/spawner,
@@ -15281,15 +15094,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"kFG" = (
-/obj/structure/anvil/obtainable{
-	anvilquality = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/reactor)
 "kFP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -15333,15 +15137,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"kHm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
 "kHo" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -15464,8 +15259,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "kMw" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/tunnel,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "kMF" = (
 /obj/structure/table/wood,
@@ -15695,11 +15492,14 @@
 	},
 /area/f13/bunker)
 "kYn" = (
-/obj/machinery/vending/tool,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "kYI" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/spider/stickyweb,
@@ -15725,13 +15525,11 @@
 /turf/open/water,
 /area/f13/sewer)
 "kZo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
+/obj/structure/table/wood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/archives)
 "kZR" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15856,13 +15654,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
-"lfs" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "lgv" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
@@ -15870,24 +15661,16 @@
 	},
 /area/f13/bunker)
 "lgG" = (
-/obj/structure/bed/dogbed,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/pet/cat/kitten{
-	desc = "One of the few things keeping morale up for the brotherhood.";
-	name = "initiate mittens"
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/bed,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "lgH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "lgL" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/f13/headscribe,
@@ -15949,9 +15732,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "lja" = (
-/obj/effect/landmark/start/f13/paladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "ljJ" = (
 /obj/structure/lattice{
 	layer = 3
@@ -16035,11 +15818,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "lmc" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/rnd)
 "lmn" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -16214,12 +15996,18 @@
 	},
 /area/f13/bunker)
 "luk" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/recycler,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "lup" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -16256,9 +16044,14 @@
 	},
 /area/f13/clinic)
 "lvK" = (
-/obj/machinery/conveyor/auto,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/trash/f13/electronic/toaster{
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "lwl" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/ruins,
@@ -16362,21 +16155,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
-"lAK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/trash/f13/mre,
-/obj/structure/closet/crate/large,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
 "lAL" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
@@ -16428,12 +16206,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood)
-"lDe" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "lDg" = (
 /obj/item/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -16464,14 +16236,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "lFa" = (
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 4;
-	pixel_y = 7
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/chemistry)
 "lFd" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -16571,9 +16340,13 @@
 	},
 /area/f13/building)
 "lLb" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 7
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "lLo" = (
 /obj/structure/curtain{
@@ -16584,19 +16357,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building)
-"lLs" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Paladin's PipBoy"
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
 "lLu" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/wood/f13/oak,
@@ -16631,15 +16391,9 @@
 	},
 /area/f13/clinic)
 "lMH" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/figure/hos{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Paladin Action Figure";
-	toysay = "SEMPER INVICTA!"
-	},
-/obj/item/book/granter/trait/pa_wear,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/item/flag/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "lMK" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /obj/effect/decal/waste{
@@ -16670,10 +16424,6 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"lNt" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
 "lNw" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -16716,20 +16466,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "lPl" = (
-/obj/machinery/button/door{
-	id = "sentdorm";
-	normaldoorcontrol = 1;
-	pixel_y = 32;
-	specialfunctions = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Senior Paladin Billet";
+	req_access_txt = "120"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
-	name = "fine bedsheet"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "lPt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16744,9 +16488,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "lPR" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/scrap/research,
-/turf/open/floor/plating/tunnel,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "lPT" = (
 /obj/structure/handrail/g_central{
@@ -16847,14 +16592,12 @@
 	},
 /area/f13/brotherhood/rnd)
 "lUw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/dogbed,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Paladin Ramos"
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Waste Disposal";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "lVd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16885,13 +16628,6 @@
 	},
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
-"lVB" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "lWh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/lattice/catwalk,
@@ -16917,18 +16653,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"lWW" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "lXh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/raider/boss,
@@ -16954,15 +16678,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
 "lYp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "lYx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17035,11 +16755,24 @@
 	},
 /area/f13/bunker)
 "mbe" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
+	anchored = 1;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mcf" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -17054,8 +16787,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "mcz" = (
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table,
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mcD" = (
 /obj/effect/landmark/start/f13/ussgt,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -17134,11 +16869,12 @@
 	},
 /area/f13/caves)
 "miB" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_y = 10
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = -6;
+	pixel_y = 12
 	},
 /turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "miI" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -17151,24 +16887,11 @@
 /obj/item/gun/ballistic/revolver/caravan_shotgun,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"miS" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/caves)
 "miY" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "sentdorm";
-	name = "Head Paladin Billet";
-	req_access_txt = "120"
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/item/kirbyplants,
+/obj/item/clothing/under/f13/bosformgold_f,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mju" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -17190,13 +16913,15 @@
 	},
 /area/f13/sewer)
 "mjR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
-	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "mkj" = (
 /obj/structure/fluff/railing{
 	dir = 5
@@ -17214,40 +16939,28 @@
 	},
 /area/f13/clinic)
 "mlz" = (
-/obj/effect/decal/cleanable/robot_debris/limb{
-	layer = 1.5
-	},
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_white,
-/obj/item/stack/cable_coil/random/five,
-/obj/item/circuitboard/machine/ore_silo,
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/seniorpaladin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood)
 "mlC" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/gun/energy/laser/plasma/scatter{
-	anchored = 1;
-	cell_type = null;
-	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
-	name = "display multiplas rifle";
-	pin = null;
-	pixel_y = 32
+/obj/machinery/cell_charger{
+	pixel_y = 6
 	},
-/obj/structure/chair/comfy/beige,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/sentinel,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "mlH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "mlV" = (
 /obj/item/radio/intercom{
 	desc = "Is there anyone on the other end? Who's in there?";
@@ -17268,12 +16981,12 @@
 	},
 /area/f13/bunker)
 "mmf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/auxillary_base{
-	pixel_y = 33
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/archives)
 "mmi" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -17318,31 +17031,19 @@
 	},
 /area/f13/clinic)
 "mnD" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "mnG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mnU" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/crafting_recipe/blueprint/aer9{
-	pixel_y = 5
+/obj/item/clothing/shoes/laceup{
+	pixel_y = 10
 	},
-/obj/item/advanced_crafting_components/assembly,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "moK" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -17367,24 +17068,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "mpu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/scrap/research,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood)
 "mpC" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "mpK" = (
-/obj/structure/fluff/railing{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/archives)
 "mro" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
@@ -17398,12 +17092,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "mtc" = (
-/obj/machinery/radioterminal/bos{
-	dir = 8;
-	pixel_x = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "mth" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/biogenerator,
@@ -17434,17 +17130,20 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "muq" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
+/obj/machinery/light/sign{
+	desc = "A deep hole, lit with unpowered coils, ready to receive power when activated. Just a nice glowy hole until then.";
+	icon_state = "norm3";
+	layer = 2.9;
+	light_color = "#1c738c";
+	light_power = 4;
+	light_range = 4;
+	name = "inactive fusion reactor tube"
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/fluff/railing{
+	dir = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
 "muF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17682,14 +17381,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mHl" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/pda/heads/cmo{
-	name = "Head Scribe PipBoy"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "mHK" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -17741,25 +17434,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mMb" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/terminal{
-	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
-	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
-	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
-	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
-	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
-	doc_title_1 = "Journal 1 - New Home";
-	doc_title_2 = "Journal 2 - Mining Duty";
-	doc_title_3 = "Journal 3 - Dead-End?";
-	doc_title_4 = "Saved Draft - Crash?";
-	name = "battered terminal";
-	termtag = "Outpost Fargo System"
-	},
-/obj/structure/sign/poster/contraband/have_a_puff{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mMj" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/water,
@@ -17976,13 +17654,11 @@
 /area/f13/enclave)
 "mXB" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4;
+	light_color = "red"
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "mXH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
@@ -18121,14 +17797,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nbm" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/item/dice/d1,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "nbA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
@@ -18297,37 +17969,21 @@
 	},
 /area/f13/sewer)
 "niu" = (
-/obj/structure/table,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/leisure)
-"niz" = (
-/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/stack/sheet/prewar/five,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
+/obj/machinery/computer/auxillary_base{
+	pixel_y = 33
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
+"niz" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Outpost Sleeping Quarters";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/dorms)
 "njG" = (
 /obj/item/ingot/silver,
 /obj/structure/closet/crate,
@@ -18520,15 +18176,15 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "ntK" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/explorer,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "ntN" = (
 /obj/structure/fence,
 /turf/open/floor/wood/f13/old,
@@ -18587,19 +18243,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"nwf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "nwI" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/wrench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nxk" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -18626,21 +18277,14 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "nzg" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nzi" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Paladin Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "nzO" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -18881,19 +18525,17 @@
 /turf/open/water,
 /area/f13/sewer)
 "nIl" = (
+/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "nIu" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "nIP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/raider/ranged{
@@ -19101,15 +18743,25 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "nRs" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/armory)
 "nRY" = (
 /obj/item/ammo_casing/a556,
 /turf/open/indestructible/ground/inside/subway,
@@ -19233,13 +18885,38 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "nWH" = (
-/obj/structure/fluff/railing{
-	dir = 4
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
 	},
-/obj/structure/lattice/catwalk,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "nXg" = (
 /obj/structure/table/wood/settler,
@@ -19277,17 +18954,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "nYR" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/glass,
-/obj/item/toy/figure/chemist{
-	layer = 2.8;
-	name = "Scribe action figure";
-	toysay = "Ad meliora."
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/medical)
 "nYZ" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -19295,13 +18966,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
-"nZd" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "nZk" = (
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/building)
@@ -19328,30 +18992,23 @@
 	},
 /area/f13/bunker)
 "obi" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/toy/katana,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "obl" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "obT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/floor,
+/obj/structure/chair/folding{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood)
 "ocb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/lattice/catwalk,
@@ -19396,27 +19053,16 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
 "odd" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/combat,
-/obj/item/storage/belt/military,
-/obj/item/storage/belt/holster,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/book/granter/trait/pa_wear,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood)
 "odD" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/bookcase,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/offices2nd)
 "odG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
@@ -19452,13 +19098,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "oev" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/hos,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "oeC" = (
 /obj/item/ammo_casing/c10mm,
 /obj/effect/decal/cleanable/blood,
@@ -19616,13 +19258,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ojv" = (
-/obj/structure/fluff/railing{
-	dir = 9
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_left"
+/obj/item/clothing/glasses/meson{
+	pixel_y = 10
 	},
-/area/f13/brotherhood/archives)
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "okb" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -19654,11 +19298,12 @@
 	},
 /area/f13/clinic)
 "ols" = (
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/archives)
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "omu" = (
 /obj/structure/guncase/shotgun,
 /obj/effect/turf_decal/bot,
@@ -19676,15 +19321,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/enclave)
 "ont" = (
-/obj/item/pen{
-	pixel_x = -16;
-	pixel_y = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/boscap,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "onP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
@@ -19700,13 +19340,15 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/leisure)
 "ool" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/fluff/railing{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "headscribedorm";
+	name = "Head Scribe Office";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/offices2nd)
 "ooz" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -19715,14 +19357,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "ooF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_right"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "ooI" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -19752,24 +19390,26 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "orp" = (
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "osd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "osu" = (
-/obj/item/clothing/shoes/laceup{
-	pixel_x = 6;
-	pixel_y = -12
+/obj/structure/anvil/obtainable{
+	anvilquality = 10
 	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "osv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19780,10 +19420,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "otW" = (
-/obj/structure/fluff/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ouf" = (
 /obj/structure/table/optable,
 /obj/machinery/light,
@@ -19821,14 +19465,13 @@
 	},
 /area/f13/bunker)
 "ouT" = (
-/obj/structure/fluff/railing{
-	dir = 6
-	},
-/obj/structure/lattice{
-	density = 1
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood/f13/carpet,
 /area/f13/brotherhood)
 "ove" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19948,9 +19591,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "oyL" = (
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "ozo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20178,16 +19821,9 @@
 	},
 /area/f13/brotherhood/rnd)
 "oLQ" = (
-/obj/structure/fluff/railing{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
-	},
-/area/f13/brotherhood/archives)
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "oLX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -20380,11 +20016,13 @@
 /area/f13/tcoms)
 "oSB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright"
 	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/medical)
 "oSF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20482,12 +20120,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "oZG" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/toy/sword,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/machinery/computer/card/bos,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "oZJ" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -20537,11 +20171,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "paO" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
+	},
+/area/f13/brotherhood)
 "paS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/wood,
@@ -20557,11 +20193,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "pbh" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "pbl" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -20697,14 +20331,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "pgs" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Senior Paladin Billet";
-	req_access_txt = "120"
+/obj/structure/table,
+/obj/item/melee/onehanded/machete/training,
+/obj/item/melee/onehanded/machete/training,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "pgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -20741,24 +20374,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "phr" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate,
-/obj/effect/turf_decal/bot_red,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/red,
+/obj/machinery/door/airlock/grunge{
+	name = "Power Armor Maintenance Room";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/brotherhood/armory)
 "phB" = (
 /obj/structure/kitchenspike,
@@ -20778,9 +20400,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pix" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/gps/mining,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "piI" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -20801,9 +20431,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "pjo" = (
-/turf/open/space/basic,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "pjs" = (
 /obj/structure/junk/small/bed2,
 /turf/open/floor/f13{
@@ -20887,32 +20516,24 @@
 	},
 /area/f13/sewer)
 "pnK" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "pnO" = (
-/obj/structure/fluff/railing{
-	dir = 6
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
 	},
-/obj/structure/destructible/clockwork/wall_gear{
-	pixel_y = 32
-	},
-/obj/machinery/light/floor{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/offices2nd)
 "pnS" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/obj/item/stack/ore/blackpowder/twenty{
-	pixel_x = 3;
-	pixel_y = -1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
@@ -20998,8 +20619,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "prd" = (
-/obj/machinery/computer/card/bos,
-/turf/open/floor/wood/f13/old,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "psx" = (
 /obj/structure/cable{
@@ -21042,15 +20669,10 @@
 /turf/open/water,
 /area/f13/sewer)
 "pub" = (
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/item/card/id/dogtag,
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/armory)
+/obj/structure/table,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pud" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -21127,20 +20749,9 @@
 	},
 /area/f13/bunker)
 "pyg" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/pda{
-	icon_state = "pda-warden";
-	name = "Armory Warden PDA"
-	},
-/obj/item/storage/belt/holster,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/gloves/combat,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/armory)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pyK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21231,14 +20842,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "pBy" = (
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_x = 32
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "pCg" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
@@ -21284,18 +20892,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/closed/wall/rust,
 /area/f13/caves)
-"pDM" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 32;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
-	},
-/obj/effect/landmark/start/f13/knightcap,
-/obj/item/clothing/shoes/laceup{
-	pixel_x = 6;
-	pixel_y = -13
-	},
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/armory)
 "pDU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -21352,10 +20948,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
 "pHr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/leisure)
 "pHv" = (
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -21417,15 +21012,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
-"pLA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "pMw" = (
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_x = 32
@@ -21474,10 +21060,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "pNR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/trash/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/trash/f13/mre,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "pNS" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/carpet/red,
@@ -21502,21 +21095,11 @@
 	},
 /area/f13/brotherhood/archives)
 "pPd" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"pPj" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "pPI" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -21602,11 +21185,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
-"pTV" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "pUe" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -21744,11 +21322,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pYB" = (
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "pYF" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/glasses/hud/health/f13,
@@ -21812,10 +21390,15 @@
 	},
 /area/f13/building)
 "qba" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "bosshop";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "qcl" = (
 /obj/structure/campfire/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -21832,18 +21415,71 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qcK" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood)
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "qcW" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
 "qdg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "qew" = (
 /obj/structure/car,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -21864,54 +21500,24 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qeX" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/turf_decal/bot_red,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
 	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
 	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/clothing/shoes/combat/swat,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "qfe" = (
-/obj/item/kirbyplants,
-/obj/item/clothing/under/f13/bosformgold_f,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/brotherhood)
 "qff" = (
 /obj/structure/tires,
 /obj/effect/decal/cleanable/dirt{
@@ -21928,10 +21534,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"qfy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "qfX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/bonfire/prelit,
@@ -21952,19 +21554,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qgy" = (
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/structure/closet/crate/large{
-	storage_capacity = 10
-	},
+/obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -21978,15 +21568,11 @@
 	},
 /area/f13/bunker)
 "qhj" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/wood/fancy{
+	dir = 1
 	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/brotherhood)
 "qhk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -22032,14 +21618,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"qin" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "qip" = (
 /mob/living/simple_animal/hostile/radscorpion/blue,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22261,14 +21839,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "qtk" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
 "qtr" = (
 /obj/structure/chair{
 	dir = 4
@@ -22287,23 +21861,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "qub" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -9;
-	pixel_y = 21
+/obj/machinery/door/airlock/grunge{
+	name = "Senior Paladin Office";
+	req_access_txt = "120"
 	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_y = 16
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 10;
-	pixel_y = 23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "quD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13vaultrusted,
@@ -22409,9 +21974,20 @@
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
 "qzL" = (
-/obj/structure/table,
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
+	},
+/obj/item/gun/energy/laser/rcw{
+	anchored = 1;
+	cell_type = null;
+	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
+	name = "display laser RCW";
+	pin = null;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "qAe" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -22474,23 +22050,16 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/tunnel)
 "qBI" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom"
-	},
-/area/f13/brotherhood/archives)
+/obj/machinery/suit_storage_unit/mining,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "qBZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "qCb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "qCm" = (
 /obj/structure/closet/crate/miningcar,
@@ -22619,21 +22188,29 @@
 /turf/open/water,
 /area/f13/sewer)
 "qHb" = (
-/obj/structure/table,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "qHd" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "qHL" = (
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/structure/decoration/hatch{
+	dir = 1;
+	layer = 2.5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/effect/overlay/junk/shower{
+	pixel_y = 16
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "qHX" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -22648,9 +22225,10 @@
 /turf/open/water,
 /area/f13/sewer)
 "qIB" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/construction/rld,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "qIH" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -22696,12 +22274,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "qKB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood/offices2nd)
 "qLi" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -22812,19 +22389,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "qQa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Senior Paladin on duty.";
-	name = "Senior Paladin's Office";
-	pixel_x = -32
+/obj/machinery/conveyor/auto{
+	dir = 8
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
-"qQy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "qQz" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22844,11 +22414,11 @@
 	},
 /area/f13/enclave)
 "qRb" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "qRc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -22904,9 +22474,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "qTX" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood/f13/old,
-/area/f13/brotherhood/armory)
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "qUd" = (
 /obj/machinery/light{
 	dir = 1
@@ -22916,10 +22488,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "qUq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/wood/fancy{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
+	},
+/area/f13/brotherhood)
 "qUr" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -22992,20 +22567,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "qXf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood)
 "qXj" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "qXl" = (
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/grille,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/medical)
 "qXr" = (
 /obj/structure/fluff/railing{
 	dir = 4
@@ -23054,15 +22631,11 @@
 	},
 /area/f13/caves)
 "qYM" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/gas/explorer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/medical)
 "qYS" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -23132,10 +22705,6 @@
 /obj/effect/mob_spawn/human/corpse/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"rbj" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "rbr" = (
 /obj/structure/closet/crate/large,
 /obj/item/trash/f13/electronic/toaster/atomics,
@@ -23258,14 +22827,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "rhb" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_bottom_left"
 	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipright"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "rhG" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag,
@@ -23295,32 +22860,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "rjT" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Senior Paladin Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices1st)
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "rkb" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating";
+	sunlight_state = 1
 	},
-/obj/item/ammo_box/magazine/m22{
-	pixel_x = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "rkv" = (
 /obj/machinery/light{
 	dir = 4
@@ -23331,16 +22879,11 @@
 	},
 /area/f13/bunker)
 "rle" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "rln" = (
 /obj/structure/chair/wood/fancy,
 /obj/structure/decoration/rag{
@@ -23396,14 +22939,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "rni" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Outpost";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood)
 "rnA" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -23420,12 +22960,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rnI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "rnO" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -23482,68 +23018,13 @@
 	},
 /area/f13/bunker)
 "rpS" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/ecp{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/ammo/mfc{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
-"rpV" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/obj/item/pda/engineering{
-	name = "Knight-Technician Pip-Boy 3000"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/restraints/legcuffs,
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "redrustyfull"
 	},
 /area/f13/brotherhood)
 "rpZ" = (
@@ -23680,11 +23161,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rvp" = (
-/obj/machinery/vending/robotics,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/dorms)
 "rvG" = (
 /obj/structure/fluff/railing,
 /obj/effect/decal/cleanable/insectguts,
@@ -23744,12 +23222,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "rxg" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/leisure)
 "rxw" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -23819,10 +23297,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
 "ryt" = (
-/obj/structure/barricade/bars,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ryw" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/burger/rib,
@@ -23837,8 +23318,15 @@
 	},
 /area/f13/caves)
 "ryS" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/granter/crafting_recipe/blueprint/aep7{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "ryY" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water{
@@ -23846,9 +23334,9 @@
 	},
 /area/f13/sewer)
 "ryZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "rzd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24114,15 +23602,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "rIn" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
+	icon_state = "darkyellowfull"
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operations)
 "rJc" = (
-/obj/item/flag/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_right"
+	},
+/area/f13/brotherhood)
 "rJp" = (
 /obj/machinery/button/door{
 	id = "room52";
@@ -24194,54 +23690,12 @@
 	},
 /area/f13/building)
 "rKX" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/shoes/laceup{
-	pixel_y = -10
-	},
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/carpet,
+/area/f13/brotherhood)
 "rLv" = (
 /obj/item/trash/f13/dog,
 /obj/effect/decal/cleanable/dirt,
@@ -24296,39 +23750,11 @@
 	},
 /area/f13/enclave)
 "rNh" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/fluff/railing{
+	dir = 1
 	},
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/brotherhood)
 "rNr" = (
 /obj/machinery/light{
 	dir = 8;
@@ -24481,14 +23907,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "rTv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/f13chair1,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "rTW" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
@@ -24586,13 +24010,9 @@
 /turf/open/water,
 /area/f13/sewer)
 "rXC" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "rXS" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
@@ -24605,11 +24025,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "rYD" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
+/obj/structure/table/wood/poker,
+/obj/item/toy/figure/hos{
+	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
+	name = "Head Paladin Action Figure";
+	toysay = "SEMPER INVICTA!"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/item/book/granter/trait/pa_wear,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "rYE" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/wirecutters/power,
@@ -24670,17 +24094,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/bunker)
 "saB" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 32
-	},
-/obj/item/melee/powered/ripper{
-	pixel_y = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/wood/f13/stage_l,
+/area/f13/brotherhood)
 "saC" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -24767,8 +24182,13 @@
 	},
 /area/f13/bunker)
 "sfl" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "sfu" = (
 /obj/machinery/light{
 	dir = 8
@@ -24823,14 +24243,10 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "shq" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/bot_white,
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "shB" = (
 /obj/machinery/light/small,
 /obj/item/mine/shrapnel,
@@ -25087,9 +24503,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "stk" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/archives)
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/brotherhood)
 "stu" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -25107,28 +24522,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "svf" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/carpet,
 /area/f13/brotherhood)
 "svr" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood)
+/obj/machinery/smartfridge,
+/turf/open/space/basic,
+/area/f13/brotherhood/leisure)
 "sxm" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Head Knight Billet";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "sxA" = (
 /obj/structure/closet,
@@ -25224,10 +24629,11 @@
 	},
 /area/f13/brotherhood)
 "sAE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/structure/chair/comfy/teal,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood/archives)
 "sAW" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/candle_box{
@@ -25237,13 +24643,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sBF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius";
-	name = "vault floor"
-	},
-/area/f13/brotherhood/chemistry)
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sBG" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -25265,14 +24667,8 @@
 	},
 /area/f13/brotherhood)
 "sBZ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/chair/bench{
-	icon_state = "dropshipleft"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "sCg" = (
 /obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
@@ -25297,17 +24693,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "sDw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat/swat,
-/obj/item/storage/belt/holster,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/machinery/light/floor,
+/obj/structure/fluff/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood/leisure)
 "sDG" = (
 /obj/structure/table/wood/fancy/blackred,
 /obj/item/candle{
@@ -25321,11 +24713,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "sEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/old,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "sEn" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -25537,18 +24932,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"sNG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/clothing/gloves/combat,
-/obj/item/storage/belt/holster,
-/obj/item/clothing/shoes/combat/swat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "sNT" = (
 /obj/machinery/light{
 	dir = 4
@@ -25595,19 +24978,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sQa" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/fluff/railing{
+	dir = 9
 	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
-"sQg" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/wood/f13/stage_t{
+	icon_state = "housewood_stage_top_left"
+	},
+/area/f13/brotherhood)
 "sQp" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -25633,14 +25013,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"sQX" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
 "sRo" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -25659,11 +25031,16 @@
 /area/f13/tunnel)
 "sSJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate/mk2,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate/mk2,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "sTo" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -25749,13 +25126,11 @@
 	},
 /area/f13/sewer)
 "sXq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/old,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "sXM" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib4-old"
@@ -25763,12 +25138,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "sXU" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/brown,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
-	},
-/area/f13/brotherhood)
+/obj/structure/table,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/rnd)
 "sYr" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/f13/oak,
@@ -25792,16 +25169,6 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/enclave)
-"sZz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "tad" = (
 /obj/structure/chair{
 	dir = 4
@@ -25936,12 +25303,13 @@
 /area/f13/brotherhood/chemistry)
 "tgQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/vending/medical{
+	pixel_y = 32
 	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/brotherhood/medical)
 "thm" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -26030,12 +25398,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker)
 "tlr" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	desc = "A RobCo Industries terminal, this one looks well worn with a few keys missing or loose.";
+	doc_content_1 = "So, the Yuma Valley chapter of the Brotherhood has been born out of opportunity and desperation. The elders sent us to this desolate place to grab up any super weapons or vital infrastructure possible, to fight against and to bargain with the savages breaking down our doors at home, respectively. They say we held off from this location until now because the Legion were guarding the area heavily, and now they're distracted. I don't see why we didn't just bowl them over in the first place. Spears against lasers? Please.";
+	doc_content_2 = "You don't see the higher ups ever pulling mining duty, the randomized chore algorithm has to be weighted. But with only initiates ever coming through here, nobody's really eager to report my little hidey-hole. Some of the others hang out here sometimes, we drink a few brews or smoke some reefer, if we manage to shake down some of those locals for the goods. They're getting smart, aren't carrying joints on them anymore.";
+	doc_content_3 = "The paladin had a talk with me about my future, says I can't remain an initiate forever, I need to actually pick my path in the chapter. How can I do that when I don't even see this chapter lasting for my lifetime? This whole operation is temporary, we've only been here a few years now. And when I actually swear an oath to knighthood or something else, shit. I can't avoid work when I'm the one in charge of those below me.";
+	doc_content_4 = "Scattered reports about a verti being spotted in the night  near that local town. But no crash site. I just know who they're going to pull on patrol duty to find the damn thing. This armor is not made for long desert walks.";
+	doc_title_1 = "Journal 1 - New Home";
+	doc_title_2 = "Journal 2 - Mining Duty";
+	doc_title_3 = "Journal 3 - Dead-End?";
+	doc_title_4 = "Saved Draft - Crash?";
+	name = "battered terminal";
+	termtag = "Outpost Fargo System"
 	},
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/sign/poster/contraband/have_a_puff{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "tls" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -26059,11 +25440,8 @@
 /area/f13/tunnel)
 "tms" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/chemistry)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operating)
 "tmz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26281,9 +25659,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
 "tuI" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/offices2nd)
 "tvv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26438,29 +25816,19 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "tAG" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
-"tBh" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/effect/overlay/junk/mirror{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
-	icon_state = "redrustyfull"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/medical)
 "tBZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/fans/tiny{
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "tCQ" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
@@ -26610,26 +25978,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "tIR" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
-	},
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 3
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
 	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "tJc" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26641,10 +25996,6 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building)
-"tJx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "tJy" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -26707,16 +26058,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/f13/enclave)
 "tKY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "tKZ" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
@@ -26799,20 +26145,15 @@
 	},
 /area/f13/sewer)
 "tQb" = (
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "tQD" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/leisure)
 "tQH" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/boxing/blue,
@@ -27039,10 +26380,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "udC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/chair/folding{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/brotherhood)
 "uef" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -27062,14 +26405,9 @@
 	},
 /area/f13/bunker)
 "ueZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/chemistry)
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "ufY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -27087,11 +26425,16 @@
 	},
 /area/f13/tunnel)
 "uhC" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/button/door{
+	id = "headscribedorm";
+	normaldoorcontrol = 1;
+	pixel_x = -5;
+	pixel_y = 5;
+	specialfunctions = 4
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "uhE" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/decoration/rag{
@@ -27201,15 +26544,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
 "ulh" = (
-/obj/structure/closet/cabinet,
-/obj/structure/sign/poster/prewar/poster82{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/head/f13/boscap,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/archives)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/f13/brotherhood)
 "uls" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/pa_wear,
@@ -27249,12 +26590,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/den)
-"umZ" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood)
 "unm" = (
 /obj/structure/nest/deathclaw{
 	max_mobs = 2
@@ -27292,22 +26627,20 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "upG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/archives)
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/mineral/random/low_chance/underground,
+/area/f13/caves)
 "upY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosshop";
-	pixel_x = 32
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "uqc" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/black,
@@ -27349,11 +26682,18 @@
 	},
 /area/f13/caves)
 "uqU" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/closet/secure_closet/personal,
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "ura" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/grass,
@@ -27365,15 +26705,19 @@
 	},
 /area/f13/tunnel)
 "urw" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
+/obj/machinery/button/door{
+	id = "sentdorm";
+	normaldoorcontrol = 1;
+	pixel_y = 32;
+	specialfunctions = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/bed,
+/obj/item/bedsheet/rd{
+	desc = "A fine quilted blanket, made with purple and yellow fabric.";
+	dream_messages = list("authority","a silvery ID","a bomb","a mech","a facehugger","maniacal laughter");
+	name = "fine bedsheet"
 	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/wood/f13/old,
 /area/f13/brotherhood)
 "urF" = (
 /obj/effect/decal/waste,
@@ -27382,11 +26726,9 @@
 	},
 /area/f13/tunnel)
 "usd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/brotherhood/archives)
+/obj/machinery/flasher/portable,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "usk" = (
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -27515,30 +26857,24 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/bunker)
 "uxx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/medical{
-	pixel_y = 32
+/obj/item/clothing/shoes/laceup{
+	pixel_x = 6;
+	pixel_y = -12
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
+"uxz" = (
+/obj/structure/table/reinforced{
+	req_access_txt = "120"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars{
+	layer = 5
 	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "redrustyfull"
 	},
-/area/f13/brotherhood/medical)
-"uxz" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
-/obj/item/pen/fountain{
-	pixel_x = 15;
-	pixel_y = 5
-	},
-/obj/item/construction/rcd/loaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "uxZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
@@ -27591,12 +26927,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uBp" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/machinery/radioterminal/bos{
+	dir = 8;
+	pixel_x = 5
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "uBO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -27605,13 +26941,8 @@
 	},
 /area/f13/brotherhood/medical)
 "uBW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "uCj" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/machinery/light/small{
@@ -27649,11 +26980,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "uDa" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
+/obj/structure/chair/f13chair1,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "uEb" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -27729,9 +27058,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uHu" = (
-/obj/item/storage/money_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/obj/structure/lattice{
+	density = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flag/bos,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "uHB" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27793,9 +27129,13 @@
 /turf/open/floor/wood/f13/oakbroken3,
 /area/f13/sewer)
 "uKV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 10
+	},
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
 /area/f13/brotherhood/leisure)
 "uLn" = (
 /obj/structure/rack,
@@ -27813,11 +27153,15 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "uLI" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/hot_potato/harmless/toy,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "uLP" = (
 /turf/open/floor/wood/f13/housewoodbroken2,
 /area/f13/building)
@@ -27902,12 +27246,12 @@
 /turf/open/floor/carpet/green,
 /area/f13/den)
 "uPp" = (
-/obj/machinery/light/floor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/medical)
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood)
 "uPr" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
@@ -27975,14 +27319,12 @@
 	},
 /area/f13/enclave)
 "uTy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Admin Accommodation";
-	req_access_txt = "120"
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/medical)
 "uTE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -27990,14 +27332,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "uUH" = (
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/wood/f13/stage_r,
 /area/f13/brotherhood)
 "uVg" = (
 /obj/structure/showcase/mecha/marauder{
@@ -28029,8 +27364,11 @@
 	},
 /area/f13/bunker)
 "uXj" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "uXF" = (
 /obj/structure/lattice{
 	layer = 3
@@ -28098,17 +27436,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
-"uYY" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/glasses/meson,
-/obj/item/gps/mining{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "uZI" = (
 /obj/structure/sign/warning{
 	pixel_x = 6;
@@ -28158,8 +27485,8 @@
 	},
 /area/f13/bunker)
 "vbt" = (
-/turf/open/floor/wood/f13/stage_l,
-/area/f13/brotherhood/archives)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "vbx" = (
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
@@ -28199,13 +27526,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "vcp" = (
-/obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/screwdriver,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "vct" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -28242,8 +27569,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "vdx" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/archives)
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vdE" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
@@ -28252,9 +27582,26 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "vep" = (
+/obj/structure/kitchenspike_frame{
+	anchored = 1;
+	name = "power armor frame"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
+	anchored = 1;
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood)
 "veu" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt{
@@ -28268,14 +27615,21 @@
 /area/f13/sewer)
 "veQ" = (
 /obj/structure/noticeboard{
-	desc = "A large, rusted plaque with a newly crafted nameplate denoting the Head Knight of the chapterhouse.";
-	dir = 1;
-	name = "Head Knight's Office";
-	pixel_y = -32
+	name = "display plate";
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/item/gun/energy/laser/plasma/scatter{
+	anchored = 1;
+	cell_type = null;
+	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots. This one is for display, and no longer fires.";
+	name = "display multiplas rifle";
+	pin = null;
+	pixel_y = 32
 	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/sentinel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood)
 "veR" = (
 /obj/structure/fence,
@@ -28345,12 +27699,20 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "vhk" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/construction/rld,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/archives)
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "vhB" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -28381,23 +27743,12 @@
 /turf/open/floor/wood/f13/stage_b,
 /area/f13/den)
 "vjG" = (
-/obj/item/radio/intercom{
-	desc = "Is there anyone on the other end? Who's in there?";
-	frequency = 1291;
-	name = "Mysterious Intercom";
-	pixel_x = 32
+/obj/structure/furnace,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood)
+/area/f13/brotherhood/operations)
 "vkc" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -28411,16 +27762,11 @@
 	},
 /area/f13/sewer)
 "vkg" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "vkp" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -28634,30 +27980,13 @@
 	icon_state = "purplefull"
 	},
 /area/f13/clinic)
-"vsP" = (
-/obj/structure/kitchenspike_frame{
-	anchored = 1;
-	name = "power armor frame"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
-	anchored = 1;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
 "vtf" = (
-/obj/structure/bed/old,
-/obj/item/bedsheet/ce,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "vtj" = (
 /obj/machinery/light/floor,
 /obj/item/kirbyplants/random,
@@ -28826,12 +28155,6 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/enclave)
-"vyt" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/keg,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
 "vyy" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/dirt,
@@ -28849,14 +28172,19 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "vzq" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "vAk" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/offices2nd)
 "vAv" = (
 /obj/structure/plasticflaps,
 /obj/effect/decal/cleanable/dirt{
@@ -28901,14 +28229,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "vCQ" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = 8;
-	pixel_y = -4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/chemistry)
 "vDt" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -28947,14 +28271,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"vFu" = (
-/obj/structure/sign/poster/prewar/poster63{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood)
 "vFx" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/clothing/head/crown,
@@ -28999,13 +28315,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/bunker)
 "vHE" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_y = -32
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
-	},
-/area/f13/brotherhood/archives)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "vHM" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "yellowrustysolid"
@@ -29122,15 +28436,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "vKz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Fargo Outpost";
-	req_access_txt = "120"
+/obj/structure/fluff/railing{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/medical)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/operations)
 "vKK" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
@@ -29590,11 +28900,14 @@
 	},
 /area/f13/bunker)
 "wbN" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/machinery/door/airlock/grunge{
+	name = "Fargo Storage";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/brotherhood/armory)
 "wbZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -29639,15 +28952,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wej" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
-"weo" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/structure/fluff/railing{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "weC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -29662,34 +28971,39 @@
 	},
 /area/f13/caves)
 "weW" = (
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/restraints/legcuffs,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/structure/chair/bench{
+	icon_state = "dropshipleft"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "wft" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wfJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Power Armor Maintenance Room";
-	req_access_txt = "120"
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhdirty_chess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/leisure)
 "wgb" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_right"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/archives)
+/obj/item/flashlight/lamp{
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "wgc" = (
 /obj/structure/table{
 	layer = 2.9
@@ -29713,23 +29027,14 @@
 	},
 /area/f13/bunker)
 "wgA" = (
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 16;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/carpet,
-/area/f13/brotherhood/offices1st)
+/obj/structure/noticeboard{
+	desc = "A large, rusted plaque with a newly crafted nameplate displaying the current Senior Paladin on duty.";
+	name = "Senior Paladin's Office";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "wgK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -29748,13 +29053,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "whQ" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/item/kirbyplants{
+	icon_state = "plant-04"
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "wiz" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -29787,16 +29092,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/sewer)
-"wkf" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
 "wkw" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood{
@@ -29816,10 +29111,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wlf" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/paper_bin{
+	pixel_x = 16;
+	pixel_y = 5
+	},
+/obj/item/pen/fountain{
+	pixel_x = 15;
+	pixel_y = 5
+	},
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/carpet/arcade,
+/area/f13/brotherhood/offices2nd)
 "wln" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -29850,7 +29153,13 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "wmL" = (
-/turf/open/floor/wood/f13/old,
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "wnT" = (
 /obj/structure/fluff/railing{
@@ -29990,12 +29299,10 @@
 	},
 /area/f13/brotherhood/leisure)
 "wtE" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices2nd)
 "wtK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/closed/wall/f13/wood/house,
@@ -30159,17 +29466,30 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/building)
 "wAU" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "formal attire closet"
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
 	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill{
-	pixel_y = -10
+/obj/item/ammo_box/magazine/m22{
+	pixel_x = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/grenade/empgrenade{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "wBa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -30250,9 +29570,18 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "wFv" = (
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "wFD" = (
 /turf/open/water,
 /area/f13/sewer)
@@ -30286,9 +29615,11 @@
 	},
 /area/f13/sewer)
 "wGn" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/structure/fluff/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "wGF" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30322,10 +29653,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "wHH" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/structure/fluff/railing{
+	dir = 6
+	},
+/obj/structure/destructible/clockwork/wall_gear{
+	pixel_y = 32
+	},
+/obj/machinery/light/floor{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "wHP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -30352,15 +29690,14 @@
 	},
 /area/f13/brotherhood/rnd)
 "wIU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/fluff/railing{
+	dir = 6
 	},
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/lattice{
+	density = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
+/obj/item/flag/bos,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "wJj" = (
@@ -30414,12 +29751,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "wKL" = (
-/obj/structure/chair/stool/retro/black,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot_red,
+/obj/item/melee/powered/ripper,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "wKX" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
@@ -30472,11 +29811,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wMJ" = (
-/obj/structure/bed/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "wNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -30492,11 +29831,10 @@
 	},
 /area/f13/bunker)
 "wNy" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/railing,
+/obj/effect/landmark/start/f13/seniorscribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/area/f13/brotherhood/rnd)
 "wND" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -30526,19 +29864,29 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
 "wPR" = (
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_bottom_left"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood/operations)
 "wQb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wQj" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Paladin's PipBoy"
+	},
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "wQn" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30588,16 +29936,24 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/armory)
 "wSi" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/chair/bench{
+	icon_state = "dropshipright"
 	},
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "wSV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
 	},
+/obj/item/stack/ore/blackpowder/twenty{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "wTz" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -30645,7 +30001,17 @@
 /turf/open/water,
 /area/f13/sewer)
 "wWD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 3
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "wWF" = (
@@ -30726,12 +30092,15 @@
 	},
 /area/f13/caves)
 "wZL" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "xas" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -30788,9 +30157,9 @@
 	},
 /area/f13/building)
 "xcW" = (
-/obj/structure/flora/junglebush/b,
-/turf/closed/mineral/random/low_chance/underground,
-/area/f13/caves)
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "xcX" = (
 /obj/structure/sign/departments/security,
 /obj/effect/decal/cleanable/dirt{
@@ -30800,17 +30169,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/bunker)
-"xdk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "xdp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30830,12 +30188,14 @@
 	},
 /area/f13/clinic)
 "xev" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_y = 32
 	},
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "casino"
+	},
+/area/f13/brotherhood/offices2nd)
 "xeC" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/indestructible/ground/inside/mountain,
@@ -30848,33 +30208,20 @@
 	},
 /area/f13/bunker)
 "xfi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_y = 32
-	},
-/obj/item/gun/energy/laser/rcw{
-	anchored = 1;
-	cell_type = null;
-	desc = "A rapid-fire laser rifle modeled after the familiar Thompson Submachine Gun. It features high-accuracy burst fire that will whittle down targets in a matter of seconds. This one is for display, and no longer fires.";
-	name = "display laser RCW";
-	pin = null;
-	pixel_y = 32
+/obj/structure/falsewall/reinforced{
+	layer = 3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/area/f13/brotherhood/medical)
 "xfq" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xfJ" = (
-/obj/machinery/workbench/forge,
-/obj/item/gun/ballistic/automatic/pistol/pistol22{
-	pixel_x = 10;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/effect/landmark/start/f13/elder,
+/obj/structure/chair/wood/fancy,
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/offices2nd)
 "xgs" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -30882,25 +30229,34 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "xgw" = (
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "vault"
+/obj/structure/table{
+	layer = 2.9
 	},
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/item/card/id/dogtag,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "xgK" = (
-/obj/structure/chair/wood/fancy{
-	dir = 1
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/brotherhood/archives)
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xgN" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Outpost Scribe Storage";
-	req_access_txt = "120"
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosshop";
+	name = "brotherhood shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "xgY" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
@@ -30912,22 +30268,18 @@
 	},
 /area/f13/brotherhood/medical)
 "xhV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/closet/crate,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "xic" = (
-/obj/structure/fluff/railing{
-	dir = 5
+/obj/machinery/door/airlock/hatch{
+	name = "Fargo Holding Cell";
+	req_access_txt = "120"
 	},
-/turf/open/floor/wood/f13/stage_t{
-	icon_state = "housewood_stage_top_right"
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkrustysolid"
 	},
-/area/f13/brotherhood/archives)
+/area/f13/brotherhood)
 "xig" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -30962,10 +30314,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/f13/bunker)
 "xje" = (
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/leisure)
 "xjD" = (
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31016,12 +30372,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xkI" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
 	},
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/brotherhood)
 "xkJ" = (
 /turf/open/indestructible/ground/outside/water{
 	density = 1;
@@ -31045,11 +30403,9 @@
 	},
 /area/f13/caves)
 "xlH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/closet/crate/engineering,
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "xmm" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
@@ -31074,8 +30430,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/bunker)
 "xns" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/mining)
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -9;
+	pixel_y = 21
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xnz" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -31191,12 +30562,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/bunker)
 "xta" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/closet/crate/footlocker{
+	anchored = 1;
+	pixel_x = 8;
+	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "xtk" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -31209,11 +30582,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "xtz" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood)
 "xtA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/tunnel,
@@ -31240,11 +30612,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "xuo" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
+/turf/open/floor/f13{
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "xuq" = (
 /obj/structure/cable{
@@ -31257,12 +30628,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "xuw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/item/radio/intercom{
+	desc = "Is there anyone on the other end? Who's in there?";
+	frequency = 1291;
+	name = "Mysterious Intercom";
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/pda/engineering{
+	name = "Knight-Technician Pip-Boy 3000"
+	},
+/obj/item/pda/engineering{
+	name = "Knight-Technician Pip-Boy 3000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood)
 "xuC" = (
 /obj/effect/decal/cleanable/dirt{
@@ -31337,11 +30723,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
 "xyn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small,
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/armory)
 "xyz" = (
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31423,10 +30811,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "xCH" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "stagestairs2"
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
 	},
-/area/f13/brotherhood/archives)
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xCI" = (
 /obj/structure/table,
 /obj/item/weldingtool/experimental{
@@ -31498,11 +30892,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xFY" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/closet/cabinet,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
 	},
-/turf/open/floor/carpet,
-/area/f13/brotherhood/archives)
+/obj/item/storage/belt/holster,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "xGd" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -31515,11 +30916,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "xGx" = (
-/obj/structure/fans/tiny{
+/obj/structure/closet/cabinet,
+/obj/structure/sign/poster/prewar/poster82{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/archives)
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/head/f13/boscap,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/offices2nd)
 "xGV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -31574,12 +30979,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "xHW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/obj/item/kirbyplants,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood/offices2nd)
 "xIe" = (
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -31630,13 +31032,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"xJM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
 "xKD" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -31730,15 +31125,8 @@
 /turf/open/water,
 /area/f13/sewer)
 "xPm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
-"xPu" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood)
 "xPO" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -31768,15 +31156,9 @@
 	},
 /area/f13/enclave)
 "xQh" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/book/granter/crafting_recipe/blueprint/aep7{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkyellowfull"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "xQo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Fargo Outpost";
@@ -31809,17 +31191,22 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "xRm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/rnd)
-"xRn" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood)
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
+"xRn" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/red{
+	icon_state = "darkyellowfull"
+	},
+/area/f13/brotherhood/operations)
 "xRv" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -31938,13 +31325,10 @@
 	},
 /area/f13/bunker)
 "xWB" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/brotherhood/mining)
+/obj/structure/bed/old,
+/obj/item/bedsheet/hos,
+/turf/open/floor/wood/f13/old,
+/area/f13/brotherhood)
 "xWH" = (
 /obj/structure/stairs/south{
 	color = "#A47449"
@@ -31975,7 +31359,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer)
 "xYt" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+/obj/structure/bookcase,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1{
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/archives)
@@ -31989,8 +31375,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker)
 "xZn" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/offices1st)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "xZy" = (
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
@@ -32015,9 +31405,54 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/bunker)
 "yaZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/f13/brotherhood/archives)
+/obj/structure/closet{
+	anchored = 1;
+	name = "formal attire closet"
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -10
+	},
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood)
 "ybf" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -32059,14 +31494,6 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"yei" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "casino"
-	},
-/area/f13/brotherhood/archives)
 "yey" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -32178,16 +31605,6 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"yiX" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 10
-	},
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
 "ykf" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating/tunnel{
@@ -32202,18 +31619,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/enclave)
 "ykR" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
-/obj/item/flashlight/lamp{
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola{
-	pixel_x = 16;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/offices1st)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "ykY" = (
 /obj/structure/lattice{
 	layer = 3
@@ -32231,12 +31641,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood)
 "ylk" = (
-/obj/structure/toilet{
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/obj/machinery/light/floor,
+/turf/open/floor/carpet,
+/area/f13/brotherhood/archives)
 "yln" = (
 /obj/structure/simple_door/metal/iron,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -76487,7 +75894,7 @@ eLE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -76744,7 +76151,7 @@ eLE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -77258,7 +76665,7 @@ eLE
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -77514,7 +76921,7 @@ eLE
 (177,1,1) = {"
 eLE
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -77539,8 +76946,8 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -77793,10 +77200,10 @@ aoj
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -78028,7 +77435,7 @@ eLE
 (179,1,1) = {"
 eLE
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -78284,7 +77691,7 @@ eLE
 "}
 (180,1,1) = {"
 eLE
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -78541,7 +77948,7 @@ eLE
 "}
 (181,1,1) = {"
 eLE
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -78798,7 +78205,7 @@ eLE
 "}
 (182,1,1) = {"
 eLE
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -78807,15 +78214,6 @@ vPg
 vPg
 vPg
 aoj
-vPg
-vPg
-vPg
-aoj
-aoj
-vPg
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -78827,6 +78225,15 @@ vPg
 vPg
 vPg
 vPg
+vPg
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 aoj
@@ -79055,9 +78462,9 @@ eLE
 "}
 (183,1,1) = {"
 eLE
+aoj
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -79080,10 +78487,10 @@ aoj
 vPg
 vPg
 vPg
+aoj
 vPg
-vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -79315,24 +78722,6 @@ eLE
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 aoj
 vPg
 aoj
@@ -79340,6 +78729,24 @@ vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+vPg
+aoj
+vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -79572,10 +78979,10 @@ eLE
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -79587,15 +78994,15 @@ vPg
 aoj
 aoj
 aoj
-dBk
-dBk
-dBk
-dBk
-dBk
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -79829,11 +79236,11 @@ eLE
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 aoj
@@ -79844,15 +79251,15 @@ vPg
 vPg
 vPg
 vPg
-dBk
-lfs
-sAE
-btc
-dBk
-aoj
-aoj
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -80086,11 +79493,11 @@ eLE
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 aoj
 vPg
@@ -80101,14 +79508,14 @@ vPg
 vPg
 vPg
 vPg
-dBk
-lmc
-lHY
-xHW
-dBk
 vPg
 vPg
 vPg
+vPg
+vPg
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -80358,16 +79765,16 @@ vPg
 vPg
 vPg
 aoj
-dBk
-lmc
-lHY
-hAk
-dBk
+vPg
+aoj
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -80608,32 +80015,32 @@ aoj
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
 aoj
-dBk
-luk
-lHY
-xHW
-dBk
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-aoj
 aoj
 vPg
 aoj
 aoj
 vPg
 vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+aoj
+vPg
+aoj
+aoj
 vPg
 aoj
 vPg
@@ -80855,7 +80262,7 @@ eLE
 (190,1,1) = {"
 eLE
 vPg
-vPg
+aoj
 yhT
 yhT
 aoj
@@ -80865,31 +80272,31 @@ yhT
 yhT
 yhT
 yhT
-yhT
-yhT
+aoj
+aoj
 yhT
 yhT
 vPg
 aoj
 vPg
-dBk
-lvK
-lLb
-xHW
-dBk
-vPg
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
 vPg
 vPg
 vPg
+vPg
+aoj
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -81112,38 +80519,6 @@ eLE
 (191,1,1) = {"
 eLE
 vPg
-vPg
-yhT
-aoj
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-vPg
-yhT
-yhT
-yhT
-aoj
-aoj
-vPg
-dBk
-dBk
-dBk
-dBk
-lUw
-dBk
-dBk
-dBk
-xta
-sAE
-sAE
-dcE
-sAE
-sAE
-btc
-dBk
 aoj
 aoj
 vPg
@@ -81156,15 +80531,47 @@ vPg
 vPg
 vPg
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
 vPg
-vPg
-vPg
+aoj
+aoj
 aoj
 aoj
 vPg
 vPg
+vPg
+vPg
 aoj
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -81368,39 +80775,14 @@ eLE
 "}
 (192,1,1) = {"
 eLE
-vPg
-vPg
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
 aoj
-aoj
-aoj
-aoj
-yhT
 vPg
 aoj
-dBk
-xta
-sAE
-sAE
-lVB
-sAE
-qCb
-nZd
-fce
-dBk
-dBk
-dBk
-dBk
-dBk
-xHW
-dBk
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -81413,6 +80795,7 @@ vPg
 vPg
 aoj
 aoj
+aoj
 vPg
 vPg
 vPg
@@ -81421,7 +80804,31 @@ vPg
 vPg
 aoj
 vPg
+vPg
+vPg
+vPg
 aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -81627,47 +81034,12 @@ eLE
 eLE
 vPg
 vPg
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-vPg
-yhT
-vPg
-yhT
-vPg
-aoj
-cDY
-cYh
-dBk
-dBk
-dBk
-dBk
-dBk
-obi
-ool
-dBk
-qba
-qzL
-rbj
-dBk
-xHW
-dBk
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
-aoj
 vPg
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -81682,6 +81054,41 @@ aoj
 aoj
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+vPg
+vPg
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -81884,51 +81291,51 @@ eLE
 eLE
 vPg
 vPg
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
-yhT
 vPg
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 dBk
-xHW
 dBk
-lLs
-mbe
-mcz
-nwI
-obT
-xZn
-xZn
-sfl
-qHb
-vep
 dBk
-cYh
 dBk
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
+dBk
+dBk
+dBk
+dBk
+dBk
 vPg
 aoj
 aoj
 vPg
-vPg
+aoj
 vPg
 aoj
 aoj
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 aoj
 vPg
 vPg
@@ -81936,7 +81343,7 @@ vPg
 vPg
 vPg
 aoj
-aoj
+vPg
 vPg
 vPg
 vPg
@@ -82139,49 +81546,50 @@ eLE
 "}
 (195,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 yhT
 yhT
 yhT
-yhT
-yhT
-yhT
+aoj
+aoj
+vPg
 dBk
-xHW
 dBk
-lMH
+dBk
+dBk
+dBk
+ajx
+ajx
+dBk
+dBk
+dBk
+dBk
+dBk
+nIl
+nIl
+dBk
+mlz
 mcz
-mcz
-xZn
-odd
-orp
-pgs
-sfl
-vep
-vep
-dBk
-xHW
-dBk
-dBk
-dBk
+pyg
 dBk
 vPg
+aoj
+aoj
+vPg
+aoj
+aoj
+aoj
+aoj
+aoj
+vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -82191,11 +81599,10 @@ vPg
 aoj
 aoj
 vPg
-aoj
-aoj
-aoj
 vPg
-aoj
+vPg
+vPg
+vPg
 vPg
 aoj
 aoj
@@ -82396,48 +81803,48 @@ eLE
 "}
 (196,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+yhT
+yhT
+yhT
+aoj
+yhT
+yhT
+dBk
+ujt
+aaQ
+ujt
+dBk
+pHr
+oev
+dBk
+wQj
+rle
+uqU
+oAL
 dBk
 dBk
 dBk
+iXo
+pub
+umo
 dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-xHW
-dBk
-lNt
-mcz
-mcz
-xZn
-odD
-mcz
-xZn
-qfe
-qKB
-vep
-dBk
-tBZ
-sAE
-sAE
-btc
-dBk
+vPg
+aoj
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -82450,10 +81857,10 @@ aoj
 vPg
 vPg
 vPg
-aoj
-aoj
 vPg
-aoj
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -82655,44 +82062,49 @@ eLE
 eLE
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
+yhT
 dBk
-xta
+qfe
+fpe
+ujt
 dcE
-sAE
-sAE
-sAE
-sAE
-sAE
+iyT
+yix
+dBk
+rYD
 qCb
-sAE
+qCb
+dBk
 kvl
-dBk
-lPl
 miB
-mtc
-xZn
-oev
-osu
-xZn
-xZn
-xZn
-rjT
-dBk
-dBk
-dBk
-dBk
-hAk
+lPl
+iXo
+umo
+umo
 dBk
 vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -82706,11 +82118,6 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-aoj
 vPg
 aoj
 aoj
@@ -82911,41 +82318,39 @@ eLE
 (198,1,1) = {"
 eLE
 vPg
+aoj
+aoj
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
 dBk
-xHW
+ujt
+hXt
+ujt
 dBk
+yix
+sJp
 dBk
-dBk
-dBk
-dBk
-dBk
-dBk
+ueZ
+qCb
+qCb
 dBk
 kMw
+qCb
 dBk
-xZn
 miY
-xZn
-xZn
-obT
-xZn
-xZn
-qhj
-qQa
-vep
-sQg
-vep
-sfl
+too
+umo
 dBk
-xHW
-dBk
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -82962,11 +82367,13 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
 aoj
 vPg
 vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 aoj
 aoj
@@ -83173,40 +82580,34 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
 dBk
-xHW
 dBk
-fzc
-gqM
-hcp
-rXr
-wrm
+dBk
+dBk
+dBk
+sJp
+sJp
+dBk
+urw
+bBA
 uBp
-utF
-sJp
-sJp
-xZn
-sfl
-xZn
+dBk
+xWB
+uxx
+dBk
+dBk
+dBk
 qub
-lgG
-vep
-nwI
-bde
-qQy
-vep
-bEm
-vep
-sDw
 dBk
-xHW
 dBk
 vPg
 vPg
 vPg
 vPg
+aoj
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -83215,14 +82616,20 @@ vPg
 vPg
 aoj
 vPg
-aoj
-aoj
-aoj
-aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 aoj
 aoj
 aoj
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -83427,43 +82834,45 @@ eLE
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+ood
+ood
+ood
+ood
+ood
+ood
+ood
+ood
+sJp
+sJp
+ood
+ood
+fUG
 dBk
-xRn
 dBk
-qgy
-wrm
-wrm
-wrm
-wrm
-wrm
-sJp
-sJp
-sJp
-xZn
+dBk
+dBk
+dBk
 mjR
 wgA
-ryZ
+umo
 sSJ
-vep
-xZn
-qUq
-vep
-vep
-rTv
-ade
-sEa
-dBk
-xHW
 dBk
 vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -83472,14 +82881,12 @@ vPg
 vPg
 aoj
 vPg
-aoj
-aoj
-aoj
-aoj
 vPg
 vPg
 vPg
-aoj
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -83684,40 +83091,31 @@ eLE
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-dBk
-lAK
+ood
+kwf
+sJp
+luk
+hcp
 rXr
 wrm
-lja
-wrm
-wrm
+fXl
 utF
 sJp
-lxZ
-xZn
+tQH
+ood
+iXo
+dBk
+xns
+lUw
+umo
+oAL
 mlC
 ont
 nzg
-sSJ
-jmS
 xZn
-tIR
-vep
-vep
-vep
-vep
-vep
 dBk
-xHW
-dBk
-vPg
+ggZ
+aoj
 vPg
 vPg
 vPg
@@ -83730,15 +83128,24 @@ vPg
 aoj
 vPg
 vPg
+aoj
 vPg
-vPg
-vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
 aoj
 aoj
 aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -83939,51 +83346,50 @@ eLE
 (202,1,1) = {"
 eLE
 vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-dBk
-dBk
-dBk
-cYh
-dBk
-fIc
+aoj
+aoj
+ood
+kvw
+sJp
+qTX
 wrm
 wrm
-rXr
-iuM
 wrm
+rjT
 sJp
 sJp
-sJp
+kEK
+ood
+ryt
+ouT
+gCM
+gCM
+umo
+dBk
 xZn
-mmf
-lFa
+umo
 ryZ
-sSJ
-vep
-xZn
-bXJ
-vep
-sfl
-iMu
-oyL
-sNG
+nwI
 dBk
-xHW
-dBk
-dBk
+ggZ
+aoj
 vPg
 vPg
+aoj
+vPg
+aoj
 vPg
 vPg
+aoj
 vPg
 vPg
+aoj
 vPg
+aoj
 vPg
-vPg
+aoj
+aoj
+aoj
 aoj
 vPg
 vPg
@@ -83992,6 +83398,7 @@ vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
@@ -84196,48 +83603,42 @@ eLE
 (203,1,1) = {"
 eLE
 vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-xta
-sAE
-sAE
-fce
-dBk
-fJs
-gtv
+aoj
+aoj
+ood
+jEu
+sJp
+rXr
 wrm
 wrm
 wrm
-iYx
+wrm
 utF
 sJp
-sJp
-xZn
+lxZ
+ood
+veQ
+iYx
+rKX
+gCM
+gPu
+dBk
 vep
-vep
-vep
+umo
+cDY
 vcp
-vep
-xZn
-vsP
-vep
-cLG
-vtf
-sfl
-sEa
 dBk
-tKY
-btc
-dBk
+ggZ
+aoj
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -84249,6 +83650,12 @@ vPg
 vPg
 vPg
 vPg
+vPg
+aoj
+aoj
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -84453,49 +83860,46 @@ eLE
 (204,1,1) = {"
 eLE
 vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
+aoj
+aoj
 ood
-ood
-ood
-ood
-ood
-ood
+kvw
+sJp
+qTX
+wrm
+rXr
+iuM
+rjT
+sJp
+sJp
 hik
-kvU
+ood
 niu
-kEK
-sJp
-sJp
-sJp
-xZn
-xZn
-xZn
+lLb
+gCM
+gCM
+umo
+dBk
+qdg
+umo
 nzi
 xZn
-xZn
-xZn
-xZn
-wfJ
-xZn
-xZn
-xZn
-xZn
 dBk
-dBk
-xHW
-dBk
-dBk
-dBk
-dBk
-dBk
+ggZ
+vPg
+aoj
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
+aoj
+aoj
 vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -84509,6 +83913,9 @@ vPg
 vPg
 vPg
 aoj
+vPg
+vPg
+vPg
 vPg
 aoj
 vPg
@@ -84712,49 +84119,46 @@ eLE
 vPg
 vPg
 vPg
-vPg
-vPg
-dBk
+ood
+kwf
+sJp
 hAk
+wrm
+wrm
+wrm
+sDw
+utF
+sJp
+pgs
 ood
-cBO
-xOz
-aeI
-ccJ
-ood
-hjT
-klB
-rSv
-tQH
-sJp
-sJp
-sJp
-sJp
-ood
-oxm
-xsD
-xsD
-wSc
-fww
-aSi
-xDb
-xfJ
-xDb
+umo
+umo
+umo
+umo
+umo
 dBk
-sQa
-wSi
-tLv
-tBZ
-sAE
-sAE
-qCb
-btc
+mbe
+umo
+yhF
+wFv
 dBk
+ggZ
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -84766,7 +84170,10 @@ vPg
 vPg
 vPg
 aoj
-aoj
+vPg
+vPg
+vPg
+vPg
 vPg
 aoj
 aoj
@@ -84966,46 +84373,35 @@ eLE
 "}
 (206,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-cEQ
-oPe
-xOz
-ccJ
 ood
-yix
-yix
-yix
-sJp
-sJp
-sJp
-sJp
-sJp
 ood
-mvU
-xsD
-xsD
+ood
+ood
+ood
+ood
+ood
+ood
+ood
+ood
+ood
+gAb
+ood
+ood
+ood
+ood
+hTd
+ood
+wSc
+wSc
 wSc
 phr
-ibx
-xDb
-xDb
-ibx
-dBk
-dBk
-dBk
-dBk
-dBk
-kMw
-dBk
-dBk
-xHW
+wSc
+wSc
+wSc
+wSc
+wSc
+wSc
 dBk
 dBk
 dBk
@@ -85013,6 +84409,12 @@ dBk
 dBk
 dBk
 dBk
+dBk
+dBk
+dBk
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -85020,8 +84422,13 @@ vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
+vPg
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -85223,53 +84630,49 @@ eLE
 "}
 (207,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-cGe
+cBO
 xOz
-xOz
-xOz
-oFo
-sJp
-sJp
-sJp
-sri
-kvU
-bko
-sJp
-sJp
+aeI
+ccJ
 ood
-mzi
+hjT
+klB
+rSv
+sJp
+sJp
+sJp
+sJp
+sJp
+pNR
+ood
+oxm
 xsD
 xsD
 wSc
+vhk
+aSi
+xDb
+xDb
+nRs
+hSz
 qeX
-xDb
-xDb
-xDb
-xDb
-xDb
-xDb
-xDb
+orp
+vkg
+ajx
+ajx
+ajx
 dBk
+oZG
+qCb
 xgw
-xgw
-xgw
+qCb
+lja
 dBk
-gse
-wNy
-sAE
-dcE
-sAE
-sAE
-btc
-dBk
+vPg
+aoj
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -85278,7 +84681,11 @@ vPg
 vPg
 vPg
 aoj
+aoj
 vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -85480,55 +84887,46 @@ eLE
 "}
 (208,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-dBk
-xHW
 ood
-sKs
+cEQ
+oPe
 xOz
-xOz
-xOz
+ccJ
 ood
-hmO
+tQD
+sJp
+yix
+yix
 sJp
 sJp
-nQz
-ffy
-bko
 sJp
 sJp
+pNR
 ood
-mDL
+mvU
 xsD
 xsD
-ouH
+wSc
+wWD
 xDb
 xDb
 xDb
-xDb
-xDb
-xDb
-xDb
-xDb
+eEh
+hSz
+pBy
+cwz
+wSc
+xuo
+xuo
+xuo
+dBk
+xFY
 dEr
-xgw
+dEr
 gFF
-gFF
-lZb
-rOT
+cAf
 dBk
-dBk
-dBk
-dBk
-dBk
-xHW
-dBk
-vPg
-vPg
+aoj
 vPg
 vPg
 aoj
@@ -85536,6 +84934,15 @@ aoj
 vPg
 vPg
 vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -85737,60 +85144,60 @@ eLE
 "}
 (209,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xta
-fce
 ood
-fKG
-oPe
+cGe
 xOz
-bXP
-ood
-hpQ
+xOz
+xOz
+oFo
 sJp
 sJp
-nQz
+sJp
+sri
 ffy
+kvU
 bko
 sJp
-sJp
+pNR
 ood
-mFo
+mzi
 xsD
-ogl
+xsD
 wSc
-piW
-xDb
-xDb
-rkb
+aNt
 xDb
 xDb
 xDb
-xDb
-dBk
-xgw
-xgw
-xgw
-cGk
-weo
-wQj
-bLn
-wQj
-bLn
+aQb
+ykR
+upY
 qcK
-pbh
+wSc
+rkb
+rXC
+rkb
+dBk
+sEa
+qCb
+dEr
+qCb
+lja
 dBk
 vPg
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
-aoj
+vPg
+vPg
+vPg
+vPg
 vPg
 aoj
 vPg
@@ -85994,52 +85401,44 @@ eLE
 "}
 (210,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-cYh
 ood
+sKs
+xOz
+xOz
+xOz
 ood
-ood
-ood
-aAA
-ood
-ood
-ood
-ood
-ixU
+hmO
 sJp
+dma
+rTv
+ffy
+ffy
+bko
 sJp
-sJp
-sJp
-sJp
-rtr
+pNR
+ood
+mDL
 xsD
 xsD
-xsD
-wSc
-pnK
+ouH
 xDb
 xDb
-rle
 xDb
-dBk
-dBk
-dBk
+xDb
+xDb
+xDb
+xDb
+xDb
+ouH
+rkb
+rXC
+rkb
+lZb
+rOT
 dBk
 sxm
-xgw
-veQ
 dBk
-pNR
-sfl
-sfl
-vep
-vep
 dBk
-cYh
 dBk
 vPg
 vPg
@@ -86051,9 +85450,17 @@ vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
+aoj
+vPg
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -86251,66 +85658,66 @@ eLE
 "}
 (211,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-bba
+fKG
+oPe
 xOz
-xOz
-xOz
-fMP
-xOz
-xOz
-hYB
+bXP
+ood
+hpQ
 sJp
 sJp
 nQz
 ffy
+ffy
 bko
 sJp
-rtr
+lxZ
+ood
+mFo
 xsD
-xsD
-xsD
+ogl
 wSc
+piW
+xDb
+xDb
+xDb
+wAU
+ibx
 pnS
-xDb
-qRb
-rpS
-xDb
-dBk
-sQX
-xgw
-dBk
-xgw
-xgw
-xgw
-vSy
-sfl
-vep
-sfl
-ykR
-hNG
-dBk
-xHW
+wKL
+wSc
+rkb
+rXC
+rkb
+cGk
+iXo
+iXo
+iXo
+iXo
+iXo
 dBk
 vPg
 vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+aoj
+aoj
+vPg
+aoj
+vPg
+aoj
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
+aoj
+aoj
+aoj
 vPg
 aoj
 vPg
@@ -86508,61 +85915,61 @@ eLE
 "}
 (212,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-bcj
-tKv
-xOz
-xOz
-fUG
-tKv
-xOz
-hZA
-sJp
-sJp
-nQz
-kvU
-bko
-sJp
 ood
-mJr
+ood
+aAA
+ood
+ood
+ixU
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
+rtr
 xsD
-ogl
+xsD
+xsD
 wSc
-wSc
+fQb
+xDb
+xDb
+xDb
+hSp
+hSz
+pBy
 cwz
 wSc
-wSc
-wSc
+kua
+rXC
+gZQ
 dBk
-sXq
-xgw
+pbh
 tQb
-xgw
-xgw
-xgw
+tQb
+wgb
+oLQ
 dBk
-xfi
-sfl
-xPu
-kCW
-lDe
-dBk
-xHW
-dBk
+aoj
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
 aoj
 aoj
+aoj
+aoj
+aoj
+aoj
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -86765,64 +86172,64 @@ eLE
 "}
 (213,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-bgZ
-xOz
-cPd
-xOz
-fXl
+bba
 xOz
 xOz
-gdz
+xOz
+wfJ
 sJp
 sJp
-kgd
+sJp
+sJp
+nQz
+ffy
 ffy
 bko
 sJp
-ood
-mXB
+rtr
+xsD
 xsD
 xsD
 wSc
+wSV
+xDb
+mXB
+xDb
+jco
+hSz
 prd
 wmL
-wmL
 wSc
+rkb
 rXC
-svr
-sXU
-xgw
+rkb
+vSy
+iXo
+tQb
+uDa
+iMu
+cqG
 dBk
-xgw
-xgw
-xgw
-cGk
-brY
-vep
-sfl
-jiR
-sfl
-dBk
-xHW
-dBk
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
-aoj
-aoj
-xVz
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
-aoj
-aoj
+vPg
+vPg
 aoj
 vPg
 vPg
@@ -87022,63 +86429,63 @@ eLE
 "}
 (214,1,1) = {"
 eLE
-dBk
-dBk
-dBk
-dBk
-dBk
-xHW
 ood
-dqz
-xOz
-cQz
-dgK
-fXl
+bcj
+tKv
 xOz
 xOz
-gAb
+uKV
 sJp
 sJp
 sJp
 sJp
-sJp
-sJp
+nQz
+ffy
+kvU
+iBC
+lxZ
 ood
-nct
+mJr
 xsD
-xsD
-wSc
-pub
-wmL
-wmL
+ogl
 wSc
 wSc
+wbN
+wSc
+wSc
+wSc
+wSc
+wSc
+wSc
+wSc
+rkb
+rXC
+rkb
 dBk
+qzL
+tQb
+tQb
+gtv
+iXo
 dBk
-dBk
-dBk
-uHZ
-uMU
-uHZ
-uHZ
-wSc
-wSc
-wSc
-wSc
-wSc
-dBk
-xHW
-dBk
+aoj
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
 vPg
 aoj
 aoj
-xVz
+vPg
+aoj
 vPg
 vPg
-vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 aoj
@@ -87279,60 +86686,60 @@ eLE
 "}
 (215,1,1) = {"
 eLE
-dBk
-ujt
-aaQ
-ujt
-dBk
+ood
+bgZ
+xOz
+cPd
+xOz
 rxg
-aVi
-bhg
-cGV
-cSe
-cGV
-shq
-cGV
-cGV
-aVi
-wKL
-jgt
-wKL
-bBA
+rSv
 sJp
+sJp
+sJp
+kgd
+ffy
+ffy
+bko
 sJp
 ood
-nib
+jgt
 xsD
 xsD
 wSc
-pyg
-wmL
-qTX
-xJp
-rZi
-naX
-sYW
-naX
-xJp
-xhj
-rXz
-rXz
-uHZ
-weW
-wSV
+jvI
+mnD
+jvI
 wSc
-ylk
-wWD
+wSc
+wSc
+wSc
+wSc
+wSc
+rkb
+rkb
+rkb
+cGk
+ade
+iXo
+iXo
+iXo
+iXo
 dBk
-xHW
-dBk
+aoj
 vPg
+vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
 aoj
 vPg
+aoj
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -87536,66 +86943,66 @@ eLE
 "}
 (216,1,1) = {"
 eLE
-dBk
-fQb
-fpe
-ujt
-qIB
+ood
+dqz
+xOz
+cQz
+dgK
 adZ
-ood
-ebT
-tKv
-xOz
-xOz
-xOz
-tKv
-xOz
-ood
-rSv
-jjA
-rSv
-cmM
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
 sJp
 sJp
 ood
-nly
+nct
 xsD
 xsD
 wSc
-pDM
-wmL
-wmL
+xhV
+mnD
+mnD
 xJp
-saB
-szc
-szc
-naX
 xJp
-xhj
-rXz
-rXz
+xJp
+xJp
+xJp
 uHZ
-lWW
-pTV
-wSc
-tBh
-pTV
-oAL
-hAk
+uHZ
+uMU
+uHZ
+uHZ
 dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
 vPg
 vPg
 aoj
+aoj
+aoj
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
-xVz
-xVz
 vPg
 vPg
+aoj
+aoj
 vPg
 vPg
 aoj
@@ -87793,53 +87200,46 @@ eLE
 "}
 (217,1,1) = {"
 eLE
-dBk
-ujt
-hXt
-ujt
-dBk
-xHW
 ood
-rSx
+uXj
 xOz
-xOz
-xOz
-xOz
-xOz
+ccJ
 xOz
 ood
+xje
+bRL
 rSv
-jlt
-rSv
+sJp
+sJp
+sJp
+sJp
+sJp
+sJp
 ood
-ood
-ood
-ood
-ood
-nEg
-ood
+nib
+xsD
+xsD
 wSc
-pHr
-wmL
-wmL
+mnD
+mnD
+xyn
 xJp
-enN
-cBa
-cBa
+rZi
 naX
-rni
-usM
+sYW
+naX
+uHZ
+xhj
 rXz
 rXz
 uHZ
-jiP
-wWD
-wSc
-jiP
-qdg
+rpS
+rni
 dBk
-xHW
+alI
+jmS
 dBk
+vPg
 vPg
 vPg
 vPg
@@ -87849,8 +87249,15 @@ aoj
 vPg
 vPg
 vPg
-xVz
-xVz
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -88050,57 +87457,57 @@ eLE
 "}
 (218,1,1) = {"
 eLE
-dBk
-dBk
-dBk
-dBk
-dBk
-agn
 ood
+ebT
+tKv
+xOz
+xOz
 ood
-oFo
+vtf
+jjA
+rSv
+sJp
+sJp
+sJp
+sJp
+sJp
+qgy
 ood
-djq
-gdz
-gAb
-gAb
-ood
-ryS
-ryS
-ryS
-ood
-kYn
-xlH
-kvw
-xlH
-xlH
-xlH
+nly
+xsD
+xsD
 wSc
-wSc
-wSc
-wSc
+xlH
+mnD
+aVi
 xJp
 sdy
 szc
 szc
 naX
-xJp
-uvR
+uHZ
+xhj
 rXz
 rXz
 uHZ
-ryt
-wZL
-wSc
-ryt
-wZL
+ioI
+hdP
 dBk
-xHW
-dBk
+cSe
+hdP
+oAL
+vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+aoj
 vPg
 aoj
 vPg
@@ -88307,56 +87714,45 @@ eLE
 "}
 (219,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-rxg
-aVi
-blV
-sJp
-sJp
-sJp
-sJp
-sJp
-sJp
 ood
-iyT
-jmE
-rIn
+rSx
+xOz
+xOz
+xOz
 ood
-aQb
-rnI
+rSv
+jlt
+rSv
+sJp
+cLG
+hXR
+ood
+ood
+ood
+ood
+ood
+nEg
+ood
+wSc
 mnD
-xlH
-ksU
-xlH
-ood
-pLA
-qin
-qXf
+mnD
+mnD
 xJp
-rZi
+enN
+cBa
+cBa
 naX
-naX
-naX
-xJp
-uxx
+uMU
+rXz
 rXz
 rXz
 uHZ
-pPj
-uqU
-tlr
-uqU
-uqU
+fSi
+jmS
 dBk
-xHW
+fSi
+djq
 dBk
-vPg
-vPg
-vPg
 vPg
 vPg
 aoj
@@ -88364,7 +87760,18 @@ vPg
 aoj
 vPg
 vPg
-xVz
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -88564,65 +87971,65 @@ eLE
 "}
 (220,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 ood
-nTG
-wtx
-syU
-dma
-wtx
-syU
-sJp
 ood
+oFo
+svr
+ood
+ood
+ood
+ood
+brY
+brY
+brY
+brY
+brY
+lYp
+jyZ
 iEm
-kFG
-rIn
-ood
+jyZ
+jyZ
+jyZ
 rvp
-xlH
-kAm
-xlH
-xhV
-xlH
-ood
-uKV
-heQ
-qfy
-pSn
-pSn
-pSn
-pSn
-tuI
-pSn
-cqG
+rvp
+rvp
+rvp
+xJp
+sdy
+szc
+szc
+naX
+uHZ
+usM
+rXz
+rXz
+uHZ
 uPp
 nIu
-vKz
-tJx
-tJx
-tJx
-ioI
-xDb
 dBk
-xHW
+uPp
+nIu
 dBk
+dBk
+dBk
+dBk
+dBk
+aoj
+vPg
 vPg
 vPg
 vPg
 vPg
 vPg
 aoj
+aoj
 vPg
 vPg
 vPg
-xVz
-xVz
-xVz
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -88821,64 +88228,64 @@ eLE
 "}
 (221,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bna
-wtx
-wtx
 sJp
-wtx
-wtx
 sJp
-ood
+sJp
+sJp
+sJp
+sJp
+sJp
+brY
+muq
+vjG
+wPR
+brY
+xRn
+jyZ
 iHF
-rIn
-rIn
-kwf
-xlH
-xlH
-xlH
-xlH
-xlH
-xlH
-ood
-uKV
-qfy
-qfy
-pSn
-sgf
-syd
-tgB
-ohZ
-aLM
-uBO
+jyZ
+fzc
+jyZ
+rvp
+mtc
+bfc
+mtc
+xJp
+rZi
+naX
+naX
+naX
+uHZ
+tgQ
 rXz
 rXz
 uHZ
-whQ
+vzq
+aLM
+avj
+aLM
+aLM
+dBk
+xtz
 xkI
 eYr
-bfc
-tJx
-qcK
-pbh
 dBk
 vPg
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
 aoj
 vPg
 vPg
 aoj
+vPg
 aoj
-xVz
+aoj
+vPg
 aoj
 aoj
 aoj
@@ -89078,63 +88485,63 @@ eLE
 "}
 (222,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xdk
 ood
-oho
+nTG
 wtx
 syU
-yix
+dma
 wtx
 syU
 sJp
-ood
+brY
+vKz
+osu
+wPR
+brY
+fIc
+jyZ
 rIn
-jte
-rIn
-kwf
-xlH
-xlH
-xlH
-xlH
-nIl
-xlH
-xgN
-xsD
-xsD
-avj
-pSn
-nYR
-bjx
-tgQ
-twI
-tQD
-rXz
-usM
-usM
+jyZ
+kYn
+jyZ
+rvp
+sXq
+xQh
+sXq
+xJp
+xJp
+xJp
+xJp
+tms
 uHZ
-wkf
+uvR
+nYR
+rXz
+uMU
+diE
+uBW
+uBW
+uBW
+diE
+dBk
 xtz
-xDb
-xDb
-xDb
+xtz
+blV
 dBk
-cYh
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
+vPg
 aoj
+vPg
+vPg
+vPg
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 aoj
 aoj
 aoj
@@ -89335,62 +88742,62 @@ eLE
 "}
 (223,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bxn
+bna
 wtx
+jiP
+sJp
+wtx
+jiP
+sJp
+brY
 daE
-sJp
-wtx
-wtx
-sJp
-ood
-iyT
-jvI
-rIn
-ood
-jOq
-xlH
+wPR
+wPR
+wPR
+jyZ
+jyZ
+jyZ
+jyZ
+jyZ
+jyZ
+rvp
 xQh
-xlH
-xhV
-xlH
-ood
-heQ
-xsD
-qXl
+xQh
+xQh
 pSn
-sio
-sBF
-tht
-twI
-uac
+sgf
+syd
+tgB
+ohZ
+qXl
+uBO
 rXz
-uvR
-usM
+rXz
 uHZ
-wlf
-ibx
-xDb
-xDb
-xDb
+wZL
+pnK
+uBW
+uBW
+diE
+gOq
+xtz
+xtz
+cdu
 dBk
-tBZ
-sAE
-sAE
-sAE
-sAE
-qCb
-sAE
-sAE
-sAE
-btc
-dBk
+vPg
+aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -89592,67 +88999,67 @@ eLE
 "}
 (224,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bEf
+oho
+wtx
+syU
+yix
 wtx
 syU
 sJp
-wtx
-syU
-sJp
-ood
-iEm
+brY
+wPR
+wPR
+wPR
+wPR
+jyZ
+jyZ
+jyZ
 jyZ
 bPo
-ood
+jyZ
 niz
 rnI
-mnU
-xlH
-xlH
-xlH
-ood
-vCQ
-qfy
-qYM
+rnI
+jmE
 pSn
-mcU
-bjx
-bjx
+lFa
+vCQ
+vCQ
 twI
-aLM
-diE
+qYM
 rXz
-uvR
+rXz
+rXz
 uHZ
-wlf
-xDb
-xDb
-wFv
+dAy
+mlH
+diE
+diE
+diE
+cmM
+xtz
+xtz
+xtz
 dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-xHW
-dBk
+vPg
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -89849,61 +89256,48 @@ eLE
 "}
 (225,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bLy
+bxn
 wtx
-cHu
+wtx
 sJp
 wtx
-cHu
+wtx
 sJp
-ood
-ryS
-ryS
-ryS
-ood
+brY
+muq
+wPR
+wPR
+brY
 kcz
-upY
-ooF
-qtk
-qtk
-qtk
-ood
-wMJ
-qfy
-wMJ
+jyZ
+ryS
+jyZ
+kYn
+jyZ
+rvp
+xQh
+rnI
+rnI
 pSn
-tGL
-uCu
-tms
-uCu
-ueZ
-uBW
-usM
-usM
+sio
+tht
+tht
+twI
+uMU
+rXz
+rXz
+rXz
 uHZ
-wSc
-wSc
+jMF
+uBW
+uBW
+uBW
+uBW
+uxz
+xtz
+qHb
 iYR
-wSc
-dBk
-wzU
-wzU
-wzU
-wzU
-mYG
-tPd
-xSE
-xSE
-xSE
-dBk
-hAk
 dBk
 vPg
 vPg
@@ -89911,6 +89305,19 @@ vPg
 vPg
 vPg
 vPg
+vPg
+aoj
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 aoj
 vPg
@@ -90106,69 +89513,69 @@ eLE
 "}
 (226,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bPG
-cHu
-syU
-dxC
+bEf
 wtx
 syU
 sJp
-ood
+wtx
+syU
+sJp
+brY
+vKz
+wPR
+wPR
+brY
+cGV
+jyZ
 iJU
-jEu
-kkd
-xNs
-ood
-ood
-ood
+jyZ
+jyZ
+jyZ
+rvp
+xta
+xQh
 ntK
-nRs
-nRs
-ood
-ood
-ood
-ood
+pSn
+mcU
+vCQ
+vCQ
+twI
+qXl
+uTy
+rXz
+rXz
+uHZ
+jMF
+uBW
+uBW
+usd
 dBk
 dBk
-dEr
-dBk
-dBk
-umZ
-oAL
 dBk
 dBk
 dBk
-paF
-umo
-umo
-umo
 dBk
-wzU
-wzU
-wzU
-lCL
-giA
-xSE
-xSE
-xSE
-xSE
 dBk
-xHW
+dBk
+dBk
+dBk
 dBk
 vPg
 vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
+vPg
+aoj
+aoj
+vPg
+aoj
+aoj
+aoj
 aoj
 aoj
 aoj
@@ -90363,69 +89770,69 @@ eLE
 "}
 (227,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xJM
 ood
-bRV
+bLy
+wtx
+syU
 sJp
+wtx
+syU
 sJp
-dBX
-yix
-yix
-sJp
-ood
+brY
+brY
+brY
+brY
+brY
+ilD
+qba
 dfN
 xRm
 xRm
-iab
-hTE
-ppR
-aYX
-bhW
-xOi
-iGC
-oJC
-wOf
-qmS
-xNs
-rnZ
-sjk
-umo
-sKx
-pZv
+xRm
+rvp
+hNG
+fvU
+hNG
+pSn
+tGL
+twI
+twI
+uCu
+oSB
+tAG
+rXz
+rXz
+uHZ
 dBk
-vLJ
-pzC
-vgC
 dBk
-wwB
-umo
-umo
-iJT
+xic
+dBk
 dBk
 wzU
 wzU
 wzU
 wzU
-sMz
+mYG
+tPd
+lPR
 xSE
-xSE
-xSE
-xSE
-dBk
-xHW
+lPR
 dBk
 vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -90620,67 +90027,67 @@ eLE
 "}
 (228,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-ajx
-xNs
-xNs
-xNs
-xNs
-xNs
-gkx
-gkx
-xNs
-xNs
-xNs
-xNs
-xNs
-xNs
-lyZ
-iRN
-uYB
-yey
-yey
-yey
-vYo
-wIR
-qpX
-xNs
-cka
-iXo
+ood
+bPG
+cHu
+syU
+dxC
+wtx
+syU
+sJp
+ood
+lHY
+tIR
+lHY
+brY
+brY
+brY
+brY
+uLI
+xgN
+xgN
+rvp
+rvp
+rvp
+rvp
+pSn
+pSn
+uac
+pSn
+pSn
+xfi
+jOL
+uHZ
+uHZ
+uHZ
+paF
 umo
-umo
-eec
-dBk
-vLJ
-pzC
-vjh
-rPB
-wwB
-iXo
 umo
 umo
 dBk
 wzU
 wzU
 wzU
-wzU
-mYG
-gDU
+lCL
+giA
+xSE
 xSE
 xSE
 xSE
 dBk
-xHW
-dBk
 vPg
 vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -90877,67 +90284,54 @@ eLE
 "}
 (229,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-lgH
-pix
-mlH
-wVg
-yey
-dCK
-wVg
-yey
-dCK
-wVg
-wVg
-yey
-lif
-exp
-vos
-iRN
-uYB
-qpl
-qpl
-ejZ
-vYo
-wIR
+ood
+bRV
+sJp
+sJp
+dBX
+yix
+yix
+sJp
+ood
+lHY
+lHY
+lHY
+iab
+hTE
+ppR
+aYX
+bhW
+xOi
+iGC
+oJC
 wOf
+qmS
 xNs
-rpZ
-iXo
-iXo
+rnZ
+sjk
 umo
-tyx
+sKx
+pZv
 dBk
 vLJ
 pzC
-vrx
-uYR
+vgC
+dBk
 wwB
 umo
-umo
-umo
+mMb
+iJT
 dBk
 wzU
 wzU
 wzU
 wzU
-giA
-ykY
+sMz
+xSE
 xSE
 xSE
 xSE
 dBk
-xHW
-dBk
-vPg
-vPg
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -90945,6 +90339,19 @@ vPg
 vPg
 vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -91134,65 +90541,54 @@ eLE
 "}
 (230,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-bTv
-yey
-yey
-ekG
-yey
-gBR
-cTR
-cTR
-iOu
-yey
-kom
-rZy
-jZo
+xNs
+xNs
+xNs
+xNs
+gkx
+gkx
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
+lyZ
 iRN
 uYB
-qpl
-qpl
 yey
-wOf
-wIR
+yey
+yey
 vYo
+wIR
+qpX
 xNs
-rvG
+cka
 iXo
 umo
-iXo
-vSj
+umo
+eec
 dBk
 vLJ
 pzC
-pzC
-vMG
-wmf
+vjh
+rPB
+wwB
 iXo
-xRK
+umo
 umo
 dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
+wzU
+wzU
+wzU
+wzU
+mYG
+gDU
 xSE
 xSE
 xSE
 dBk
-xHW
-dBk
-vPg
-vPg
-vPg
 vPg
 vPg
 vPg
@@ -91201,7 +90597,18 @@ vPg
 vPg
 aoj
 vPg
+vPg
+vPg
+vPg
 aoj
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -91391,74 +90798,74 @@ eLE
 "}
 (231,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-bUV
-lgL
+wVg
+wVg
 yey
-epz
-qFd
-gOq
-aFh
-ify
-wKI
+dCK
+wVg
 yey
-xNs
-kyx
-oEt
+dCK
+wVg
+wVg
+yey
+lif
+exp
+vos
+iRN
 uYB
-uYB
-yey
-yey
-yey
-wIR
-wIR
+qpl
+qpl
+ejZ
 vYo
+wIR
+wOf
 xNs
-ouT
-iXo
-iXo
-iXo
-mkj
-dBk
-dBk
-dBk
-dBk
-dBk
-wnT
+rpZ
 iXo
 iXo
 umo
+tyx
 dBk
-xBz
-xBz
-qXr
-xBz
-xBz
+vLJ
+pzC
+vrx
+uYR
+wwB
+umo
+umo
+umo
 dBk
+wzU
+wzU
+wzU
+wzU
+giA
+ykY
 xSE
 xSE
 xSE
 dBk
-cYh
-dBk
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 xVz
 xVz
 xVz
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -91648,73 +91055,73 @@ eLE
 "}
 (232,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-dlr
+bTv
 yey
 yey
-lVf
+ekG
 yey
-otW
-hpZ
-xSa
-wKI
+gBR
+cTR
+cTR
+iOu
 yey
-krT
-qow
-xIu
-vIW
-vIW
-vIW
-xIu
-vIW
-vIW
-vIW
-vIW
-vIW
-nlz
-xnL
-xrV
-xnL
-xrV
-xrV
-qOQ
-qOQ
-qOQ
-xrV
-kbw
-xrV
-egU
-xnL
-ofv
-nlz
-reI
-reI
-reI
-reI
-caD
-xSE
-xSE
-xSE
+kom
+rZy
+jZo
+iRN
+uYB
+qpl
+qpl
+yey
+wOf
+wIR
+vYo
+xNs
+rvG
+iXo
+umo
+iXo
+vSj
 dBk
-xHW
+vLJ
+pzC
+pzC
+vMG
+wmf
+iXo
+xRK
+umo
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+lPR
+xSE
+lPR
 dBk
 vPg
 vPg
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 dsC
 nFw
 xVz
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 vPg
 aoj
 vPg
@@ -91905,73 +91312,73 @@ eLE
 "}
 (233,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-wOM
-yey
-yey
-yey
-yey
-otW
-xSa
-xSa
+bUV
+lgL
+nbm
+epz
+qFd
+wNy
+aFh
+ify
 wKI
-wVg
 yey
-qow
-xIu
-xIu
-vIW
-vIW
-xIu
-xIu
-vIW
-vIW
-vIW
-vIW
-qOQ
-xrV
-wgK
-xnL
-xrV
-xrV
-kbw
-kbw
-qOQ
-xrV
-kbw
-egU
-xrV
-wgK
-ofv
-nlz
-reI
-reI
-reI
-reI
-caD
+xNs
+kyx
+oEt
+uYB
+uYB
+yey
+yey
+yey
+wIR
+wIR
+vYo
+xNs
+wIU
+iXo
+iXo
+iXo
+mkj
+dBk
+dBk
+dBk
+dBk
+dBk
+wnT
+iXo
+iXo
+umo
+dBk
+xBz
+xBz
+qXr
+xBz
+xBz
+dBk
 xSE
 xSE
 xSE
 dBk
-xHW
-dBk
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 pxU
 xVz
 xVz
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 vPg
 aoj
 vPg
@@ -92162,49 +91569,43 @@ eLE
 "}
 (234,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-fXL
 xNs
-bVG
-wVg
-yey
-eyH
-yey
-otW
-hsX
-xAe
+dlr
+fXL
+nbm
+lVf
+fXL
+gse
+hpZ
+xSa
 wKI
-wVg
 yey
-nUu
-xIu
-xIu
-vIW
-vIW
-vIW
+krT
+qow
 xIu
 vIW
 vIW
 vIW
+xIu
 vIW
-qOQ
-xrV
-xrV
-xrV
+vIW
+vIW
+vIW
+vIW
+nlz
+xnL
 xrV
 xnL
-qOQ
-qOQ
-nlz
+xrV
 xrV
 qOQ
-egU
-egU
+qOQ
+qOQ
 xrV
+kbw
+xrV
+egU
+xnL
 ofv
 nlz
 reI
@@ -92216,13 +91617,13 @@ xSE
 xSE
 xSE
 dBk
-xHW
-dBk
 vPg
 vPg
 vPg
 vPg
-vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -92230,6 +91631,12 @@ lVx
 xVz
 xVz
 aoj
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -92419,62 +91826,56 @@ eLE
 "}
 (235,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-bZT
-cLU
+wOM
+fXL
+nbm
 yey
-eAG
-tFu
-otW
-dOH
+fXL
+gse
+xSa
 xSa
 wKI
+wVg
 yey
-xNs
-kMi
-lBn
-wgc
-wIR
-yey
-yey
-yey
-wOf
-wIR
-wIR
-xNs
-uUH
-iXo
-iXo
-umo
-gOV
-dBk
-dBk
-dBk
-dBk
-dBk
-wpj
-iXo
-iXo
-iXo
-dBk
-dBk
-aNt
-rpV
-wvR
-muq
-dBk
-vFu
+qow
+xIu
+xIu
+ipB
+vIW
+xIu
+xIu
+ipB
+vIW
+vIW
+vIW
+qOQ
+xrV
+ulh
+xnL
+xrV
+xrV
+kbw
+kbw
+qOQ
+xrV
+kbw
+egU
+qtk
+wgK
+ofv
+nlz
+reI
+reI
+reI
+reI
+caD
 xSE
 xSE
+xSE
 dBk
-xHW
-dBk
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -92487,6 +91888,12 @@ xVz
 xVz
 vPg
 aoj
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
 aoj
 vPg
 vPg
@@ -92502,8 +91909,8 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 aoj
@@ -92676,62 +92083,56 @@ eLE
 "}
 (236,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
 xNs
-caK
+bVG
+obi
+nbm
+eyH
+fXL
+gse
+hsX
+xAe
+wKI
+wVg
 yey
-yey
-eEh
-yey
-xMi
-huC
-huC
-iRl
-yey
-lif
-kXa
-ygy
-gwI
-wIR
-yey
-qpl
-qpl
-fes
-beW
-vYo
-xNs
-rpZ
-iXo
-iXo
-umo
-pZv
-dBk
-bHg
-rTW
-bRa
-vMG
-wmf
-iXo
-umo
-iXo
-dBk
-iBC
-rrh
-rrh
-eLx
-rrh
-sAw
+nUu
+xIu
+xIu
+vIW
+vIW
+vIW
+xIu
+vIW
+vIW
+vIW
+vIW
+qOQ
+xrV
+xrV
+xrV
+xrV
+xnL
+qOQ
+qOQ
+nlz
+xrV
+qOQ
+egU
+egU
+xrV
+ofv
+nlz
+reI
+reI
+reI
+reI
+caD
 xSE
 xSE
 xSE
 dBk
-xHW
-dBk
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -92747,6 +92148,12 @@ vPg
 vPg
 vPg
 vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -92759,7 +92166,7 @@ vPg
 aoj
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -92933,62 +92340,56 @@ eLE
 "}
 (237,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-tSE
-ceF
-cMe
-yey
-eJv
-yey
-wVg
-eJv
-wVg
-wVg
-yey
-kom
-xBr
-gFj
-wIR
-wIR
-qpl
-qpl
-yey
-vYo
-fes
-vYo
 xNs
-rpZ
+bZT
+cLU
+nbm
+eAG
+tFu
+gse
+dOH
+xSa
+wKI
+yey
+xNs
+kMi
+lBn
+wgc
+wIR
+yey
+yey
+yey
+wOf
+wIR
+wIR
+xNs
+uHu
 iXo
 iXo
 umo
-pZv
+gOV
 dBk
-uJC
-uVg
-pzC
-rPB
-wwB
-umo
-umo
-umo
-sBM
-nlz
-rrh
-rrh
-rrh
-rrh
+dBk
+dBk
+dBk
+dBk
+wpj
+iXo
+iXo
+iXo
+dBk
+dBk
 wvR
-xSE
-xSE
-xSE
+wvR
+wvR
+wvR
 dBk
-hAk
+kAm
+xSE
+lPR
 dBk
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -93003,6 +92404,12 @@ vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
 vPg
 vPg
@@ -93015,8 +92422,8 @@ vPg
 aoj
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -93190,62 +92597,56 @@ eLE
 "}
 (238,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-alI
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-ija
-yeD
-yeD
 xNs
-xNs
-lFT
-lTu
+caK
+yey
+yey
+sXU
+yey
+xMi
+huC
+huC
+iRl
+yey
+lif
+kXa
+ygy
+gwI
 wIR
 yey
-wVg
-yey
-vYo
-wOf
+qpl
+qpl
+fes
+beW
 vYo
 xNs
 rpZ
 iXo
-umo
+iXo
 umo
 pZv
 dBk
+bHg
 rTW
-pzC
-pzC
-uYR
-wwB
+bRa
+vMG
+wmf
+iXo
 umo
-umo
-umo
+iXo
 dBk
-bRw
-tkA
-vjG
-gWQ
-ePA
-wvR
+bXJ
+rrh
+rrh
+eLx
+rrh
+sAw
 xSE
 xSE
-xSE
+udC
 dBk
-xHW
-dBk
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -93256,6 +92657,12 @@ vPg
 xVz
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -93447,62 +92854,56 @@ eLE
 "}
 (239,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-uhC
-hdP
-vAk
-vAk
-vAk
-cdu
-yeD
-uHu
-vAk
-vAk
-yeD
-kua
-iab
-uYx
-lUf
-cUm
+tSE
+ceF
+cMe
+yey
+eJv
+yey
+wVg
+eJv
 wVg
 wVg
-wVg
-oKY
-pMw
+yey
+kom
+xBr
+gFj
+wIR
+wIR
+qpl
+qpl
+yey
+vYo
+fes
 vYo
 xNs
-ryf
-yhF
+rpZ
+iXo
+iXo
 umo
-too
 pZv
 dBk
-uKm
+uJC
+uVg
 pzC
-vxT
-dBk
+rPB
 wwB
 umo
 umo
-iXo
-dBk
-dBk
-dBk
+umo
+sBM
+nlz
+rrh
+rrh
+rrh
+rrh
+wvR
+xSE
+xSE
 udC
 dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-xHW
-dBk
+vPg
+vPg
 vPg
 vPg
 xVz
@@ -93515,6 +92916,12 @@ vPg
 aoj
 vPg
 vPg
+vPg
+vPg
+vPg
+aoj
+vPg
+aoj
 aoj
 vPg
 vPg
@@ -93704,74 +93111,74 @@ eLE
 "}
 (240,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
+lmc
+xNs
+xNs
+xNs
+xNs
+lFT
+lTu
+wIR
+yey
+wVg
+yey
+vYo
+wOf
+vYo
+xNs
+rpZ
+iXo
+umo
+umo
+pZv
 dBk
-lYp
-yeD
-xGx
-vAk
-jkw
-vAk
-vAk
-yeD
-hQs
-vAk
-vAk
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-nVz
-yeD
-yeD
-yeD
-yeD
-yeD
+rTW
+pzC
+pzC
+uYR
+wwB
+umo
+umo
+umo
 dBk
-dBk
-sBM
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-pRf
+otW
+tkA
 xuw
-iXo
-iXo
-dBk
+gWQ
+ePA
+wvR
 lPR
-tLv
-tBZ
-sAE
-sAE
-sAE
-sAE
-dcE
-sAE
-sAE
-fce
+xSE
+obT
 dBk
 vPg
-xVz
-xVz
-xVz
-xVz
 vPg
+vPg
+xVz
+xVz
+xVz
+xVz
+lVx
 vPg
 vPg
 vPg
 aoj
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+aoj
+aoj
 aoj
 vPg
 vPg
@@ -93961,51 +93368,43 @@ eLE
 "}
 (241,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+pjo
+agx
+agx
+lgH
+agx
 xHW
-yeD
+pjo
 dxN
-xje
-rYD
-gCM
-vAk
-gPu
-vAk
 vAk
 vAk
 yeD
-iWZ
-sEB
-pWh
-sEB
-iWZ
-pWh
-iWZ
-iWZ
-pWh
-iWZ
-iWZ
 yeD
-rAj
-vKK
-vKK
-tDk
-qMn
-bAm
+iab
+uYx
+lUf
+cUm
+wVg
+wVg
+wVg
+oKY
+pMw
+vYo
+xNs
+ryf
+yhF
+umo
+too
+pZv
+dBk
+uKm
+pzC
+vxT
+dBk
+wwB
+umo
 mMb
-paO
-vyt
-wej
-wej
-hhe
-xWB
-wej
-wej
-wej
+iXo
 dBk
 dBk
 dBk
@@ -94017,6 +93416,8 @@ dBk
 dBk
 dBk
 dBk
+vPg
+vPg
 vPg
 xVz
 xVz
@@ -94029,6 +93430,12 @@ vPg
 vPg
 vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -94218,74 +93625,74 @@ eLE
 "}
 (242,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
+pjo
+qKB
+gdz
+lgH
+lgH
+agx
 pjo
 vAk
 vAk
-rYD
-vAk
 vAk
 yeD
-hSp
-vAk
-vAk
-xQo
-iWZ
-sEB
-iWZ
-sEB
-iWZ
-iWZ
-iWZ
-iWZ
-ibg
-ibg
-rbr
 yeD
-rAz
-vKK
-vKK
+yeD
+yeD
+yeD
+yeD
+yeD
+nVz
+yeD
+yeD
+yeD
+yeD
+yeD
+dBk
+dBk
+sBM
 dBk
 dBk
 dBk
-nbm
-xns
-vzq
-wej
-mlz
-xyn
-uXj
-jMF
-uXj
-wej
-uDa
-cQN
+dBk
+dBk
+dBk
+dBk
+pRf
+umo
+iXo
+iXo
+dBk
+dBk
+vPg
+ggZ
+ggZ
+ggZ
+ggZ
+ggZ
+ggZ
+ggZ
+ggZ
+aoj
+aoj
+xVz
+xVz
+vPg
+vPg
+xVz
+xVz
+xVz
+upG
+vPg
+xVz
+vPg
+aoj
 vPg
 vPg
 vPg
 vPg
 aoj
-aoj
 vPg
-aoj
-aoj
-xVz
-xVz
-vPg
-vPg
-xVz
-xVz
-xVz
-vPg
-vPg
-xVz
-vPg
-aoj
 vPg
 vPg
 vPg
@@ -94475,74 +93882,74 @@ eLE
 "}
 (243,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+pjo
+xfJ
+xcW
+tKY
+lgH
 lgH
 aWQ
-cfu
 vAk
 vAk
 vAk
-cdu
 yeD
-tAG
-ilD
-iUi
-yeD
-iWZ
-iWZ
 iWZ
 sEB
-iWZ
+pWh
 sEB
 iWZ
+pWh
 iWZ
-oMA
+iWZ
+pWh
 iWZ
 iWZ
 yeD
-rFC
-sok
+rAj
+vKK
 vKK
 tDk
 qMn
+bAm
+tlr
+wMJ
+iVj
 dBk
-uLI
-xns
-xns
-wbN
-wAU
+dBk
+dBk
+sBM
+dBk
+dBk
+dBk
 xPm
-hXe
-gcj
-dAy
-wej
-cUh
-xVz
-xVz
-vPg
+xPm
 vPg
 vPg
 aoj
 aoj
 vPg
+vPg
+vPg
 aoj
 aoj
 xVz
 vPg
-vPg
-vPg
+lVx
+lVx
 xVz
 xVz
 xVz
-vPg
+lVx
 xVz
 xVz
 vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -94732,64 +94139,58 @@ eLE
 "}
 (244,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+tuI
+qKB
+xcW
+lgH
+lgH
 agx
-yeD
-yeD
-uTy
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
+pjo
+fUs
+vAk
+vAk
+xQo
+iWZ
+sEB
 iWZ
 sEB
 iWZ
 iWZ
 iWZ
-sEB
 iWZ
-iWZ
-oNT
-pOW
-iWZ
+ibg
+ibg
+rbr
 yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-wej
+rAz
+vKK
+vKK
+dBk
+dBk
+dBk
+jkw
+sBZ
+qRb
+dBk
+agn
+iXo
+iXo
+iXo
+qBI
+dBk
 wGn
-uXj
-uYY
-xyn
-uXj
-wej
-pnO
-xVz
-xVz
-xVz
+xPm
+xPm
 vPg
 vPg
+aoj
 aoj
 aoj
 vPg
 aoj
 aoj
 vPg
-vPg
+lVx
 xVz
 xVz
 gdl
@@ -94798,6 +94199,12 @@ xVz
 xVz
 xVz
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -94989,60 +94396,54 @@ eLE
 "}
 (245,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+pjo
+agx
+agx
+lgH
+agx
 xHW
-yeD
+pjo
 cgC
 gak
+pnO
 yeD
-eMo
-xYt
-gRd
-xYt
-yei
-yeD
-jJl
 iWZ
-sEB
+iWZ
 iWZ
 sEB
 iWZ
 sEB
 iWZ
 iWZ
-oSi
+oMA
 iWZ
-qyf
+iWZ
 yeD
-rJc
-gak
+rFC
+sok
+vKK
+tDk
+qMn
+dBk
+heQ
 sBZ
+sBZ
+tLv
 hgp
-hgp
-gak
-oLQ
-vbt
+iXo
+iXo
+iXo
 vHE
-wej
+dBk
 gsv
-uXj
-yiX
-xyn
-uXj
-xWB
-miS
-xVz
-xVz
-xVz
-xVz
+xPm
+xPm
+xPm
 vPg
 aoj
 aoj
-vPg
+aoj
+lVx
 xVz
 xVz
 xVz
@@ -95057,6 +94458,12 @@ vPg
 vPg
 vPg
 vPg
+aoj
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 aoj
@@ -95246,60 +94653,54 @@ eLE
 "}
 (246,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
+pjo
+pjo
+bCe
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+yeD
+iWZ
+sEB
+iWZ
+iWZ
+iWZ
+sEB
+iWZ
+iWZ
+oNT
+pOW
+iWZ
+yeD
 dBk
-fXL
-yeD
-izR
-gak
-yeD
-fSi
-xYt
-xYt
-xYt
-xYt
-yeD
-alQ
-iWZ
-sEB
-iWZ
-sEB
-iWZ
-iWZ
-iWZ
-iWZ
-kCd
-ibg
-akC
-qZB
-rKX
-gak
-pYB
-pYB
-pYB
-gak
-xCH
-jco
-xgK
-wej
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+dBk
+sBF
+iXo
+ksU
+iXo
+iXo
+dBk
 wHH
-uXj
-xev
-xyn
-uXj
-wej
-dcO
+xPm
+xPm
+xPm
+xPm
 xVz
 xVz
 xVz
 xVz
-vPg
-vPg
-vPg
-lVx
 xVz
 xVz
 xVz
@@ -95312,6 +94713,12 @@ xVz
 xVz
 xVz
 xVz
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -95503,60 +94910,54 @@ eLE
 "}
 (247,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
+pjo
+wtE
+vbt
+pjo
+odD
+cOc
+whQ
+cOc
+aZm
+pjo
+jJl
+iWZ
+sEB
+iWZ
+xYt
+iWZ
+sEB
+iWZ
+iWZ
+oSi
+iWZ
+qyf
+yeD
+lMH
+tQb
+weW
+pPd
+pPd
+tQb
+ija
+saB
+qUq
 dBk
-xHW
-yeD
-cAf
-gak
-yeD
-ePO
-xYt
-uxz
-xYt
-xYt
-yeD
-xsn
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yeD
-xsn
-xsn
-xsn
-xsn
-xsn
-xsn
+pix
+iXo
 ojv
-jco
-wgb
-wej
-fUs
-uXj
-uXj
-pBy
-uXj
-wej
-ipB
+iXo
+iXo
+sBM
+nlz
+xPm
+xPm
+xPm
+xPm
 xVz
 xVz
 xVz
 xVz
-xVz
-vPg
-vPg
-lVx
 xVz
 vNs
 uHB
@@ -95571,11 +94972,17 @@ xVz
 xVz
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
+aoj
+vPg
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -95760,60 +95167,54 @@ eLE
 "}
 (248,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-yeD
-yeD
-yeD
-yeD
+pjo
+sfl
+vbt
+pjo
+iTZ
+mHl
+mHl
+mHl
+cOc
+pjo
 eSu
-gkX
-vhk
-hSz
-xYt
-iVj
-xsn
+iWZ
+sEB
+iWZ
+sEB
+iWZ
+iWZ
+iWZ
+iWZ
+kCd
+ibg
+akC
+qZB
 yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-yaZ
-xsn
-xsn
-yaZ
-raa
-xsn
-xsn
-xsn
-xsn
-xsn
-xsn
+tQb
+wSi
+wSi
+wSi
+tQb
+gqM
+jiR
+qhj
+dBk
+shq
+iXo
 ols
-qBI
-vAk
-wej
+iXo
+iXo
+dBk
 daD
-wej
-vkg
-hhe
-kni
-wej
-jcm
+xPm
+xPm
+xPm
+xPm
 xVz
 xVz
-xVz
-xVz
-xVz
-vPg
-vPg
-vPg
+lVx
+lVx
 xVz
 gHj
 eSL
@@ -95828,9 +95229,15 @@ jNu
 jNu
 vPg
 vPg
+aoj
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -96017,57 +95424,51 @@ eLE
 "}
 (249,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-yeD
+pjo
+lvK
+vbt
+pjo
+xev
 mHl
-gZQ
-uTy
-xYt
-xYt
-haJ
-xYt
-xYt
+wlf
+mHl
+cOc
+pjo
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
 yeD
-xsn
-xsn
-yaZ
-yaZ
-yaZ
-xsn
-xFY
-yaZ
-yaZ
-oSB
-xsn
-yaZ
-yeD
-xsn
-xsn
-xsn
-xsn
-xsn
-xsn
-xic
+svf
+svf
+svf
+svf
+svf
+svf
+paO
+jiR
+ooF
+dBk
+hhe
+iXo
+iXo
 vdx
-wPR
-wej
+iXo
+dBk
 qHL
-faB
-bCe
-bRL
-faB
-wej
-vPg
-vPg
-xVz
-xVz
-xVz
-xVz
+xPm
+xPm
+xPm
+xPm
+xPm
 vPg
 vPg
 vPg
@@ -96091,13 +95492,19 @@ vPg
 vPg
 vPg
 vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 aoj
 aoj
 vPg
-vPg
-vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -96274,57 +95681,51 @@ eLE
 "}
 (250,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+pjo
+pjo
+pjo
+pjo
+fbn
 aOU
-yeD
+qIB
 cgP
 cOc
-yeD
-fbn
-xYt
-xYt
-hTd
-xYt
-yeD
-jLd
-usd
-usd
-wKj
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
+ool
+xsn
+xsn
+ylk
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+ylk
+xsn
+xsn
+raa
+svf
+svf
+svf
+svf
+svf
+svf
 rNh
-gak
-hgp
-hgp
-hgp
-gak
+qXf
+iXo
+dBk
+qQa
+dBk
 xCH
-vdx
+dBk
 xgK
+dBk
 wej
-wej
-wej
-wej
-hhe
-wej
-wej
-vPg
-vPg
-xVz
-xVz
-xVz
-xVz
+xPm
+xPm
+xPm
+xPm
+xPm
 vPg
 vPg
 vPg
@@ -96352,8 +95753,14 @@ vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -96531,57 +95938,51 @@ eLE
 "}
 (251,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-xHW
-uhC
-ulh
-gZQ
-yeD
+pjo
+fnq
 feI
-jOL
-yei
-xYt
-yei
+bCe
+cOc
+mHl
+uhC
+mHl
+cOc
+pjo
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
+xsn
 yeD
-jLd
-usd
-kHm
-lHt
-yeD
-mpu
-iTZ
-iTZ
-yeD
-oZG
 svf
-xuo
-yeD
+svf
+svf
+svf
+svf
+svf
 rJc
-gak
+stk
 rhb
+dBk
 pYB
-pYB
-upG
+dtG
 fYO
 dtG
-dzf
-dBk
-xta
-sAE
-sAE
-fce
+dtG
 dBk
 vPg
 vPg
-vPg
-xVz
-xVz
-xVz
-xmm
+xPm
+xPm
+xPm
+xPm
 vPg
 vPg
 vPg
@@ -96601,16 +96002,22 @@ vPg
 vPg
 vPg
 vPg
+aoj
+aoj
+vPg
+vPg
+vPg
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -96788,60 +96195,54 @@ eLE
 "}
 (252,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-sZz
-yeD
-yeD
-yeD
-yeD
-fnq
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-yeD
-fnq
-yeD
-yeD
+pjo
+lgG
+mnU
+pjo
+cOc
+mHl
+mHl
+oyL
+cOc
+pjo
+jLd
 mpK
 mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+mpK
+yeD
 nWH
-yeD
-yeD
+tQb
 pPd
-yeD
-yeD
-yeD
+pPd
+pPd
+tQb
+gqM
 stk
-yeD
-yeD
-yeD
-fnq
-yeD
-yeD
-yeD
+qhj
 dBk
-wIU
+dBk
+dBk
 dBk
 dBk
 dBk
 dBk
 vPg
 vPg
-xmm
-xVz
-xVz
-frt
-xmm
+xPm
+xPm
+xPm
+xPm
 vPg
 vPg
-xVz
+vPg
 xVz
 xkJ
 xkJ
@@ -96856,15 +96257,21 @@ jNu
 jNu
 vPg
 vPg
+aoj
+aoj
 vPg
 vPg
 vPg
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
+aoj
+aoj
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -97045,60 +96452,54 @@ eLE
 "}
 (253,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
+frt
+xGx
+feI
+pjo
+iTZ
 tBZ
 aZm
+cOc
+aZm
+pjo
+jLd
+mpK
 sAE
-sAE
-sAE
-fvU
-sAE
-sAE
-hXR
-sAE
-sAE
+lHt
+wKj
+mpK
 kaE
 sAE
 kZo
-sAE
-sAE
-sAE
-nwf
-sAE
-sAE
-sAE
-sAE
-sAE
-kaE
-sAE
-sAE
-sAE
-sAE
-sAE
-urw
-sAE
-sAE
-sAE
-sAE
-fce
+eMo
+mpK
+mpK
+yeD
+lMH
+tQb
+bjx
+wSi
+wSi
+tQb
+sQa
+uUH
+jte
 dBk
 vPg
 vPg
 vPg
 vPg
 vPg
-xmm
-wtE
-xVz
-xVz
-xmm
 vPg
 vPg
-xVz
+vPg
+xPm
+xPm
+xPm
+mpu
+vPg
+vPg
+vPg
 fha
 xkJ
 xkJ
@@ -97116,6 +96517,12 @@ vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+aoj
+vPg
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -97302,37 +96709,29 @@ eLE
 "}
 (254,1,1) = {"
 eLE
-vPg
-vPg
-vPg
-vPg
-dBk
-dBk
-iqo
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
-dBk
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+pjo
+yeD
+yeD
+yeD
+yeD
+yeD
+yeD
+yeD
+yeD
+yeD
+yeD
+mmf
+yeD
+yeD
 dBk
 dBk
 dBk
@@ -97348,14 +96747,16 @@ vPg
 vPg
 vPg
 vPg
-xmm
+vPg
+vPg
+mpu
+xPm
+xPm
+odd
+mpu
+vPg
+vPg
 xVz
-xVz
-xVz
-xmm
-vPg
-vPg
-xcW
 trC
 xVz
 xkJ
@@ -97373,6 +96774,12 @@ vPg
 vPg
 vPg
 vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -97599,17 +97006,11 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-xmm
-gtS
-gtS
-gtS
-xmm
+mpu
+ajx
+ajx
+ajx
+mpu
 eLE
 eLE
 eLE
@@ -97622,6 +97023,12 @@ eLE
 eLE
 eLE
 eLE
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 vPg


### PR DESCRIPTION
## About The Pull Request
Unfucks a lot of things weezer did for BoS bunker... also I guess fixes enclave's base problem since they can't get into medical, LOL.

Changes this:
![image](https://user-images.githubusercontent.com/13832819/179084699-f15e5b53-be0c-46b9-a34b-b14d36de9025.png)
Into This:
![image](https://user-images.githubusercontent.com/13832819/179084770-d0034654-a031-4e9b-a9f8-0d14181881d4.png)

A lot of things when Weezer did the BoS rework were done... the opposite of what we asked.
We requested mainly for bigger armoury, less claustrophobic stuff and a chem smartfridge in chemistry... instead we got this
![image](https://user-images.githubusercontent.com/13832819/179085008-9879f1cc-a41f-4608-9377-1f431bd6ab08.png)
Now it's this:
![image](https://user-images.githubusercontent.com/13832819/179085108-57bdf717-3de1-42d2-bbde-c3347d9760a2.png)

Few rooms were also changed like Messhall and PA/Paladins places changed from this
![image](https://user-images.githubusercontent.com/13832819/179085325-cf6320c9-2df4-4314-9142-4cc3518abcc8.png)
To this:
![image](https://user-images.githubusercontent.com/13832819/179085351-f1b3545b-a0cb-469b-b081-4b2497bd522b.png)

Room under the forge turning from Scribes ERP dungeon
![chrome_STIgrJHNze](https://user-images.githubusercontent.com/13832819/179085573-6f1751ec-9e50-40c9-a572-56bde8cf4bd7.png)
into like generic dorms anyone can sleep in,
![StrongDMM_OOlCtdFab1](https://user-images.githubusercontent.com/13832819/179085587-124f6fb1-5f0d-4e03-9f98-d4300196a91e.png)

HK office and Brig also got a small update:
![chrome_Yzm43YnjQW](https://user-images.githubusercontent.com/13832819/179085730-db2b3588-2f35-46f4-a3bc-1a94be37368a.png)
Also the HK bedroom is next to it instead of like on the other side of the bunker
![StrongDMM_2IdBeRFoSD](https://user-images.githubusercontent.com/13832819/179085770-14da1c19-4632-4312-9f48-32076a2013f3.png)

Removed the entire disposal and maintenance system, put all the strange objects in one place instead of you know, 4 hidden walls inside maintenance. 
Also added a senior scribe spawn since he forgot about it 

ALSO Changed the codex from being super "stay in the bunker and ERP" doctrine into "Go out and assist the wasters" one, still energy weapons bad for wasters, take them away.

![image](https://user-images.githubusercontent.com/13832819/179086086-b200430e-7a13-4f02-81e7-ebc7d43a7c41.png)
ah and for enclave base they get access to medical without needing to destroy an entire wall


## Why It's Good For The Game

Brotherhood of Steel players on discord complained a lot during mapping and without consulting us Weezer just pushed the merge, changed the codex into something most BoS players didn't agree with and generally after first batch of feedback came in after the merge he threw a fit at us calling us redditors so here's the change with the previous consult of BoS players.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: BoS bunker should be a bit more playable
fix: Enclave can enter their medical departament
/:cl: