### PR TITLE
Remove CQC Knockour Kick

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -52,7 +52,7 @@
 		D.DefaultCombatKnockdown(120)
 		log_combat(A, D, "slammed (CQC)")
 	return TRUE
-
+/*
 /datum/martial_art/cqc/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
@@ -77,7 +77,7 @@
 		D.throw_at(throw_target, 1, 14, A)
 		log_combat(A, D, "kicked (CQC)")
 	return TRUE
-
+*/
 /datum/martial_art/cqc/proc/Pressure(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -178,7 +178,6 @@
 	to_chat(usr, "<b><i>You try to remember some of the basics of CQC.</i></b>")
 
 	to_chat(usr, "<span class='notice'>Slam</span>: Disarm Harm. Slam opponent into the ground, knocking them down.")
-	to_chat(usr, "<span class='notice'>CQC Kick</span>: Harm Harm. Knocks opponent away. Knocks out stunned or knocked down opponents.")
 	to_chat(usr, "<span class='notice'>Restrain</span>: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a chokehold.")
 	to_chat(usr, "<span class='notice'>Pressure</span>: Disarm Disarm Disarm. Decent stamina damage.")
 	to_chat(usr, "<span class='notice'>Consecutive CQC</span>: Disarm Disarm Harm. Mainly offensive move, huge damage and decent stamina damage.")

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -1,5 +1,4 @@
 #define SLAM_COMBO "DH"
-#define KICK_COMBO "HH"
 #define RESTRAIN_COMBO "GG"
 #define PRESSURE_COMBO "DDD"
 #define CONSECUTIVE_COMBO "DDH"
@@ -22,10 +21,6 @@
 	if(findtext(streak,SLAM_COMBO))
 		streak = ""
 		Slam(A,D)
-		return TRUE
-	if(findtext(streak,KICK_COMBO))
-		streak = ""
-		Kick(A,D)
 		return TRUE
 	if(findtext(streak,RESTRAIN_COMBO))
 		streak = ""

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -52,32 +52,8 @@
 		D.DefaultCombatKnockdown(120)
 		log_combat(A, D, "slammed (CQC)")
 	return TRUE
-/*
-/datum/martial_art/cqc/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return FALSE
-	var/damage = damage_roll(A,D)
-	if(!CHECK_MOBILITY(D, MOBILITY_STAND) && CHECK_MOBILITY(D, MOBILITY_USE))
-		log_combat(A, D, "knocked out (Head kick)(CQC)")
-		D.visible_message("<span class='warning'>[A] kicks [D]'s head, knocking [D.p_them()] out!</span>", \
-							"<span class='userdanger'>[A] kicks your head, knocking you out!</span>")
-		playsound(get_turf(A), 'sound/weapons/genhit1.ogg', 50, 1, -1)
-		D.SetSleeping(300)
-		D.apply_damage(damage + 5, BRUTE)
-		var/atom/throw_target = get_edge_target_turf(D, A.dir)
-		D.throw_at(throw_target, 1, 14, A)
-		D.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage + 10, 150)
-	else
-		D.visible_message("<span class='warning'>[A] kicks [D]!</span>", \
-							"<span class='userdanger'>[A] kicks you!</span>")
-		playsound(get_turf(A), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
-		D.Dizzy(damage)
-		D.apply_damage(damage + 15, BRUTE)
-		var/atom/throw_target = get_edge_target_turf(D, A.dir)
-		D.throw_at(throw_target, 1, 14, A)
-		log_combat(A, D, "kicked (CQC)")
-	return TRUE
-*/
+
+
 /datum/martial_art/cqc/proc/Pressure(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE


### PR DESCRIPTION


## About The Pull Request

Removes CQC Kick. Its commented out in-case some apes want it back.

## Why It's Good For The Game

Just removes the knockout. People keep going ape about "hurr durr it knockout so it broke" Okay. Now its gone, ez solution to an ez problem B)

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



