### PR TITLE
something about mall's aer9

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -34011,8 +34011,8 @@
 	pixel_x = 16
 	},
 /obj/structure/closet/cardboard,
-/obj/item/gun/energy/laser/aer9,
-/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/gun/energy/laser/pistol,
+/obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building)
 "pIQ" = (


### PR DESCRIPTION
## About The Pull Request
![StrongDMM_A6ZieBSIeC](https://user-images.githubusercontent.com/13832819/179351115-6fdff0bc-598d-464b-a6cc-89558a54d443.png)
Replaces the AER9 static spawn with AEP7

## Why It's Good For The Game

AER9 is a good weapon now and not a joke so having it be a static spawn in a place even a naked person can walk in and get it is not a really good design, judging how laser weapons are now one of the better types after Raptor's balance

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
balance: Mall gets AEP7 instead of AER9
/:cl:
